### PR TITLE
Add admin user management and improve login guidance

### DIFF
--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,154 @@
+import { NextResponse } from 'next/server'
+import {
+  createServerComponentClient,
+  createServiceRoleClient,
+} from '@/lib/supabase/server-client'
+import type { UpdateAdminUserPayload } from '@/utils/types'
+import {
+  fetchRoles,
+  fetchProfileById,
+  ensureRoleAssignments,
+  buildUserSummary,
+} from '../route'
+
+const getAdminProfile = async (): Promise<
+  | { response: NextResponse }
+  | { profile: { id: string } }
+> => {
+  const supabase = createServerComponentClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return {
+      response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    }
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, is_admin')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (error) {
+    return {
+      response: NextResponse.json(
+        { error: `Unable to load profile: ${error.message}` },
+        { status: 500 },
+      ),
+    }
+  }
+
+  if (!profile || !profile.is_admin) {
+    return {
+      response: NextResponse.json(
+        { error: 'Forbidden: admin access required.' },
+        { status: 403 },
+      ),
+    }
+  }
+
+  return { profile: { id: profile.id } }
+}
+
+const sanitizeDisplayName = (value: unknown): string => {
+  if (typeof value !== 'string') return ''
+  return value.trim()
+}
+
+const sanitizePassword = (value: unknown): string => {
+  if (typeof value !== 'string') return ''
+  return value.trim()
+}
+
+const sanitizeRoleSlugs = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return []
+  const slugs = new Set<string>()
+  for (const entry of value) {
+    if (typeof entry === 'string' && entry.trim().length > 0) {
+      slugs.add(entry.trim())
+    }
+  }
+  return Array.from(slugs)
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const profileId = params.id
+  if (!profileId) {
+    return NextResponse.json({ error: 'Profile id is required.' }, { status: 400 })
+  }
+
+  const body = (await request.json()) as Partial<UpdateAdminUserPayload>
+
+  const displayName = sanitizeDisplayName(body?.displayName)
+  const isAdmin = Boolean(body?.isAdmin)
+  const requestedRoles = sanitizeRoleSlugs(body?.roleSlugs)
+  const newPassword = sanitizePassword(body?.newPassword)
+
+  if (!displayName) {
+    return NextResponse.json({ error: 'Display name is required.' }, { status: 400 })
+  }
+
+  const serviceClient = createServiceRoleClient()
+
+  try {
+    const profileRecord = await fetchProfileById(serviceClient, profileId)
+
+    const roles = await fetchRoles(serviceClient)
+
+    const { error: profileUpdateError } = await serviceClient
+      .from('profiles')
+      .update({ display_name: displayName, is_admin: isAdmin })
+      .eq('id', profileId)
+
+    if (profileUpdateError) {
+      throw new Error(`Unable to update profile: ${profileUpdateError.message}`)
+    }
+
+    await ensureRoleAssignments(serviceClient, profileId, roles, requestedRoles, isAdmin)
+
+    if (newPassword) {
+      if (newPassword.length < 8) {
+        return NextResponse.json(
+          { error: 'New password must be at least 8 characters long.' },
+          { status: 400 },
+        )
+      }
+
+      const { error: passwordError } = await serviceClient.auth.admin.updateUserById(
+        profileRecord.user_id,
+        { password: newPassword },
+      )
+
+      if (passwordError) {
+        throw new Error(`Unable to update password: ${passwordError.message}`)
+      }
+    }
+
+    const refreshedProfile = await fetchProfileById(serviceClient, profileId)
+    const summary = await buildUserSummary(serviceClient, refreshedProfile)
+
+    return NextResponse.json({ user: summary })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to update user.'
+    let status = 500
+    if (error instanceof Error) {
+      if (message.startsWith('Unknown role slug')) {
+        status = 400
+      } else if (message.includes('Profile not found')) {
+        status = 404
+      }
+    }
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,0 +1,444 @@
+import { NextResponse } from 'next/server'
+import {
+  createServerComponentClient,
+  createServiceRoleClient,
+} from '@/lib/supabase/server-client'
+import type {
+  AdminRole,
+  AdminUserRole,
+  AdminUserSummary,
+  CreateAdminUserPayload,
+} from '@/utils/types'
+
+export interface ProfileRecord {
+  id: string
+  user_id: string
+  display_name: string
+  is_admin: boolean
+  created_at: string
+  primary_role_id: string | null
+  profile_roles: Array<{
+    role: {
+      id: string
+      slug: string
+      name: string
+      description: string | null
+      priority: number
+    } | null
+  }> | null
+}
+
+export interface RoleRecord {
+  id: string
+  slug: string
+  name: string
+  description: string | null
+  priority: number
+}
+
+const getAdminProfile = async (): Promise<
+  | { response: NextResponse }
+  | { profile: { id: string } }
+> => {
+  const supabase = createServerComponentClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return {
+      response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    }
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, is_admin')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (error) {
+    return {
+      response: NextResponse.json(
+        { error: `Unable to load profile: ${error.message}` },
+        { status: 500 },
+      ),
+    }
+  }
+
+  if (!profile || !profile.is_admin) {
+    return {
+      response: NextResponse.json(
+        { error: 'Forbidden: admin access required.' },
+        { status: 403 },
+      ),
+    }
+  }
+
+  return { profile: { id: profile.id } }
+}
+
+const sanitizeEmail = (value: unknown): string => {
+  if (typeof value !== 'string') return ''
+  const trimmed = value.trim()
+  return trimmed.toLowerCase()
+}
+
+const sanitizeDisplayName = (value: unknown): string => {
+  if (typeof value !== 'string') return ''
+  return value.trim()
+}
+
+const sanitizePassword = (value: unknown): string => {
+  if (typeof value !== 'string') return ''
+  return value.trim()
+}
+
+const sanitizeRoleSlugs = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return []
+  const slugs = new Set<string>()
+  for (const entry of value) {
+    if (typeof entry === 'string' && entry.trim().length > 0) {
+      slugs.add(entry.trim())
+    }
+  }
+  return Array.from(slugs)
+}
+
+export const fetchRoles = async (
+  serviceClient: ReturnType<typeof createServiceRoleClient>,
+) => {
+  const { data, error } = await serviceClient
+    .from('roles')
+    .select('id, slug, name, description, priority')
+    .order('priority', { ascending: true })
+
+  if (error) {
+    throw new Error(`Unable to load roles: ${error.message}`)
+  }
+
+  return (data ?? []) as RoleRecord[]
+}
+
+export const ensureRoleAssignments = async (
+  serviceClient: ReturnType<typeof createServiceRoleClient>,
+  profileId: string,
+  allRoles: RoleRecord[],
+  requestedSlugs: string[],
+  isAdmin: boolean,
+): Promise<AdminUserRole[]> => {
+  const roleMap = new Map<string, RoleRecord>(
+    allRoles.map((role) => [role.slug, role]),
+  )
+
+  const finalSlugs = new Set<string>(requestedSlugs)
+  finalSlugs.add('member')
+
+  if (isAdmin) {
+    finalSlugs.add('admin')
+  } else {
+    finalSlugs.delete('admin')
+  }
+
+  const resolvedRoles: RoleRecord[] = []
+  for (const slug of finalSlugs) {
+    const role = roleMap.get(slug)
+    if (!role) {
+      throw new Error(`Unknown role slug: ${slug}`)
+    }
+    resolvedRoles.push(role)
+  }
+
+  const finalRoleIds = new Set(resolvedRoles.map((role) => role.id))
+
+  const { data: existingRoleRows, error: existingRoleError } = await serviceClient
+    .from('profile_roles')
+    .select('role_id')
+    .eq('profile_id', profileId)
+
+  if (existingRoleError) {
+    throw new Error(`Unable to load current role assignments: ${existingRoleError.message}`)
+  }
+
+  const existingRoleIds = new Set<string>(
+    (existingRoleRows ?? []).map((row) => row.role_id as string),
+  )
+
+  const rolesToInsert = [...finalRoleIds].filter((id) => !existingRoleIds.has(id))
+  const rolesToRemove = [...existingRoleIds].filter((id) => !finalRoleIds.has(id))
+
+  if (rolesToInsert.length > 0) {
+    const { error: insertError } = await serviceClient
+      .from('profile_roles')
+      .insert(
+        rolesToInsert.map((roleId) => ({
+          profile_id: profileId,
+          role_id: roleId,
+        })),
+      )
+
+    if (insertError) {
+      throw new Error(`Unable to assign roles: ${insertError.message}`)
+    }
+  }
+
+  if (rolesToRemove.length > 0) {
+    const { error: deleteError } = await serviceClient
+      .from('profile_roles')
+      .delete()
+      .eq('profile_id', profileId)
+      .in('role_id', rolesToRemove)
+
+    if (deleteError) {
+      throw new Error(`Unable to remove outdated roles: ${deleteError.message}`)
+    }
+  }
+
+  const sortedRoles = [...resolvedRoles].sort((a, b) => a.priority - b.priority)
+  const primaryRoleId = sortedRoles[0]?.id ?? null
+
+  const { error: profileUpdateError } = await serviceClient
+    .from('profiles')
+    .update({
+      is_admin: isAdmin,
+      primary_role_id: primaryRoleId,
+    })
+    .eq('id', profileId)
+
+  if (profileUpdateError) {
+    throw new Error(`Unable to update profile role metadata: ${profileUpdateError.message}`)
+  }
+
+  return sortedRoles.map((role) => ({
+    id: role.id,
+    slug: role.slug,
+    name: role.name,
+    description: role.description,
+    priority: role.priority,
+  }))
+}
+
+export const buildUserSummary = async (
+  serviceClient: ReturnType<typeof createServiceRoleClient>,
+  profile: ProfileRecord,
+  emailMap?: Map<string, string>,
+): Promise<AdminUserSummary> => {
+  let email = ''
+
+  if (emailMap?.has(profile.user_id)) {
+    email = emailMap.get(profile.user_id) ?? ''
+  } else {
+    const { data, error } = await serviceClient.auth.admin.getUserById(profile.user_id)
+    if (error) {
+      throw new Error(`Unable to load auth user: ${error.message}`)
+    }
+    email = data.user?.email ?? ''
+  }
+
+  const roles: AdminUserRole[] =
+    profile.profile_roles
+      ?.map((entry) => entry.role)
+      .filter((role): role is RoleRecord => !!role)
+      .map((role) => ({
+        id: role.id,
+        slug: role.slug,
+        name: role.name,
+        description: role.description,
+        priority: role.priority,
+      })) ?? []
+
+  roles.sort((a, b) => a.priority - b.priority)
+
+  return {
+    profileId: profile.id,
+    userId: profile.user_id,
+    email,
+    displayName: profile.display_name,
+    isAdmin: profile.is_admin,
+    createdAt: profile.created_at,
+    primaryRoleId: profile.primary_role_id ?? null,
+    roles,
+  }
+}
+
+export const fetchProfileById = async (
+  serviceClient: ReturnType<typeof createServiceRoleClient>,
+  profileId: string,
+): Promise<ProfileRecord> => {
+  const { data, error } = await serviceClient
+    .from('profiles')
+    .select(
+      `id, user_id, display_name, is_admin, created_at, primary_role_id,
+       profile_roles(role:roles(id, slug, name, description, priority))`,
+    )
+    .eq('id', profileId)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Unable to load profile: ${error.message}`)
+  }
+
+  if (!data) {
+    throw new Error('Profile not found.')
+  }
+
+  return data as ProfileRecord
+}
+
+const loadAllUserSummaries = async (
+  serviceClient: ReturnType<typeof createServiceRoleClient>,
+): Promise<AdminUserSummary[]> => {
+  const { data: profiles, error: profilesError } = await serviceClient
+    .from('profiles')
+    .select(
+      `id, user_id, display_name, is_admin, created_at, primary_role_id,
+       profile_roles(role:roles(id, slug, name, description, priority))`,
+    )
+    .order('created_at', { ascending: false })
+
+  if (profilesError) {
+    throw new Error(`Unable to load profiles: ${profilesError.message}`)
+  }
+
+  const profileRecords = (profiles ?? []) as ProfileRecord[]
+
+  const emailMap = new Map<string, string>()
+  let page = 1
+
+  while (true) {
+    const { data: pageData, error: pageError } = await serviceClient.auth.admin.listUsers({
+      page,
+      perPage: 1000,
+    })
+
+    if (pageError) {
+      throw new Error(`Unable to load user directory: ${pageError.message}`)
+    }
+
+    for (const user of pageData.users ?? []) {
+      if (user.id) {
+        emailMap.set(user.id, user.email ?? '')
+      }
+    }
+
+    if (!pageData.nextPage) {
+      break
+    }
+
+    page = pageData.nextPage
+  }
+
+  return Promise.all(
+    profileRecords.map((profile) => buildUserSummary(serviceClient, profile, emailMap)),
+  )
+}
+
+export async function GET() {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  try {
+    const serviceClient = createServiceRoleClient()
+    const [roles, users] = await Promise.all([
+      fetchRoles(serviceClient),
+      loadAllUserSummaries(serviceClient),
+    ])
+
+    const formattedRoles: AdminRole[] = roles.map((role) => ({
+      id: role.id,
+      slug: role.slug,
+      name: role.name,
+      description: role.description,
+      priority: role.priority,
+    }))
+
+    return NextResponse.json({ users, roles: formattedRoles })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to load users.'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const body = (await request.json()) as Partial<CreateAdminUserPayload>
+
+  const email = sanitizeEmail(body?.email)
+  const password = sanitizePassword(body?.password)
+  const displayName = sanitizeDisplayName(body?.displayName)
+  const isAdmin = Boolean(body?.isAdmin)
+  const requestedRoles = sanitizeRoleSlugs(body?.roleSlugs)
+
+  if (!email) {
+    return NextResponse.json({ error: 'Email is required.' }, { status: 400 })
+  }
+
+  if (!password || password.length < 8) {
+    return NextResponse.json(
+      { error: 'Password must be at least 8 characters long.' },
+      { status: 400 },
+    )
+  }
+
+  if (!displayName) {
+    return NextResponse.json({ error: 'Display name is required.' }, { status: 400 })
+  }
+
+  const serviceClient = createServiceRoleClient()
+
+  try {
+    const roles = await fetchRoles(serviceClient)
+
+    const { data: authResult, error: authError } = await serviceClient.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+    })
+
+    if (authError) {
+      throw new Error(`Unable to create user: ${authError.message}`)
+    }
+
+    const authUser = authResult.user
+    if (!authUser) {
+      throw new Error('Unable to create user: missing auth record.')
+    }
+
+    const { data: profileData, error: profileError } = await serviceClient
+      .from('profiles')
+      .insert({
+        user_id: authUser.id,
+        display_name: displayName,
+        is_admin: isAdmin,
+      })
+      .select(
+        `id, user_id, display_name, is_admin, created_at, primary_role_id,
+         profile_roles(role:roles(id, slug, name, description, priority))`,
+      )
+      .single()
+
+    if (profileError || !profileData) {
+      throw new Error(
+        `Unable to provision profile: ${profileError?.message ?? 'missing record.'}`,
+      )
+    }
+
+    await ensureRoleAssignments(serviceClient, profileData.id, roles, requestedRoles, isAdmin)
+
+    const refreshedProfile = await fetchProfileById(serviceClient, profileData.id)
+    const summary = await buildUserSummary(serviceClient, refreshedProfile)
+
+    return NextResponse.json({ user: summary })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to create user.'
+    const status =
+      error instanceof Error && message.startsWith('Unknown role slug') ? 400 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -63,7 +63,11 @@ export default function LoginPage() {
     });
 
     if (signInError) {
-      setError(signInError.message);
+      const normalizedMessage = signInError.message.toLowerCase();
+      const friendlyMessage = normalizedMessage.includes('invalid login')
+        ? 'Invalid login credentials. If you are using the bundled admin account, run `npm run seed:test-user` to (re)create it and confirm the profile is flagged as admin in Supabase.'
+        : signInError.message;
+      setError(friendlyMessage);
       setIsLoading(false);
       return;
     }
@@ -162,6 +166,11 @@ export default function LoginPage() {
           <p>
             Use your Supabase email and password. Only accounts marked as admin in
             the <code>profiles</code> table can access this dashboard.
+          </p>
+          <p className="mt-2">
+            Need a test account? Run <code>npm run seed:test-user</code> after applying
+            the migrations to generate <code>test.admin@syntaxblogs.dev</code> with the
+            default password.
           </p>
         </div>
       </div>

--- a/src/components/admin/Sidebar.tsx
+++ b/src/components/admin/Sidebar.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import {
+  BarChart,
   Coffee,
   Code,
-  LayoutDashboard,
   FileText,
-  Settings,
+  LayoutDashboard,
   LogOut,
-  BarChart,
+  Settings,
   ShieldCheck,
+  Users,
 } from 'lucide-react'
 
 interface SidebarProps {
@@ -65,6 +66,14 @@ export const Sidebar = ({
             isActive={currentView === 'posts'}
             onClick={() => onNavigate('posts')}
           />
+          {isAdmin && (
+            <SidebarLink
+              icon={<Users />}
+              label="Users"
+              isActive={currentView === 'users'}
+              onClick={() => onNavigate('users')}
+            />
+          )}
           <SidebarLink
             icon={<BarChart />}
             label="Analytics"

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -1,0 +1,423 @@
+"use client"
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  AdminRole,
+  AdminUserSummary,
+  CreateAdminUserPayload,
+  UpdateAdminUserPayload,
+} from '@/utils/types'
+
+interface UserManagementProps {
+  users: AdminUserSummary[]
+  roles: AdminRole[]
+  isLoading: boolean
+  isSaving: boolean
+  onRefresh: () => Promise<void> | void
+  onCreateUser: (payload: CreateAdminUserPayload) => Promise<boolean>
+  onUpdateUser: (profileId: string, payload: UpdateAdminUserPayload) => Promise<boolean>
+}
+
+type FormMode = 'create' | 'edit'
+
+const DEFAULT_CREATE_ROLE = 'member'
+
+export const UserManagement = ({
+  users,
+  roles,
+  isLoading,
+  isSaving,
+  onRefresh,
+  onCreateUser,
+  onUpdateUser,
+}: UserManagementProps) => {
+  const [mode, setMode] = useState<FormMode>('create')
+  const [selectedUser, setSelectedUser] = useState<AdminUserSummary | null>(null)
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [displayName, setDisplayName] = useState('')
+  const [isAdmin, setIsAdmin] = useState(false)
+  const [roleSlugs, setRoleSlugs] = useState<Set<string>>(new Set([DEFAULT_CREATE_ROLE]))
+
+  const sortedRoles = useMemo(
+    () => [...roles].sort((a, b) => a.priority - b.priority),
+    [roles],
+  )
+
+  useEffect(() => {
+    if (mode === 'create') {
+      setEmail('')
+      setPassword('')
+      setNewPassword('')
+      setDisplayName('')
+      setIsAdmin(false)
+      setRoleSlugs(new Set([DEFAULT_CREATE_ROLE]))
+      setSelectedUser(null)
+    }
+  }, [mode])
+
+  useEffect(() => {
+    if (mode === 'edit' && selectedUser) {
+      setEmail(selectedUser.email)
+      setDisplayName(selectedUser.displayName)
+      setIsAdmin(selectedUser.isAdmin)
+      setNewPassword('')
+      setPassword('')
+      setRoleSlugs(
+        new Set(
+          selectedUser.roles.length > 0
+            ? selectedUser.roles.map((role) => role.slug)
+            : [DEFAULT_CREATE_ROLE],
+        ),
+      )
+    }
+  }, [mode, selectedUser])
+
+  const resetToCreateMode = () => {
+    setMode('create')
+  }
+
+  const ensureRoleSelection = (nextRoles: Set<string>, includeAdmin: boolean) => {
+    const updated = new Set(nextRoles)
+    updated.add(DEFAULT_CREATE_ROLE)
+    if (includeAdmin) {
+      updated.add('admin')
+    } else {
+      updated.delete('admin')
+    }
+    return updated
+  }
+
+  const handleToggleRole = (slug: string) => {
+    if (slug === DEFAULT_CREATE_ROLE) {
+      return
+    }
+
+    setRoleSlugs((current) => {
+      const next = new Set(current)
+      if (next.has(slug)) {
+        next.delete(slug)
+      } else {
+        next.add(slug)
+      }
+      return ensureRoleSelection(next, isAdmin)
+    })
+  }
+
+  const handleAdminToggle = (value: boolean) => {
+    setIsAdmin(value)
+    setRoleSlugs((current) => ensureRoleSelection(current, value))
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const baseRoles = ensureRoleSelection(roleSlugs, isAdmin)
+    const payloadRoles = Array.from(baseRoles)
+
+    if (mode === 'create') {
+      const success = await onCreateUser({
+        email: email.trim(),
+        password: password.trim(),
+        displayName: displayName.trim(),
+        isAdmin,
+        roleSlugs: payloadRoles,
+      })
+
+      if (success) {
+        resetToCreateMode()
+      }
+      return
+    }
+
+    if (!selectedUser) {
+      return
+    }
+
+    const success = await onUpdateUser(selectedUser.profileId, {
+      displayName: displayName.trim(),
+      isAdmin,
+      roleSlugs: payloadRoles,
+      newPassword: newPassword.trim() ? newPassword.trim() : undefined,
+    })
+
+    if (success) {
+      setNewPassword('')
+    }
+  }
+
+  const handleEditClick = (user: AdminUserSummary) => {
+    setSelectedUser(user)
+    setMode('edit')
+  }
+
+  const renderRoleSelector = () => (
+    <div className="space-y-2">
+      <p className="text-sm font-semibold text-gray-700">Roles</p>
+      {sortedRoles.length === 0 ? (
+        <p className="text-xs text-gray-500">
+          No roles are configured yet. Add roles in the database to control access levels.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {sortedRoles.map((role) => {
+            const isChecked = roleSlugs.has(role.slug)
+            const isDisabled = role.slug === DEFAULT_CREATE_ROLE
+            return (
+              <label
+                key={role.id}
+                className={`flex items-start gap-2 rounded-md border-2 p-3 transition-colors ${
+                  isChecked
+                    ? 'border-[#6C63FF] bg-[#6C63FF]/5'
+                    : 'border-gray-200 hover:border-[#6C63FF]/40'
+                } ${isDisabled ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'}`}
+              >
+                <input
+                  type="checkbox"
+                  checked={isChecked}
+                  disabled={isDisabled}
+                  onChange={() => handleToggleRole(role.slug)}
+                  className="mt-1"
+                />
+                <span>
+                  <span className="block font-semibold text-sm text-gray-900">
+                    {role.name}
+                  </span>
+                  {role.description && (
+                    <span className="block text-xs text-gray-500">{role.description}</span>
+                  )}
+                </span>
+              </label>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-[#2A2A2A]">User Management</h1>
+          <p className="text-gray-600">
+            Create new accounts, manage roles, and control access to the dashboard.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={resetToCreateMode}
+            className={`neo-button px-4 py-2 font-bold ${
+              mode === 'create' ? 'bg-[#6C63FF] text-white' : 'bg-white text-[#2A2A2A]'
+            }`}
+          >
+            + New User
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              void onRefresh()
+            }}
+            className="neo-button px-4 py-2 font-bold bg-white text-[#2A2A2A]"
+            disabled={isLoading}
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="grid lg:grid-cols-[2fr_1fr] gap-6">
+        <div className="bg-white border-3 border-[#2A2A2A]/20 rounded-lg p-6 shadow-[4px_4px_0px_0px_rgba(0,0,0,0.1)]">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-2xl font-bold text-[#2A2A2A]">Team Members</h2>
+            <span className="text-sm text-gray-500">{users.length} total</span>
+          </div>
+
+          {isLoading ? (
+            <p className="text-gray-500">Loading users...</p>
+          ) : users.length === 0 ? (
+            <p className="text-gray-500">No users found. Create the first account above.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr className="bg-gray-50 text-left text-sm font-semibold text-gray-700">
+                    <th className="px-4 py-3">Name</th>
+                    <th className="px-4 py-3">Email</th>
+                    <th className="px-4 py-3">Roles</th>
+                    <th className="px-4 py-3 text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {users.map((user) => (
+                    <tr key={user.profileId} className="text-sm">
+                      <td className="px-4 py-3 font-semibold text-gray-900">
+                        {user.displayName}
+                        {user.isAdmin && (
+                          <span className="ml-2 inline-flex items-center rounded-full bg-[#6C63FF]/10 px-2 py-0.5 text-xs font-bold text-[#6C63FF]">
+                            Admin
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-gray-600">{user.email}</td>
+                      <td className="px-4 py-3 text-gray-600">
+                        {user.roles.length === 0 ? (
+                          <span className="italic text-gray-400">No roles</span>
+                        ) : (
+                          <div className="flex flex-wrap gap-2">
+                            {user.roles.map((role) => (
+                              <span
+                                key={`${user.profileId}-${role.id}`}
+                                className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-700"
+                              >
+                                {role.name}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <button
+                          type="button"
+                          onClick={() => handleEditClick(user)}
+                          className="neo-button px-3 py-1 text-xs font-bold bg-white text-[#2A2A2A]"
+                          disabled={isSaving && selectedUser?.profileId === user.profileId}
+                        >
+                          Edit
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
+        <div className="bg-white border-3 border-[#2A2A2A]/20 rounded-lg p-6 shadow-[4px_4px_0px_0px_rgba(0,0,0,0.1)]">
+          <h2 className="text-2xl font-bold text-[#2A2A2A] mb-4">
+            {mode === 'create' ? 'Create New User' : 'Update User'}
+          </h2>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {mode === 'create' ? (
+              <>
+                <div>
+                  <label className="block text-sm font-semibold text-gray-700 mb-1">
+                    Email
+                  </label>
+                  <input
+                    type="email"
+                    required
+                    className="w-full rounded-md border-2 border-gray-300 px-3 py-2 focus:border-[#6C63FF] focus:outline-none"
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-semibold text-gray-700 mb-1">
+                    Temporary Password
+                  </label>
+                  <input
+                    type="password"
+                    required
+                    minLength={8}
+                    className="w-full rounded-md border-2 border-gray-300 px-3 py-2 focus:border-[#6C63FF] focus:outline-none"
+                    value={password}
+                    onChange={(event) => setPassword(event.target.value)}
+                  />
+                  <p className="mt-1 text-xs text-gray-500">
+                    Share this password with the new admin. They can update it after signing in.
+                  </p>
+                </div>
+              </>
+            ) : (
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 mb-1">
+                  Email
+                </label>
+                <input
+                  type="email"
+                  value={email}
+                  disabled
+                  className="w-full rounded-md border-2 border-gray-200 bg-gray-100 px-3 py-2 text-gray-600"
+                />
+              </div>
+            )}
+
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-1">
+                Display Name
+              </label>
+              <input
+                type="text"
+                required
+                className="w-full rounded-md border-2 border-gray-300 px-3 py-2 focus:border-[#6C63FF] focus:outline-none"
+                value={displayName}
+                onChange={(event) => setDisplayName(event.target.value)}
+              />
+            </div>
+
+            <div className="flex items-center gap-2">
+              <input
+                id="user-management-is-admin"
+                type="checkbox"
+                checked={isAdmin}
+                onChange={(event) => handleAdminToggle(event.target.checked)}
+                className="h-4 w-4"
+              />
+              <label htmlFor="user-management-is-admin" className="text-sm font-semibold text-gray-700">
+                Grant administrator access
+              </label>
+            </div>
+
+            {renderRoleSelector()}
+
+            {mode === 'edit' && (
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 mb-1">
+                  Reset Password (optional)
+                </label>
+                <input
+                  type="password"
+                  minLength={8}
+                  placeholder="Leave blank to keep current password"
+                  className="w-full rounded-md border-2 border-gray-300 px-3 py-2 focus:border-[#6C63FF] focus:outline-none"
+                  value={newPassword}
+                  onChange={(event) => setNewPassword(event.target.value)}
+                />
+              </div>
+            )}
+
+            <div className="flex items-center gap-3 pt-2">
+              <button
+                type="submit"
+                className="neo-button px-4 py-2 font-bold bg-[#FF5252] text-white"
+                disabled={isSaving}
+              >
+                {isSaving
+                  ? mode === 'create'
+                    ? 'Creating...'
+                    : 'Updating...'
+                  : mode === 'create'
+                  ? 'Create User'
+                  : 'Save Changes'}
+              </button>
+              {mode === 'edit' && (
+                <button
+                  type="button"
+                  onClick={resetToCreateMode}
+                  className="neo-button px-4 py-2 font-bold bg-white text-[#2A2A2A]"
+                  disabled={isSaving}
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -41,3 +41,45 @@ export interface PostFormValues {
   scheduledFor: string | null
   authorId?: string | null
 }
+
+export interface AdminRole {
+  id: string
+  slug: string
+  name: string
+  description: string | null
+  priority: number
+}
+
+export interface AdminUserRole {
+  id: string
+  slug: string
+  name: string
+  description: string | null
+  priority: number
+}
+
+export interface AdminUserSummary {
+  profileId: string
+  userId: string
+  email: string
+  displayName: string
+  isAdmin: boolean
+  createdAt: string
+  primaryRoleId: string | null
+  roles: AdminUserRole[]
+}
+
+export interface CreateAdminUserPayload {
+  email: string
+  password: string
+  displayName: string
+  isAdmin: boolean
+  roleSlugs: string[]
+}
+
+export interface UpdateAdminUserPayload {
+  displayName: string
+  isAdmin: boolean
+  roleSlugs: string[]
+  newPassword?: string | null
+}


### PR DESCRIPTION
## Summary
- add protected admin API endpoints to list, create, and update users while syncing Supabase roles
- integrate a full user management view into the admin dashboard, including navigation and role-aware forms
- update the admin login page with clearer guidance for seeding the test account when credentials fail

## Testing
- npm run lint *(fails: existing lint issues in src/components/ui and src/utils/useLocalStorage)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f3efb07c832d8755423c1e61b21d