### PR TITLE
Fix hydration mismatch and make admin route dynamic

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,6 +2,8 @@ import { redirect } from 'next/navigation'
 import { AdminDashboard } from '@/components/admin/AdminDashboard'
 import { createServerComponentClient } from '@/lib/supabase/server-client'
 
+export const dynamic = 'force-dynamic'
+
 export default async function AdminPage() {
   const supabase = createServerComponentClient()
 

--- a/src/components/ui/NewBlogsPage.tsx
+++ b/src/components/ui/NewBlogsPage.tsx
@@ -31,6 +31,17 @@ export function NewBlogsPage({ posts }: NewBlogsPageProps) {
     return Array.from(categoryMap.values()).sort((a, b) => a.label.localeCompare(b.label));
   }, [posts]);
 
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        timeZone: 'UTC',
+      }),
+    []
+  );
+
   const allBlogs = useMemo(
     () =>
       posts.map((post) => {
@@ -44,17 +55,14 @@ export function NewBlogsPage({ posts }: NewBlogsPageProps) {
           categorySlug: slug,
           categoryLabel: label,
           accentColor: post.accentColor ?? null,
-          dateLabel: post.publishedAt
-            ? new Date(post.publishedAt).toLocaleDateString('en-US', {
-                month: 'short',
-                day: 'numeric',
-                year: 'numeric',
-              })
-            : 'Unscheduled',
+          dateLabel:
+            post.publishedAt && !Number.isNaN(new Date(post.publishedAt).getTime())
+              ? dateFormatter.format(new Date(post.publishedAt))
+              : 'Unscheduled',
           views: post.views ?? 0,
         };
       }),
-    [posts]
+    [dateFormatter, posts]
   );
 
   const recommendedTopics = useMemo(


### PR DESCRIPTION
## Summary
- ensure blog date formatting uses a fixed UTC locale formatter to avoid hydration mismatches
- mark the admin page as force-dynamic so it can access cookies without rendering errors

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f0d6bf94832d80ccd91e177470f7