### PR TITLE
Fix admin login redirect loop by syncing Supabase auth cookies

### DIFF
--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
+import { createServerClient } from '@/lib/supabase/server-client';
+
+interface SyncAuthPayload {
+  event?: AuthChangeEvent;
+  session?: Session | null;
+}
+
+export async function POST(request: Request) {
+  const supabase = createServerClient();
+
+  try {
+    const { event, session }: SyncAuthPayload = await request.json();
+
+    if (!event) {
+      return NextResponse.json(
+        { success: false, error: 'Missing auth change event.' },
+        { status: 400 },
+      );
+    }
+
+    if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+      if (!session) {
+        return NextResponse.json(
+          { success: false, error: 'Missing session for auth event.' },
+          { status: 400 },
+        );
+      }
+
+      const { error } = await supabase.auth.setSession(session);
+
+      if (error) {
+        console.error('Failed to persist Supabase session', error);
+        return NextResponse.json(
+          { success: false, error: 'Unable to persist session.' },
+          { status: 500 },
+        );
+      }
+    }
+
+    if (event === 'SIGNED_OUT') {
+      const { error } = await supabase.auth.signOut();
+      if (error) {
+        console.error('Failed to clear Supabase session', error);
+        return NextResponse.json(
+          { success: false, error: 'Unable to clear session.' },
+          { status: 500 },
+        );
+      }
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Failed to sync auth session', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to sync auth session.' },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add an auth session API route that persists Supabase auth events to server cookies
- sync the client session with the server from the login page and remove redundant refresh calls to stop the /me ↔ /admin loop

## Testing
- npm run lint *(fails: existing lint issues in unrelated UI components)*

------
https://chatgpt.com/codex/tasks/task_e_68e405545cd4832db5ea19aab7af6309