### PR TITLE
Add profile role hierarchy tables and policies

### DIFF
--- a/supabase/migrations/0002_hardening_existing_schema.sql
+++ b/supabase/migrations/0002_hardening_existing_schema.sql
@@ -1,0 +1,486 @@
+-- Ensure pgcrypto extension is available for uuid generation
+create extension if not exists "pgcrypto";
+
+-- Ensure the post_status enum exists with the expected values
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_type t
+    where t.typname = 'post_status'
+      and t.typnamespace = 'public'::regnamespace
+  ) then
+    create type public.post_status as enum ('draft', 'scheduled', 'published');
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_enum e
+    join pg_type t on t.oid = e.enumtypid
+    where t.typname = 'post_status'
+      and t.typnamespace = 'public'::regnamespace
+      and e.enumlabel = 'draft'
+  ) then
+    alter type public.post_status add value 'draft';
+  end if;
+  if not exists (
+    select 1 from pg_enum e
+    join pg_type t on t.oid = e.enumtypid
+    where t.typname = 'post_status'
+      and t.typnamespace = 'public'::regnamespace
+      and e.enumlabel = 'scheduled'
+  ) then
+    alter type public.post_status add value 'scheduled';
+  end if;
+  if not exists (
+    select 1 from pg_enum e
+    join pg_type t on t.oid = e.enumtypid
+    where t.typname = 'post_status'
+      and t.typnamespace = 'public'::regnamespace
+      and e.enumlabel = 'published'
+  ) then
+    alter type public.post_status add value 'published';
+  end if;
+end;
+$$;
+
+-- =========================================================================
+-- Profiles hardening
+-- =========================================================================
+alter table if exists public.profiles
+  add column if not exists user_id uuid,
+  add column if not exists display_name text,
+  add column if not exists avatar_url text,
+  add column if not exists is_admin boolean not null default false,
+  add column if not exists created_at timestamptz not null default now(),
+  add column if not exists updated_at timestamptz not null default now();
+
+alter table if exists public.profiles
+  alter column id set default gen_random_uuid();
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint c
+    where c.conname = 'profiles_pkey'
+      and c.conrelid = 'public.profiles'::regclass
+  ) then
+    alter table public.profiles
+      add constraint profiles_pkey primary key (id);
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint c
+    where c.conname = 'profiles_user_id_key'
+      and c.conrelid = 'public.profiles'::regclass
+  ) then
+    alter table public.profiles
+      add constraint profiles_user_id_key unique (user_id);
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint c
+    where c.conname = 'profiles_user_id_fkey'
+      and c.conrelid = 'public.profiles'::regclass
+  ) then
+    alter table public.profiles
+      add constraint profiles_user_id_fkey
+        foreign key (user_id) references auth.users (id) on delete cascade;
+  end if;
+end;
+$$;
+
+-- =========================================================================
+-- Categories hardening
+-- =========================================================================
+alter table if exists public.categories
+  add column if not exists slug text,
+  add column if not exists name text,
+  add column if not exists created_at timestamptz not null default now();
+
+alter table if exists public.categories
+  alter column id set default gen_random_uuid();
+
+create unique index if not exists categories_slug_key
+  on public.categories (slug);
+
+-- =========================================================================
+-- Posts hardening
+-- =========================================================================
+alter table if exists public.posts
+  add column if not exists title text,
+  add column if not exists slug text,
+  add column if not exists excerpt text,
+  add column if not exists content text,
+  add column if not exists accent_color text,
+  add column if not exists status public.post_status not null default 'draft',
+  add column if not exists views integer not null default 0,
+  add column if not exists seo_title text,
+  add column if not exists seo_description text,
+  add column if not exists created_at timestamptz not null default now(),
+  add column if not exists updated_at timestamptz not null default now(),
+  add column if not exists published_at timestamptz,
+  add column if not exists scheduled_for timestamptz,
+  add column if not exists author_id uuid,
+  add column if not exists category_id uuid;
+
+alter table if exists public.posts
+  alter column id set default gen_random_uuid();
+
+create unique index if not exists posts_slug_key on public.posts (slug);
+create index if not exists posts_status_idx on public.posts (status);
+create index if not exists posts_published_at_idx on public.posts (published_at desc nulls last);
+create index if not exists posts_category_idx on public.posts (category_id);
+create index if not exists posts_author_idx on public.posts (author_id);
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint c
+    where c.conname = 'posts_author_id_fkey'
+      and c.conrelid = 'public.posts'::regclass
+  ) then
+    alter table public.posts
+      add constraint posts_author_id_fkey
+        foreign key (author_id) references public.profiles (id) on delete set null;
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint c
+    where c.conname = 'posts_category_id_fkey'
+      and c.conrelid = 'public.posts'::regclass
+  ) then
+    alter table public.posts
+      add constraint posts_category_id_fkey
+        foreign key (category_id) references public.categories (id) on delete set null;
+  end if;
+end;
+$$;
+
+-- =========================================================================
+-- Tags hardening
+-- =========================================================================
+alter table if exists public.tags
+  add column if not exists slug text,
+  add column if not exists name text,
+  add column if not exists created_at timestamptz not null default now();
+
+alter table if exists public.tags
+  alter column id set default gen_random_uuid();
+
+create unique index if not exists tags_slug_key on public.tags (slug);
+
+-- =========================================================================
+-- Post tags hardening
+-- =========================================================================
+create table if not exists public.post_tags (
+  post_id uuid not null references public.posts (id) on delete cascade,
+  tag_id uuid not null references public.tags (id) on delete cascade,
+  primary key (post_id, tag_id)
+);
+
+-- =========================================================================
+-- Helper triggers
+-- =========================================================================
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_trigger
+    where tgname = 'profiles_set_updated_at'
+      and tgrelid = 'public.profiles'::regclass
+  ) then
+    create trigger profiles_set_updated_at
+      before update on public.profiles
+      for each row execute function public.set_updated_at();
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_trigger
+    where tgname = 'posts_set_updated_at'
+      and tgrelid = 'public.posts'::regclass
+  ) then
+    create trigger posts_set_updated_at
+      before update on public.posts
+      for each row execute function public.set_updated_at();
+  end if;
+end;
+$$;
+
+-- =========================================================================
+-- Policies (idempotent creation)
+-- =========================================================================
+alter table if exists public.profiles enable row level security;
+alter table if exists public.categories enable row level security;
+alter table if exists public.tags enable row level security;
+alter table if exists public.post_tags enable row level security;
+alter table if exists public.posts enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'profiles'
+      and policyname = 'Profiles are viewable by everyone.'
+  ) then
+    create policy "Profiles are viewable by everyone."
+      on public.profiles for select
+      using (true);
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'profiles'
+      and policyname = 'Users can insert their own profile.'
+  ) then
+    create policy "Users can insert their own profile."
+      on public.profiles for insert
+      with check (auth.uid() = user_id);
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'profiles'
+      and policyname = 'Users can update own profile. Admins can update any profile.'
+  ) then
+    create policy "Users can update own profile. Admins can update any profile."
+      on public.profiles for update
+      using (
+        auth.uid() = user_id
+        or (select is_admin from public.profiles where user_id = auth.uid())
+      );
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'posts'
+      and policyname = 'Published posts are viewable by everyone.'
+  ) then
+    create policy "Published posts are viewable by everyone."
+      on public.posts for select
+      using (status = 'published');
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'posts'
+      and policyname = 'Authors can view their own posts.'
+  ) then
+    create policy "Authors can view their own posts."
+      on public.posts for select
+      using (
+        auth.uid() = (
+          select user_id from public.profiles where id = author_id
+        )
+      );
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'posts'
+      and policyname = 'Authors can insert their own posts.'
+  ) then
+    create policy "Authors can insert their own posts."
+      on public.posts for insert
+      with check (
+        auth.uid() = (
+          select user_id from public.profiles where id = author_id
+        )
+      );
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'posts'
+      and policyname = 'Authors can update their own posts. Admins can update any post.'
+  ) then
+    create policy "Authors can update their own posts. Admins can update any post."
+      on public.posts for update
+      using (
+        auth.uid() = (
+          select user_id from public.profiles where id = author_id
+        )
+        or (
+          select is_admin from public.profiles where user_id = auth.uid()
+        )
+      );
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'posts'
+      and policyname = 'Authors can delete their own posts. Admins can delete any post.'
+  ) then
+    create policy "Authors can delete their own posts. Admins can delete any post."
+      on public.posts for delete
+      using (
+        auth.uid() = (
+          select user_id from public.profiles where id = author_id
+        )
+        or (
+          select is_admin from public.profiles where user_id = auth.uid()
+        )
+      );
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'categories'
+      and policyname = 'Public can read categories'
+  ) then
+    create policy "Public can read categories"
+      on public.categories for select
+      using (true);
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'categories'
+      and policyname = 'Admins can manage categories'
+  ) then
+    create policy "Admins can manage categories"
+      on public.categories for all
+      using ((select is_admin from public.profiles where user_id = auth.uid()))
+      with check ((select is_admin from public.profiles where user_id = auth.uid()));
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'tags'
+      and policyname = 'Public can read tags'
+  ) then
+    create policy "Public can read tags"
+      on public.tags for select
+      using (true);
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'tags'
+      and policyname = 'Admins can manage tags'
+  ) then
+    create policy "Admins can manage tags"
+      on public.tags for all
+      using ((select is_admin from public.profiles where user_id = auth.uid()))
+      with check ((select is_admin from public.profiles where user_id = auth.uid()));
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'post_tags'
+      and policyname = 'Admins can manage post tags'
+  ) then
+    create policy "Admins can manage post tags"
+      on public.post_tags for all
+      using ((select is_admin from public.profiles where user_id = auth.uid()))
+      with check ((select is_admin from public.profiles where user_id = auth.uid()));
+  end if;
+end;
+$$;
+
+-- =========================================================================
+-- Seed data safeguards
+-- =========================================================================
+insert into public.categories (slug, name)
+values
+  ('machine-learning', 'Machine Learning'),
+  ('reinforcement-learning', 'Reinforcement Learning'),
+  ('data-science', 'Data Science'),
+  ('quantum-computing', 'Quantum Computing')
+on conflict (slug) do nothing;

--- a/supabase/migrations/0003_manage_profile_hierarchy.sql
+++ b/supabase/migrations/0003_manage_profile_hierarchy.sql
@@ -1,0 +1,622 @@
+-- Manage profile hierarchy with dedicated roles and membership mappings
+create extension if not exists "pgcrypto";
+
+-- =====================================================================
+-- Roles table ensures clear privilege hierarchy
+-- =====================================================================
+create table if not exists public.roles (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  name text not null,
+  description text,
+  priority integer not null default 100,
+  created_at timestamptz not null default now()
+);
+
+alter table if exists public.roles
+  add column if not exists slug text,
+  add column if not exists name text,
+  add column if not exists description text,
+  add column if not exists priority integer not null default 100,
+  add column if not exists created_at timestamptz not null default now();
+
+alter table if exists public.roles
+  alter column id set default gen_random_uuid();
+
+create unique index if not exists roles_slug_key on public.roles(slug);
+
+-- =====================================================================
+-- Junction table between profiles and roles
+-- =====================================================================
+create table if not exists public.profile_roles (
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  role_id uuid not null references public.roles(id) on delete cascade,
+  assigned_at timestamptz not null default now(),
+  primary key (profile_id, role_id)
+);
+
+alter table if exists public.profile_roles
+  add column if not exists profile_id uuid,
+  add column if not exists role_id uuid,
+  add column if not exists assigned_at timestamptz not null default now();
+
+alter table if exists public.profile_roles
+  alter column assigned_at set default now();
+
+create index if not exists profile_roles_role_idx on public.profile_roles(role_id);
+create index if not exists profile_roles_assigned_idx on public.profile_roles(assigned_at);
+
+-- Ensure constraints exist even if table predated this migration
+DO $$
+BEGIN
+  IF not exists (
+    select 1
+    from pg_constraint
+    where conname = 'profile_roles_pkey'
+      and conrelid = 'public.profile_roles'::regclass
+  ) THEN
+    alter table public.profile_roles
+      add constraint profile_roles_pkey primary key (profile_id, role_id);
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF not exists (
+    select 1
+    from pg_constraint
+    where conname = 'profile_roles_profile_id_fkey'
+      and conrelid = 'public.profile_roles'::regclass
+  ) THEN
+    alter table public.profile_roles
+      add constraint profile_roles_profile_id_fkey foreign key (profile_id) references public.profiles(id) on delete cascade;
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF not exists (
+    select 1
+    from pg_constraint
+    where conname = 'profile_roles_role_id_fkey'
+      and conrelid = 'public.profile_roles'::regclass
+  ) THEN
+    alter table public.profile_roles
+      add constraint profile_roles_role_id_fkey foreign key (role_id) references public.roles(id) on delete cascade;
+  END IF;
+END;
+$$;
+
+-- =====================================================================
+-- Primary role pointer on profiles
+-- =====================================================================
+alter table if exists public.profiles
+  add column if not exists primary_role_id uuid;
+
+DO $$
+BEGIN
+  IF not exists (
+    select 1
+    from pg_constraint
+    where conname = 'profiles_primary_role_id_fkey'
+      and conrelid = 'public.profiles'::regclass
+  ) THEN
+    alter table public.profiles
+      add constraint profiles_primary_role_id_fkey foreign key (primary_role_id) references public.roles(id) on delete set null;
+  END IF;
+END;
+$$;
+
+-- =====================================================================
+-- Seed canonical roles with deterministic ordering
+-- =====================================================================
+insert into public.roles (slug, name, description, priority)
+values
+  ('admin', 'Administrator', 'Full control over content, users, and configuration.', 10),
+  ('editor', 'Editor', 'Manage and publish any post content.', 20),
+  ('author', 'Author', 'Create and edit personal drafts.', 30),
+  ('member', 'Member', 'Default reader profile with basic permissions.', 40)
+on conflict (slug) do update
+set
+  name = excluded.name,
+  description = excluded.description,
+  priority = excluded.priority;
+
+-- =====================================================================
+-- Helper functions to inspect role membership
+-- =====================================================================
+create or replace function public.user_has_any_role(role_slugs text[])
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  has_role boolean;
+begin
+  if role_slugs is null or array_length(role_slugs, 1) = 0 then
+    return false;
+  end if;
+
+  select exists(
+    select 1
+    from public.profiles p
+    left join public.profile_roles pr on pr.profile_id = p.id
+    left join public.roles r on r.id = pr.role_id
+    where p.user_id = auth.uid()
+      and (
+        r.slug = any(role_slugs)
+        or (
+          p.is_admin = true
+          and array_position(role_slugs, 'admin') is not null
+        )
+      )
+  )
+  into has_role;
+
+  return coalesce(has_role, false);
+end;
+$$;
+
+create or replace function public.user_has_role(role_slug text)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if role_slug is null then
+    return false;
+  end if;
+  return public.user_has_any_role(array[role_slug]);
+end;
+$$;
+
+-- =====================================================================
+-- Triggers to maintain primary role and role assignments
+-- =====================================================================
+create or replace function public.assign_primary_role()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  admin_role uuid;
+  member_role uuid;
+begin
+  if new.primary_role_id is null then
+    if new.is_admin then
+      select id into admin_role from public.roles where slug = 'admin';
+      if admin_role is not null then
+        new.primary_role_id := admin_role;
+      end if;
+    end if;
+
+    if new.primary_role_id is null then
+      select id into member_role from public.roles where slug = 'member';
+      if member_role is not null then
+        new.primary_role_id := member_role;
+      end if;
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function public.ensure_profile_role_membership()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  admin_role uuid;
+  member_role uuid;
+begin
+  select id into admin_role from public.roles where slug = 'admin';
+  select id into member_role from public.roles where slug = 'member';
+
+  if tg_op = 'INSERT' then
+    if admin_role is not null and new.is_admin then
+      insert into public.profile_roles(profile_id, role_id)
+      values (new.id, admin_role)
+      on conflict (profile_id, role_id) do nothing;
+    end if;
+
+    if member_role is not null then
+      insert into public.profile_roles(profile_id, role_id)
+      values (new.id, member_role)
+      on conflict (profile_id, role_id) do nothing;
+    end if;
+  elsif tg_op = 'UPDATE' then
+    if admin_role is not null then
+      if new.is_admin then
+        insert into public.profile_roles(profile_id, role_id)
+        values (new.id, admin_role)
+        on conflict (profile_id, role_id) do nothing;
+      else
+        delete from public.profile_roles
+        where profile_id = new.id
+          and role_id = admin_role;
+      end if;
+    end if;
+
+    if member_role is not null then
+      insert into public.profile_roles(profile_id, role_id)
+      values (new.id, member_role)
+      on conflict (profile_id, role_id) do nothing;
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function public.sync_admin_flag_from_roles()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  admin_role uuid;
+  member_role uuid;
+  effective_admin boolean;
+begin
+  select id into admin_role from public.roles where slug = 'admin';
+  select id into member_role from public.roles where slug = 'member';
+
+  if admin_role is null then
+    return null;
+  end if;
+
+  if tg_op = 'INSERT' then
+    if new.role_id = admin_role then
+      update public.profiles
+      set is_admin = true,
+          primary_role_id = coalesce(primary_role_id, admin_role)
+      where id = new.profile_id;
+    end if;
+  elsif tg_op = 'DELETE' then
+    if old.role_id = admin_role then
+      select exists(
+        select 1
+        from public.profile_roles pr
+        where pr.profile_id = old.profile_id
+          and pr.role_id = admin_role
+      ) into effective_admin;
+
+      update public.profiles
+      set is_admin = coalesce(effective_admin, false),
+          primary_role_id = case
+            when coalesce(effective_admin, false) then primary_role_id
+            when member_role is not null then member_role
+            else primary_role_id
+          end
+      where id = old.profile_id;
+    end if;
+  end if;
+
+  return null;
+end;
+$$;
+
+-- Drop old triggers before recreating to avoid duplicates
+DO $$
+BEGIN
+  IF exists (
+    select 1 from pg_trigger
+    where tgname = 'profiles_assign_primary_role'
+      and tgrelid = 'public.profiles'::regclass
+  ) THEN
+    drop trigger profiles_assign_primary_role on public.profiles;
+  END IF;
+END;
+$$;
+
+create trigger profiles_assign_primary_role
+  before insert or update on public.profiles
+  for each row execute function public.assign_primary_role();
+
+DO $$
+BEGIN
+  IF exists (
+    select 1 from pg_trigger
+    where tgname = 'profiles_ensure_role_membership'
+      and tgrelid = 'public.profiles'::regclass
+  ) THEN
+    drop trigger profiles_ensure_role_membership on public.profiles;
+  END IF;
+END;
+$$;
+
+create trigger profiles_ensure_role_membership
+  after insert or update on public.profiles
+  for each row execute function public.ensure_profile_role_membership();
+
+DO $$
+BEGIN
+  IF exists (
+    select 1 from pg_trigger
+    where tgname = 'profile_roles_sync_admin_flag'
+      and tgrelid = 'public.profile_roles'::regclass
+  ) THEN
+    drop trigger profile_roles_sync_admin_flag on public.profile_roles;
+  END IF;
+END;
+$$;
+
+create trigger profile_roles_sync_admin_flag
+  after insert or delete on public.profile_roles
+  for each row execute function public.sync_admin_flag_from_roles();
+
+-- =====================================================================
+-- Data backfill to guarantee consistency for existing profiles
+-- =====================================================================
+DO $$
+DECLARE
+  admin_role uuid;
+  member_role uuid;
+BEGIN
+  select id into admin_role from public.roles where slug = 'admin';
+  select id into member_role from public.roles where slug = 'member';
+
+  IF member_role IS NOT NULL THEN
+    update public.profiles
+    set primary_role_id = coalesce(primary_role_id, member_role)
+    where primary_role_id is null;
+
+    insert into public.profile_roles(profile_id, role_id)
+    select p.id, member_role
+    from public.profiles p
+    where not exists (
+      select 1
+      from public.profile_roles pr
+      where pr.profile_id = p.id
+        and pr.role_id = member_role
+    );
+  END IF;
+
+  IF admin_role IS NOT NULL THEN
+    insert into public.profile_roles(profile_id, role_id)
+    select p.id, admin_role
+    from public.profiles p
+    where p.is_admin = true
+      and not exists (
+        select 1
+        from public.profile_roles pr
+        where pr.profile_id = p.id
+          and pr.role_id = admin_role
+      );
+
+    update public.profiles
+    set primary_role_id = admin_role
+    where is_admin = true
+      and primary_role_id <> admin_role;
+  END IF;
+END;
+$$;
+
+DO $$
+DECLARE
+  admin_role uuid;
+BEGIN
+  select id into admin_role from public.roles where slug = 'admin';
+
+  IF admin_role IS NOT NULL THEN
+    update public.profiles p
+    set is_admin = exists (
+      select 1
+      from public.profile_roles pr
+      where pr.profile_id = p.id
+        and pr.role_id = admin_role
+    );
+  END IF;
+END;
+$$;
+
+-- =====================================================================
+-- Row level security for new tables
+-- =====================================================================
+alter table if exists public.roles enable row level security;
+alter table if exists public.profile_roles enable row level security;
+
+DO $$
+BEGIN
+  IF exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'roles'
+      and policyname = 'Authenticated users can read roles'
+  ) THEN
+    drop policy "Authenticated users can read roles" on public.roles;
+  END IF;
+END;
+$$;
+
+create policy "Authenticated users can read roles"
+  on public.roles for select
+  using (auth.uid() is not null);
+
+DO $$
+BEGIN
+  IF exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'roles'
+      and policyname = 'Admins manage roles'
+  ) THEN
+    drop policy "Admins manage roles" on public.roles;
+  END IF;
+END;
+$$;
+
+create policy "Admins manage roles"
+  on public.roles for all
+  using (public.user_has_role('admin'))
+  with check (public.user_has_role('admin'));
+
+DO $$
+BEGIN
+  IF exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'profile_roles'
+      and policyname = 'Users can read their role assignments'
+  ) THEN
+    drop policy "Users can read their role assignments" on public.profile_roles;
+  END IF;
+END;
+$$;
+
+create policy "Users can read their role assignments"
+  on public.profile_roles for select
+  using (
+    public.user_has_role('admin')
+    or auth.uid() = (
+      select user_id from public.profiles where id = profile_id
+    )
+  );
+
+DO $$
+BEGIN
+  IF exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'profile_roles'
+      and policyname = 'Admins manage role assignments'
+  ) THEN
+    drop policy "Admins manage role assignments" on public.profile_roles;
+  END IF;
+END;
+$$;
+
+create policy "Admins manage role assignments"
+  on public.profile_roles for all
+  using (public.user_has_role('admin'))
+  with check (public.user_has_role('admin'));
+
+-- =====================================================================
+-- Refresh existing policies to leverage helper role checks
+-- =====================================================================
+DO $$
+BEGIN
+  IF exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'profiles'
+      and policyname = 'Users can update own profile. Admins can update any profile.'
+  ) THEN
+    drop policy "Users can update own profile. Admins can update any profile." on public.profiles;
+  END IF;
+END;
+$$;
+
+create policy "Users can update own profile. Admins can update any profile."
+  on public.profiles for update
+  using (
+    auth.uid() = user_id
+    or public.user_has_role('admin')
+  );
+
+DO $$
+BEGIN
+  IF exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'posts'
+      and policyname = 'Authors can update their own posts. Admins can update any post.'
+  ) THEN
+    drop policy "Authors can update their own posts. Admins can update any post." on public.posts;
+  END IF;
+END;
+$$;
+
+create policy "Authors can update their own posts. Admins can update any post."
+  on public.posts for update
+  using (
+    auth.uid() = (
+      select user_id from public.profiles where id = author_id
+    )
+    or public.user_has_any_role(array['admin', 'editor'])
+  );
+
+DO $$
+BEGIN
+  IF exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'posts'
+      and policyname = 'Authors can delete their own posts. Admins can delete any post.'
+  ) THEN
+    drop policy "Authors can delete their own posts. Admins can delete any post." on public.posts;
+  END IF;
+END;
+$$;
+
+create policy "Authors can delete their own posts. Admins can delete any post."
+  on public.posts for delete
+  using (
+    auth.uid() = (
+      select user_id from public.profiles where id = author_id
+    )
+    or public.user_has_any_role(array['admin', 'editor'])
+  );
+
+DO $$
+BEGIN
+  IF exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'categories'
+      and policyname = 'Admins can manage categories'
+  ) THEN
+    drop policy "Admins can manage categories" on public.categories;
+  END IF;
+END;
+$$;
+
+create policy "Admins can manage categories"
+  on public.categories for all
+  using (public.user_has_role('admin'))
+  with check (public.user_has_role('admin'));
+
+DO $$
+BEGIN
+  IF exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'tags'
+      and policyname = 'Admins can manage tags'
+  ) THEN
+    drop policy "Admins can manage tags" on public.tags;
+  END IF;
+END;
+$$;
+
+create policy "Admins can manage tags"
+  on public.tags for all
+  using (public.user_has_role('admin'))
+  with check (public.user_has_role('admin'));
+
+DO $$
+BEGIN
+  IF exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'post_tags'
+      and policyname = 'Admins can manage post tags'
+  ) THEN
+    drop policy "Admins can manage post tags" on public.post_tags;
+  END IF;
+END;
+$$;
+
+create policy "Admins can manage post tags"
+  on public.post_tags for all
+  using (public.user_has_role('admin'))
+  with check (public.user_has_role('admin'));


### PR DESCRIPTION
## Summary
- add dedicated roles and profile_roles tables plus a primary_role_id pointer on profiles to support a persistent hierarchy
- seed canonical roles and create triggers that keep admin flags, default memberships, and primary roles synchronized
- introduce reusable helper functions and refresh RLS policies so admin/editor privileges reflect the role hierarchy across content tables

## Testing
- not run (Supabase CLI credentials unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e39a4f9f60832d9dcde201144b3f81