### PR TITLE
Fix test admin seeding script and suppress hydration warning

### DIFF
--- a/scripts/create-test-user.ts
+++ b/scripts/create-test-user.ts
@@ -58,4 +58,95 @@ const supabase = createClient(supabaseUrl, serviceRoleKey, {
     persistSession: false,
     autoRefreshToken: false,
   },
-})
+});
+
+async function ensureTestUser() {
+  const { data: existingUser, error: fetchError } = await supabase.auth.admin.getUserByEmail(
+    TEST_USER_EMAIL
+  );
+
+  if (fetchError) {
+    throw new Error(`Failed to look up existing test user: ${fetchError.message}`);
+  }
+
+  if (existingUser?.user) {
+    const { error: updateError } = await supabase.auth.admin.updateUserById(existingUser.user.id, {
+      password: TEST_USER_PASSWORD,
+      email_confirm: true,
+    });
+
+    if (updateError) {
+      throw new Error(`Failed to update existing test user credentials: ${updateError.message}`);
+    }
+
+    await ensureProfile(existingUser.user.id);
+    return existingUser.user.id;
+  }
+
+  const { data: createdUser, error: createError } = await supabase.auth.admin.createUser({
+    email: TEST_USER_EMAIL,
+    password: TEST_USER_PASSWORD,
+    email_confirm: true,
+  });
+
+  if (createError || !createdUser?.user) {
+    throw new Error(createError?.message ?? 'Unable to create test user.');
+  }
+
+  await ensureProfile(createdUser.user.id);
+  return createdUser.user.id;
+}
+
+async function ensureProfile(userId: string) {
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('id, is_admin, display_name')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (profileError) {
+    throw new Error(`Failed to load profile for test user: ${profileError.message}`);
+  }
+
+  if (!profile) {
+    const { error: insertError } = await supabase.from('profiles').insert({
+      user_id: userId,
+      display_name: TEST_USER_DISPLAY_NAME,
+      is_admin: true,
+    });
+
+    if (insertError) {
+      throw new Error(`Failed to insert profile for test user: ${insertError.message}`);
+    }
+    return;
+  }
+
+  if (!profile.is_admin || !profile.display_name) {
+    const { error: updateError } = await supabase
+      .from('profiles')
+      .update({
+        display_name: profile.display_name ?? TEST_USER_DISPLAY_NAME,
+        is_admin: true,
+      })
+      .eq('id', profile.id);
+
+    if (updateError) {
+      throw new Error(`Failed to promote test user profile to admin: ${updateError.message}`);
+    }
+  }
+}
+
+async function main() {
+  try {
+    const userId = await ensureTestUser();
+    console.log('Test admin user is ready.');
+    console.log(`Email:    ${TEST_USER_EMAIL}`);
+    console.log(`Password: ${TEST_USER_PASSWORD}`);
+    console.log(`Supabase user id: ${userId}`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -129,7 +129,9 @@ export default function LoginPage() {
               id="email"
               name="email"
               type="email"
+              autoComplete="email"
               required
+              suppressHydrationWarning
               className="w-full px-3 py-2 border border-black focus:outline-none focus:ring-2 focus:ring-purple-500"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
@@ -144,7 +146,9 @@ export default function LoginPage() {
               id="password"
               name="password"
               type="password"
+              autoComplete="current-password"
               required
+              suppressHydrationWarning
               className="w-full px-3 py-2 border border-black focus:outline-none focus:ring-2 focus:ring-purple-500"
               value={password}
               onChange={(e) => setPassword(e.target.value)}


### PR DESCRIPTION
## Summary
- restore the test user seed script logic so the admin account is created or updated alongside its profile
- retain improved environment loading diagnostics while ensuring the script exits with useful errors
- add autocomplete hints and hydration warning suppression to login inputs to avoid browser extension mismatches

## Testing
- not run (requires Supabase credentials/environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3fceddfac832da59c8ef1661a54ac