### PR TITLE
Fix static blog rendering by using service role client

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,5 +1,5 @@
 import { cache } from 'react'
-import { createServerComponentClient } from '@/lib/supabase/server-client'
+import { createServiceRoleClient } from '@/lib/supabase/server-client'
 
 interface CategoryRecord {
   id: string | null
@@ -95,7 +95,7 @@ const mapDetailPost = (record: PostDetailRecord): BlogPostDetail => ({
 })
 
 export const getPublishedPosts = cache(async () => {
-  const supabase = createServerComponentClient()
+  const supabase = createServiceRoleClient()
 
   const { data, error } = await supabase
     .from('posts')
@@ -114,7 +114,7 @@ export const getPublishedPosts = cache(async () => {
 })
 
 export const getPublishedPostBySlug = cache(async (slug: string) => {
-  const supabase = createServerComponentClient()
+  const supabase = createServiceRoleClient()
 
   const { data, error } = await supabase
     .from('posts')
@@ -147,7 +147,7 @@ export const getPublishedPostBySlug = cache(async (slug: string) => {
 })
 
 export const getPublishedSlugs = cache(async () => {
-  const supabase = createServerComponentClient()
+  const supabase = createServiceRoleClient()
 
   const { data, error } = await supabase
     .from('posts')


### PR DESCRIPTION
## Summary
- use the Supabase service role client when loading blog content so static generation no longer touches cookies
- keep incremental static regeneration enabled for the blogs listing and detail helpers

## Testing
- npm run lint *(fails: existing lint violations in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ef2dede8832d90b3cc7b39594bb0