### PR TITLE
Allow admin route to run without static export

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,15 +1,21 @@
 import type { NextConfig } from "next";
 
+const isStaticExport = process.env.STATIC_EXPORT === 'true'
+
 const nextConfig: NextConfig = {
-  output: 'export',
+  ...(isStaticExport
+    ? {
+        output: 'export',
+        // Ensure trailing slashes for consistent routing during static export
+        trailingSlash: true,
+      }
+    : {}),
   // Set the base path if your site will be deployed to a subdirectory
   // basePath: '/syntaxblogs',
   // Disable image optimization since GitHub Pages doesn't support it
   images: {
     unoptimized: true,
   },
-  // Ensure trailing slashes for consistent routing
-  trailingSlash: true,
-};
+}
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- make the static export configuration optional so dynamic routes like /admin can run during development

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3f264dc50832db3eb2b4494d25b8e