### PR TITLE
Fix Supabase client to share auth session with server

### DIFF
--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,6 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createBrowserClient as createSupabaseBrowserClient } from '@supabase/ssr'
 
-type ClientOptions = Parameters<typeof createClient>[2]
+type ClientOptions = Parameters<typeof createSupabaseBrowserClient>[2]
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
@@ -21,4 +21,4 @@ const defaultOptions: ClientOptions = {
 }
 
 export const createBrowserClient = () =>
-  createClient(supabaseUrl, supabaseAnonKey, defaultOptions)
+  createSupabaseBrowserClient(supabaseUrl, supabaseAnonKey, defaultOptions)


### PR DESCRIPTION
## Summary
- switch the client-side Supabase helper to use `@supabase/ssr` so that auth sessions are mirrored into cookies
- keep existing auth options so the browser client still persists and refreshes sessions

## Testing
- npm run lint *(fails: pre-existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e405545cd4832db5ea19aab7af6309