### PR TITLE
Integrate Supabase-powered admin workflows

### DIFF
--- a/src/app/admin/create/page.tsx
+++ b/src/app/admin/create/page.tsx
@@ -1,37 +1,5 @@
-"use client";
-
-import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { AdminDashboard } from '@/components/admin/AdminDashboard';
+import { redirect } from 'next/navigation'
 
 export default function CreatePostPage() {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const router = useRouter();
-
-  useEffect(() => {
-    // Check if user is authenticated
-    const token = localStorage.getItem('adminToken');
-    if (!token) {
-      router.push('/me');
-      return;
-    }
-
-    setIsAuthenticated(true);
-    setIsLoading(false);
-  }, [router]);
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <p>Loading...</p>
-      </div>
-    );
-  }
-
-  if (!isAuthenticated) {
-    return null; // Will redirect in useEffect
-  }
-
-  return <AdminDashboard />;
+  redirect('/admin')
 }

--- a/src/app/admin/edit/[id]/page.tsx
+++ b/src/app/admin/edit/[id]/page.tsx
@@ -1,37 +1,10 @@
-"use client";
+import { redirect } from 'next/navigation'
 
-import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { AdminDashboard } from '@/components/admin/AdminDashboard';
+interface RouteParams {
+  params: { id: string }
+}
 
-export default function EditPostPage() {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const router = useRouter();
-
-  useEffect(() => {
-    // Check if user is authenticated
-    const token = localStorage.getItem('adminToken');
-    if (!token) {
-      router.push('/me');
-      return;
-    }
-
-    setIsAuthenticated(true);
-    setIsLoading(false);
-  }, [router]);
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <p>Loading...</p>
-      </div>
-    );
-  }
-
-  if (!isAuthenticated) {
-    return null; // Will redirect in useEffect
-  }
-
-  return <AdminDashboard />;
+export default function EditPostPage({ params }: RouteParams) {
+  void params
+  redirect('/admin')
 }

--- a/src/app/api/admin/posts/[id]/route.ts
+++ b/src/app/api/admin/posts/[id]/route.ts
@@ -1,0 +1,251 @@
+import { NextResponse } from 'next/server'
+import {
+  createServerComponentClient,
+  createServiceRoleClient,
+} from '@/lib/supabase/server-client'
+import { PostStatus, type AdminPost } from '@/utils/types'
+
+const POST_SELECT = `
+  id,
+  title,
+  slug,
+  excerpt,
+  content,
+  accent_color,
+  status,
+  views,
+  created_at,
+  published_at,
+  scheduled_for,
+  author_id,
+  category_id,
+  categories:categories(id, name, slug)
+`
+
+interface ProfileRecord {
+  id: string
+  is_admin: boolean
+}
+
+interface PostRecord {
+  id: string
+  title: string
+  slug: string
+  excerpt: string | null
+  content: string
+  accent_color: string | null
+  status: string
+  views: number | null
+  created_at: string
+  published_at: string | null
+  scheduled_for: string | null
+  author_id: string | null
+  category_id: string | null
+  categories: { id: string | null; name: string | null; slug: string | null } | null
+}
+
+const allowedStatuses = new Set<string>([
+  PostStatus.DRAFT,
+  PostStatus.SCHEDULED,
+  PostStatus.PUBLISHED,
+])
+
+const mapPostRecord = (record: PostRecord): AdminPost => ({
+  id: record.id,
+  title: record.title,
+  slug: record.slug,
+  excerpt: record.excerpt ?? null,
+  content: record.content,
+  accentColor: record.accent_color ?? null,
+  status: record.status as PostStatus,
+  views: record.views ?? 0,
+  createdAt: record.created_at,
+  publishedAt: record.published_at ?? null,
+  scheduledFor: record.scheduled_for ?? null,
+  authorId: record.author_id ?? null,
+  categoryId: record.category_id ?? null,
+  categoryName: record.categories?.name ?? null,
+  categorySlug: record.categories?.slug ?? null,
+})
+
+const getAdminProfile = async (): Promise<
+  | { profile: ProfileRecord }
+  | { response: NextResponse }
+> => {
+  const supabase = createServerComponentClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return {
+      response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    }
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, is_admin')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (error) {
+    return {
+      response: NextResponse.json(
+        { error: `Unable to load profile: ${error.message}` },
+        { status: 500 },
+      ),
+    }
+  }
+
+  if (!profile || !profile.is_admin) {
+    return {
+      response: NextResponse.json(
+        { error: 'Forbidden: admin access required.' },
+        { status: 403 },
+      ),
+    }
+  }
+
+  return { profile }
+}
+
+export async function PATCH(request: Request, { params }: { params: { id: string } }) {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const id = params.id
+  if (!id) {
+    return NextResponse.json({ error: 'Post id is required.' }, { status: 400 })
+  }
+
+  const body = (await request.json()) as Record<string, unknown>
+
+  const updates: Record<string, unknown> = {}
+
+  if (typeof body.title === 'string') {
+    updates.title = body.title.trim()
+  }
+
+  if (typeof body.slug === 'string') {
+    updates.slug = body.slug.trim()
+  }
+
+  if (typeof body.excerpt === 'string') {
+    updates.excerpt = body.excerpt.trim() || null
+  }
+
+  if (typeof body.content === 'string') {
+    updates.content = body.content.trim()
+  }
+
+  if (typeof body.accentColor === 'string') {
+    updates.accent_color = body.accentColor.trim() || null
+  }
+
+  if (typeof body.categoryId === 'string') {
+    updates.category_id = body.categoryId.trim() || null
+  } else if (body.categoryId === null) {
+    updates.category_id = null
+  }
+
+  if (typeof body.authorId === 'string') {
+    updates.author_id = body.authorId.trim()
+  }
+
+  if (typeof body.status === 'string' && allowedStatuses.has(body.status)) {
+    const status = body.status as PostStatus
+    updates.status = status
+
+    if (status === PostStatus.PUBLISHED) {
+      const providedPublishedAt =
+        typeof body.publishedAt === 'string' && body.publishedAt.trim().length > 0
+          ? body.publishedAt
+          : null
+      updates.published_at = providedPublishedAt ?? new Date().toISOString()
+      updates.scheduled_for = null
+    } else if (status === PostStatus.SCHEDULED) {
+      const providedSchedule =
+        typeof body.scheduledFor === 'string' && body.scheduledFor.trim().length > 0
+          ? body.scheduledFor
+          : null
+      if (!providedSchedule) {
+        return NextResponse.json(
+          { error: 'Scheduled posts require a valid scheduled date/time.' },
+          { status: 400 },
+        )
+      }
+      updates.scheduled_for = providedSchedule
+      updates.published_at = null
+    } else {
+      updates.published_at = null
+      updates.scheduled_for = null
+    }
+  }
+
+  const serviceClient = createServiceRoleClient()
+
+  const { error: existingError, data: existing } = await serviceClient
+    .from('posts')
+    .select('id')
+    .eq('id', id)
+    .maybeSingle()
+
+  if (existingError) {
+    return NextResponse.json(
+      { error: `Unable to load post: ${existingError.message}` },
+      { status: 500 },
+    )
+  }
+
+  if (!existing) {
+    return NextResponse.json({ error: 'Post not found.' }, { status: 404 })
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'No updates provided.' }, { status: 400 })
+  }
+
+  const { data, error } = await serviceClient
+    .from('posts')
+    .update(updates)
+    .eq('id', id)
+    .select(POST_SELECT)
+    .maybeSingle()
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Unable to update post: ${error.message}` },
+      { status: 400 },
+    )
+  }
+
+  return NextResponse.json({ post: mapPostRecord(data as PostRecord) })
+}
+
+export async function DELETE(_request: Request, { params }: { params: { id: string } }) {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const id = params.id
+  if (!id) {
+    return NextResponse.json({ error: 'Post id is required.' }, { status: 400 })
+  }
+
+  const serviceClient = createServiceRoleClient()
+
+  const { error } = await serviceClient.from('posts').delete().eq('id', id)
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Unable to delete post: ${error.message}` },
+      { status: 400 },
+    )
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/admin/posts/route.ts
+++ b/src/app/api/admin/posts/route.ts
@@ -1,0 +1,232 @@
+import { NextResponse } from 'next/server'
+import {
+  createServerComponentClient,
+  createServiceRoleClient,
+} from '@/lib/supabase/server-client'
+import { PostStatus, type AdminPost } from '@/utils/types'
+
+const POST_SELECT = `
+  id,
+  title,
+  slug,
+  excerpt,
+  content,
+  accent_color,
+  status,
+  views,
+  created_at,
+  published_at,
+  scheduled_for,
+  author_id,
+  category_id,
+  categories:categories(id, name, slug)
+`
+
+interface ProfileRecord {
+  id: string
+  is_admin: boolean
+}
+
+interface PostRecord {
+  id: string
+  title: string
+  slug: string
+  excerpt: string | null
+  content: string
+  accent_color: string | null
+  status: string
+  views: number | null
+  created_at: string
+  published_at: string | null
+  scheduled_for: string | null
+  author_id: string | null
+  category_id: string | null
+  categories: { id: string | null; name: string | null; slug: string | null } | null
+}
+
+const mapPostRecord = (record: PostRecord): AdminPost => ({
+  id: record.id,
+  title: record.title,
+  slug: record.slug,
+  excerpt: record.excerpt ?? null,
+  content: record.content,
+  accentColor: record.accent_color ?? null,
+  status: record.status as PostStatus,
+  views: record.views ?? 0,
+  createdAt: record.created_at,
+  publishedAt: record.published_at ?? null,
+  scheduledFor: record.scheduled_for ?? null,
+  authorId: record.author_id ?? null,
+  categoryId: record.category_id ?? null,
+  categoryName: record.categories?.name ?? null,
+  categorySlug: record.categories?.slug ?? null,
+})
+
+const allowedStatuses = new Set<string>([
+  PostStatus.DRAFT,
+  PostStatus.SCHEDULED,
+  PostStatus.PUBLISHED,
+])
+
+const normalizeStatus = (value: string | null | undefined): PostStatus => {
+  if (!value) return PostStatus.DRAFT
+  return allowedStatuses.has(value) ? (value as PostStatus) : PostStatus.DRAFT
+}
+
+const getAdminProfile = async (): Promise<
+  | { profile: ProfileRecord }
+  | { response: NextResponse }
+> => {
+  const supabase = createServerComponentClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return {
+      response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    }
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, is_admin')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (error) {
+    return {
+      response: NextResponse.json(
+        { error: `Unable to load profile: ${error.message}` },
+        { status: 500 },
+      ),
+    }
+  }
+
+  if (!profile || !profile.is_admin) {
+    return {
+      response: NextResponse.json(
+        { error: 'Forbidden: admin access required.' },
+        { status: 403 },
+      ),
+    }
+  }
+
+  return { profile }
+}
+
+export async function GET() {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const serviceClient = createServiceRoleClient()
+  const { data, error } = await serviceClient
+    .from('posts')
+    .select(POST_SELECT)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Unable to load posts: ${error.message}` },
+      { status: 500 },
+    )
+  }
+
+  const posts = (data ?? []).map((record) => mapPostRecord(record as PostRecord))
+
+  return NextResponse.json({ posts })
+}
+
+export async function POST(request: Request) {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const body = (await request.json()) as Record<string, unknown>
+
+  const title = typeof body.title === 'string' ? body.title.trim() : ''
+  const slug = typeof body.slug === 'string' ? body.slug.trim() : ''
+  const content = typeof body.content === 'string' ? body.content.trim() : ''
+  const excerpt =
+    typeof body.excerpt === 'string' && body.excerpt.trim().length > 0
+      ? body.excerpt.trim()
+      : null
+  const accentColor =
+    typeof body.accentColor === 'string' && body.accentColor.trim().length > 0
+      ? body.accentColor.trim()
+      : null
+  const categoryId =
+    typeof body.categoryId === 'string' && body.categoryId.trim().length > 0
+      ? body.categoryId
+      : null
+  const requestedStatus = normalizeStatus(body.status as string | null | undefined)
+  const authorId =
+    typeof body.authorId === 'string' && body.authorId.trim().length > 0
+      ? body.authorId
+      : result.profile.id
+
+  if (!title || !slug || !content) {
+    return NextResponse.json(
+      {
+        error: 'Title, slug, and content are required.',
+      },
+      { status: 400 },
+    )
+  }
+
+  let publishedAt: string | null = null
+  let scheduledFor: string | null = null
+
+  if (requestedStatus === PostStatus.PUBLISHED) {
+    const providedPublishedAt =
+      typeof body.publishedAt === 'string' && body.publishedAt.trim().length > 0
+        ? body.publishedAt
+        : null
+    publishedAt = providedPublishedAt ?? new Date().toISOString()
+    scheduledFor = null
+  } else if (requestedStatus === PostStatus.SCHEDULED) {
+    const providedSchedule =
+      typeof body.scheduledFor === 'string' && body.scheduledFor.trim().length > 0
+        ? body.scheduledFor
+        : null
+    if (!providedSchedule) {
+      return NextResponse.json(
+        { error: 'Scheduled posts require a valid scheduled date/time.' },
+        { status: 400 },
+      )
+    }
+    scheduledFor = providedSchedule
+    publishedAt = null
+  }
+
+  const serviceClient = createServiceRoleClient()
+  const { data, error } = await serviceClient
+    .from('posts')
+    .insert({
+      title,
+      slug,
+      content,
+      excerpt,
+      accent_color: accentColor,
+      status: requestedStatus,
+      published_at: publishedAt,
+      scheduled_for: scheduledFor,
+      category_id: categoryId,
+      author_id: authorId,
+    })
+    .select(POST_SELECT)
+    .single()
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Unable to create post: ${error.message}` },
+      { status: 400 },
+    )
+  }
+
+  const post = mapPostRecord(data as PostRecord)
+  return NextResponse.json({ post }, { status: 201 })
+}

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,62 +1,137 @@
 "use client";
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import '@/styles/neo-brutalism.css';
+import { createBrowserClient } from '@/lib/supabase/client';
 
 export default function LoginPage() {
-  const [username, setUsername] = useState('');
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const supabase = useMemo(() => createBrowserClient(), []);
+
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const [info, setInfo] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const router = useRouter();
+
+  useEffect(() => {
+    const unauthorized = searchParams.get('error');
+    if (unauthorized === 'not_authorized') {
+      setError('You do not have permission to access the admin dashboard.');
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    const checkSession = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (!session) {
+        return;
+      }
+
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('is_admin')
+        .eq('user_id', session.user.id)
+        .maybeSingle();
+
+      if (profile?.is_admin) {
+        router.replace('/admin');
+        router.refresh();
+      } else {
+        setError('Your account is not authorized for admin access.');
+        await supabase.auth.signOut();
+      }
+    };
+
+    void checkSession();
+  }, [router, supabase]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
     setError('');
+    setInfo('');
 
-    // Simple authentication for demo purposes
-    // In a real app, this would be a server-side API call
-    if (username === 'psadmin' && password === 'ps123') {
-      // Set a session token in localStorage
-      localStorage.setItem('adminToken', 'demo-token-12345');
-      // Redirect to admin dashboard
-      router.push('/admin');
-    } else {
-      setError('Invalid username or password');
+    const { data, error: signInError } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+
+    if (signInError) {
+      setError(signInError.message);
+      setIsLoading(false);
+      return;
     }
-    
-    setIsLoading(false);
+
+    if (!data.user) {
+      setError('Unable to authenticate.');
+      setIsLoading(false);
+      return;
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select('id, is_admin')
+      .eq('user_id', data.user.id)
+      .maybeSingle();
+
+    if (profileError) {
+      setError('Unable to load your profile. Please try again.');
+      await supabase.auth.signOut();
+      setIsLoading(false);
+      return;
+    }
+
+    if (!profile?.is_admin) {
+      setError('This account is not authorized for admin access.');
+      await supabase.auth.signOut();
+      setIsLoading(false);
+      return;
+    }
+
+    setInfo('Login successful! Redirecting to the dashboard...');
+    router.replace('/admin');
+    router.refresh();
   };
 
   return (
     <div className="neo-brutalism min-h-screen flex items-center justify-center bg-white p-4">
       <div className="neo-container w-full max-w-md p-8">
         <h1 className="text-3xl font-bold mb-6 text-center">Admin Login</h1>
-        
+
         {error && (
           <div className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-6" role="alert">
             <p>{error}</p>
           </div>
         )}
-        
+
+        {info && (
+          <div className="bg-green-100 border-l-4 border-green-500 text-green-700 p-4 mb-6" role="status">
+            <p>{info}</p>
+          </div>
+        )}
+
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
-            <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-1">
-              Username
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+              Email
             </label>
             <input
-              id="username"
-              name="username"
-              type="text"
+              id="email"
+              name="email"
+              type="email"
               required
               className="w-full px-3 py-2 border border-black focus:outline-none focus:ring-2 focus:ring-purple-500"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
             />
           </div>
-          
+
           <div>
             <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
               Password
@@ -82,10 +157,12 @@ export default function LoginPage() {
             </button>
           </div>
         </form>
-        
+
         <div className="mt-6 text-center text-sm text-gray-500">
-          <p>Default credentials for demo:</p>
-          <p>Username: psadmin | Password: ps123</p>
+          <p>
+            Use your Supabase email and password. Only accounts marked as admin in
+            the <code>profiles</code> table can access this dashboard.
+          </p>
         </div>
       </div>
     </div>

--- a/src/components/admin/PostsTable.tsx
+++ b/src/components/admin/PostsTable.tsx
@@ -6,11 +6,11 @@ import {
   ArrowUpRight,
   Calendar,
 } from 'lucide-react'
-import { Post, PostStatus } from '../../utils/types'
+import { AdminPost, PostStatus } from '../../utils/types'
 
 interface PostsTableProps {
-  posts: Post[]
-  onEdit: (post: Post) => void
+  posts: AdminPost[]
+  onEdit: (post: AdminPost) => void
   onDelete: (id: string) => void
   onPublish: (id: string) => void
 }
@@ -32,11 +32,6 @@ export const PostsTable = ({
     if (activeTab === 'published') return post.status === PostStatus.PUBLISHED
     return true
   })
-
-  // Only show developer posts (as per requirement)
-  const developerPosts = filteredPosts.filter(
-    (post) => !post.author || post.author === 'Developer',
-  )
 
   return (
     <div className="bg-white border-3 border-[#2A2A2A]/20 rounded-lg shadow-[4px_4px_0px_0px_rgba(0,0,0,0.1)] overflow-hidden">
@@ -78,7 +73,7 @@ export const PostsTable = ({
           />
         </div>
       </div>
-      {developerPosts.length === 0 ? (
+      {filteredPosts.length === 0 ? (
         <div className="p-12 text-center">
           <p className="text-xl font-bold">No posts found</p>
           <p className="text-gray-500 mt-2">Create a new post to get started</p>
@@ -97,72 +92,79 @@ export const PostsTable = ({
               </tr>
             </thead>
             <tbody>
-              {developerPosts.map((post) => (
-                <tr
-                  key={post.id}
-                  className="border-b border-black/10 hover:bg-gray-50"
-                >
-                  <td className="p-4">
-                    <div className="font-bold">{post.title}</div>
-                    <div className="text-sm text-gray-500 truncate max-w-[300px]">
-                      {post.excerpt || 'No excerpt provided'}
-                    </div>
-                  </td>
-                  <td className="p-4">
-                    <div
-                      className="inline-block px-3 py-1 font-bold text-white rounded-md"
-                      style={{
-                        backgroundColor: getCategoryColor(post.category),
-                        transform: 'rotate(-2deg)',
-                      }}
-                    >
-                      {post.category}
-                    </div>
-                  </td>
-                  <td className="p-4">
-                    <StatusBadge status={post.status} />
-                  </td>
-                  <td className="p-4">
-                    <div className="flex items-center gap-1 text-sm">
-                      <Calendar className="h-4 w-4" />
-                      {formatDate(post.publishedAt || post.createdAt)}
-                    </div>
-                  </td>
-                  <td className="p-4">
-                    <div className="flex items-center gap-1">
-                      <Eye className="h-4 w-4" />
-                      {post.views}
-                    </div>
-                  </td>
-                  <td className="p-4">
-                    <div className="flex items-center justify-end gap-2">
-                      <button
-                        onClick={() => onEdit(post)}
-                        className="bg-[#6C63FF] text-white p-2 rounded-md hover:opacity-90"
-                        title="Edit"
+              {filteredPosts.map((post) => {
+                const displayDate =
+                  post.status === PostStatus.SCHEDULED
+                    ? formatDateValue(post.scheduledFor)
+                    : formatDateValue(post.publishedAt || post.createdAt)
+
+                return (
+                  <tr
+                    key={post.id}
+                    className="border-b border-black/10 hover:bg-gray-50"
+                  >
+                    <td className="p-4">
+                      <div className="font-bold">{post.title}</div>
+                      <div className="text-sm text-gray-500 truncate max-w-[300px]">
+                        {post.excerpt || 'No excerpt provided'}
+                      </div>
+                    </td>
+                    <td className="p-4">
+                      <div
+                        className="inline-block px-3 py-1 font-bold text-white rounded-md"
+                        style={{
+                          backgroundColor: getCategoryColor(post),
+                          transform: 'rotate(-2deg)',
+                        }}
                       >
-                        <Pencil className="h-4 w-4" />
-                      </button>
-                      {post.status !== PostStatus.PUBLISHED && (
+                        {post.categoryName ?? 'Uncategorized'}
+                      </div>
+                    </td>
+                    <td className="p-4">
+                      <StatusBadge status={post.status} />
+                    </td>
+                    <td className="p-4">
+                      <div className="flex items-center gap-1 text-sm">
+                        <Calendar className="h-4 w-4" />
+                        {displayDate}
+                      </div>
+                    </td>
+                    <td className="p-4">
+                      <div className="flex items-center gap-1">
+                        <Eye className="h-4 w-4" />
+                        {post.views ?? 0}
+                      </div>
+                    </td>
+                    <td className="p-4">
+                      <div className="flex items-center justify-end gap-2">
                         <button
-                          onClick={() => onPublish(post.id)}
-                          className="bg-[#06D6A0] text-white p-2 rounded-md hover:opacity-90"
-                          title="Publish"
+                          onClick={() => onEdit(post)}
+                          className="bg-[#6C63FF] text-white p-2 rounded-md hover:opacity-90"
+                          title="Edit"
                         >
-                          <ArrowUpRight className="h-4 w-4" />
+                          <Pencil className="h-4 w-4" />
                         </button>
-                      )}
-                      <button
-                        onClick={() => onDelete(post.id)}
-                        className="bg-[#FF5252] text-white p-2 rounded-md hover:opacity-90"
-                        title="Delete"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
+                        {post.status !== PostStatus.PUBLISHED && (
+                          <button
+                            onClick={() => onPublish(post.id)}
+                            className="bg-[#06D6A0] text-white p-2 rounded-md hover:opacity-90"
+                            title="Publish"
+                          >
+                            <ArrowUpRight className="h-4 w-4" />
+                          </button>
+                        )}
+                        <button
+                          onClick={() => onDelete(post.id)}
+                          className="bg-[#FF5252] text-white p-2 rounded-md hover:opacity-90"
+                          title="Delete"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
             </tbody>
           </table>
         </div>
@@ -217,19 +219,26 @@ const StatusBadge = ({ status }: { status: PostStatus }) => {
   )
 }
 
-function getCategoryColor(category: string): string {
-  const colorMap: Record<string, string> = {
-    AI: '#FF5252',
-    DEEP_LEARNING: '#6C63FF',
-    MACHINE_LEARNING: '#06D6A0',
-    WEB_DEV: '#118AB2',
-    DATABASES: '#FFD166',
-    DEVOPS: '#073B4C',
+function getCategoryColor(post: AdminPost): string {
+  if (post.accentColor) {
+    return post.accentColor
   }
-  return colorMap[category] || '#6C63FF'
+
+  const colorMap: Record<string, string> = {
+    'machine-learning': '#06D6A0',
+    'reinforcement-learning': '#FFD166',
+    'data-science': '#118AB2',
+    'quantum-computing': '#6C63FF',
+  }
+
+  if (post.categorySlug && colorMap[post.categorySlug]) {
+    return colorMap[post.categorySlug]
+  }
+
+  return '#6C63FF'
 }
 
-function formatDate(dateString?: string): string {
+function formatDateValue(dateString?: string | null): string {
   if (!dateString) return 'N/A'
   const date = new Date(dateString)
   return date.toLocaleDateString('en-US', {

--- a/src/components/admin/Sidebar.tsx
+++ b/src/components/admin/Sidebar.tsx
@@ -7,26 +7,27 @@ import {
   Settings,
   LogOut,
   BarChart,
+  ShieldCheck,
 } from 'lucide-react'
-import { useRouter } from 'next/navigation'
 
 interface SidebarProps {
   currentView: string
   onNavigate: (view: string) => void
   onCreatePost: () => void
+  onSignOut: () => Promise<void> | void
+  displayName: string
+  isAdmin: boolean
 }
 
 export const Sidebar = ({
   currentView,
   onNavigate,
   onCreatePost,
+  onSignOut,
+  displayName,
+  isAdmin,
 }: SidebarProps) => {
-  const router = useRouter()
-
-  const handleLogout = () => {
-    localStorage.removeItem('adminToken')
-    router.push('/me')
-  }
+  const roleLabel = isAdmin ? 'Administrator' : 'Author'
 
   return (
     <div className="w-[280px] bg-[#2A2A2A] text-white border-r-4 border-[#FF5252]/50 h-full flex flex-col">
@@ -43,6 +44,12 @@ export const Sidebar = ({
             Dashboard
           </span>
         </h1>
+        <div className="mt-4 text-sm text-white/70 space-y-1">
+          <p className="font-semibold text-white">{displayName}</p>
+          <p className="flex items-center gap-1 uppercase tracking-wide">
+            <ShieldCheck className="h-4 w-4" /> {roleLabel}
+          </p>
+        </div>
       </div>
       <div className="p-6 flex-1">
         <nav className="space-y-2">
@@ -81,8 +88,10 @@ export const Sidebar = ({
         </div>
       </div>
       <div className="p-6 border-t border-white/10">
-        <button 
-          onClick={handleLogout}
+        <button
+          onClick={() => {
+            void onSignOut()
+          }}
           className="flex items-center gap-2 text-lg font-bold text-white/80 hover:text-red-500 transition-colors"
         >
           <LogOut className="h-5 w-5" />

--- a/src/components/admin/StatsSection.tsx
+++ b/src/components/admin/StatsSection.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import { Eye, Clock, BarChart2, Tags } from 'lucide-react'
-import { Post, PostStatus } from '../../utils/types'
+import { AdminPost, PostStatus } from '../../utils/types'
 
 interface StatsSectionProps {
-  posts: Post[]
+  posts: AdminPost[]
 }
 
 export const StatsSection = ({ posts }: StatsSectionProps) => {
-  const totalViews = posts.reduce((sum, post) => sum + post.views, 0)
+  const totalViews = posts.reduce((sum, post) => sum + (post.views ?? 0), 0)
   const publishedPosts = posts.filter(
     (post) => post.status === PostStatus.PUBLISHED,
   ).length
@@ -19,13 +19,11 @@ export const StatsSection = ({ posts }: StatsSectionProps) => {
   ).length
 
   // Calculate category distribution
-  const categoryCount = posts.reduce(
-    (acc, post) => {
-      acc[post.category] = (acc[post.category] || 0) + 1
-      return acc
-    },
-    {} as Record<string, number>,
-  )
+  const categoryCount = posts.reduce((acc, post) => {
+    const key = post.categoryName ?? 'Uncategorized'
+    acc[key] = (acc[key] || 0) + 1
+    return acc
+  }, {} as Record<string, number>)
   const topCategory =
     Object.entries(categoryCount).sort(([, a], [, b]) => b - a)[0]?.[0] ||
     'None'

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,20 +1,43 @@
 export enum PostStatus {
   DRAFT = 'draft',
   SCHEDULED = 'scheduled',
-  PUBLISHED = 'published'
+  PUBLISHED = 'published',
 }
 
-export interface Post {
-  id: string;
-  title: string;
-  slug: string;
-  excerpt?: string;
-  content: string;
-  category: string;
-  accentColor?: string;
-  status: PostStatus;
-  views: number;
-  createdAt: string;
-  publishedAt?: string;
-  author?: string;
+export interface CategoryOption {
+  id: string
+  name: string
+  slug: string
+}
+
+export interface AdminPost {
+  id: string
+  title: string
+  slug: string
+  excerpt: string | null
+  content: string
+  categoryId: string | null
+  categoryName: string | null
+  categorySlug: string | null
+  accentColor: string | null
+  status: PostStatus
+  views: number
+  createdAt: string
+  publishedAt: string | null
+  scheduledFor: string | null
+  authorId: string | null
+}
+
+export interface PostFormValues {
+  id?: string
+  title: string
+  slug: string
+  excerpt: string | null
+  content: string
+  categoryId: string | null
+  accentColor: string | null
+  status: PostStatus
+  publishedAt: string | null
+  scheduledFor: string | null
+  authorId?: string | null
 }


### PR DESCRIPTION
## Summary
- enforce Supabase-authenticated access to the admin area and replace the login flow with profile-based role checks
- rebuild the admin dashboard UI to load, create, schedule, publish, and delete posts via Supabase-backed requests
- add service-role API routes for listing and mutating posts so the dashboard can persist changes in Supabase

## Testing
- npm run lint *(fails: Next CLI unavailable before installing dependencies)*
- npm install *(fails: peer dependency conflict between react@19 and @react-spring/web@9.7.5)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a48b48b0832db2a0df4db23ecafe