### PR TITLE
Add marketing and legal information pages

### DIFF
--- a/src/app/cookies/page.tsx
+++ b/src/app/cookies/page.tsx
@@ -1,0 +1,73 @@
+import { ContentPageLayout, ContentSection } from '@/components/ui/ContentPageLayout';
+
+const categories = [
+  {
+    title: 'Essential cookies',
+    description: 'Keep the site secure and operational. Required for authentication, session management, and load balancing.',
+    examples: ['Session tokens', 'CSRF protection cookies', 'Traffic routing'],
+  },
+  {
+    title: 'Analytics cookies',
+    description: 'Help us understand how you use Syntax & Sips so we can make smarter improvements.',
+    examples: ['Aggregate page views', 'Feature adoption metrics', 'Anonymized device info'],
+  },
+  {
+    title: 'Preference cookies',
+    description: 'Remember your theme, saved filters, and last-played content for a personalized experience.',
+    examples: ['Theme selection', 'Saved category filters', 'Recently played podcasts'],
+  },
+];
+
+export const metadata = {
+  title: 'Cookie Policy',
+  description: 'Learn how Syntax & Sips uses cookies and how you can manage your preferences.',
+};
+
+export default function CookiesPage() {
+  return (
+    <ContentPageLayout
+      badge={<span>Legal</span>}
+      title="Cookie policy"
+      description="Cookies help us keep Syntax & Sips fast, secure, and tailored to you. Here is what we use and how you can take control."
+    >
+      <ContentSection
+        eyebrow={<span role="img" aria-label="cookie">🍪</span>}
+        title="Types of cookies"
+        description="We keep our categories simple."
+        fullWidth
+      >
+        <div className="grid gap-6 md:grid-cols-3">
+          {categories.map((category) => (
+            <article key={category.title} className="border-4 border-black bg-white p-6 shadow-[6px_6px_0_0_#000]">
+              <h3 className="text-lg font-black">{category.title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-gray-700">{category.description}</p>
+              <ul className="mt-3 space-y-1 text-xs font-semibold uppercase tracking-widest text-gray-600">
+                {category.examples.map((example) => (
+                  <li key={example}>{example}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow={<span role="img" aria-label="controls">🎛️</span>}
+        title="Managing preferences"
+        description="You can adjust analytics and preference cookies at any time."
+        fullWidth
+      >
+        <div className="space-y-3 text-sm leading-relaxed text-gray-700">
+          <p>
+            Use the cookie banner to opt in or out of analytics. You can also clear cookies directly from your browser
+            settings.
+          </p>
+          <p>
+            Want a manual reset? Email privacy@syntaxandsips.dev and we will wipe non-essential cookies associated with your
+            account.
+          </p>
+        </div>
+      </ContentSection>
+    </ContentPageLayout>
+  );
+}

--- a/src/app/disclaimer/page.tsx
+++ b/src/app/disclaimer/page.tsx
@@ -1,0 +1,69 @@
+import { ContentPageLayout, ContentSection } from '@/components/ui/ContentPageLayout';
+
+const disclaimers = [
+  {
+    title: 'Educational purposes',
+    description: 'Syntax & Sips content is for educational and informational purposes. Apply judgment before using it in production systems.',
+  },
+  {
+    title: 'No guarantees',
+    description: 'We strive for accuracy, but AI and ML evolve quickly. Validate approaches independently before launching.',
+  },
+  {
+    title: 'Affiliations & sponsorships',
+    description: 'Some content may include affiliate links or sponsorships. We only promote tools we trust and disclose partnerships clearly.',
+  },
+];
+
+const responsibilities = [
+  'You are responsible for complying with local laws, industry regulations, and internal policies when implementing anything you learn here.',
+  'Code samples, prompts, and workflows are provided “as is.” Review security, privacy, and compliance requirements before deploying.',
+  'By using Syntax & Sips you agree that we are not liable for damages arising from the use of our content or products.',
+];
+
+export const metadata = {
+  title: 'Disclaimer',
+  description: 'Understand the boundaries of responsibility when using Syntax & Sips content and tools.',
+};
+
+export default function DisclaimerPage() {
+  return (
+    <ContentPageLayout
+      badge={<span>Legal</span>}
+      title="Disclaimer"
+      description="We want you to build confidently. This disclaimer clarifies how to interpret Syntax & Sips content and tools."
+    >
+      <ContentSection
+        eyebrow={<span role="img" aria-label="lightbulb">💡</span>}
+        title="What to keep in mind"
+        description="We love sharing knowledge, but there are a few boundaries."
+        fullWidth
+      >
+        <div className="grid gap-6 md:grid-cols-3">
+          {disclaimers.map((item) => (
+            <div key={item.title} className="border-4 border-black bg-white p-6 shadow-[6px_6px_0_0_#000]">
+              <h3 className="text-lg font-black">{item.title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-gray-700">{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow={<span role="img" aria-label="clipboard">📋</span>}
+        title="Your responsibility"
+        description="We provide guidance—you apply it wisely."
+        fullWidth
+      >
+        <ul className="space-y-3 text-sm leading-relaxed text-gray-700">
+          {responsibilities.map((item) => (
+            <li key={item} className="flex items-start gap-3">
+              <span aria-hidden className="mt-1 text-[#118AB2]">•</span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </ContentSection>
+    </ContentPageLayout>
+  );
+}

--- a/src/app/newsletter/page.tsx
+++ b/src/app/newsletter/page.tsx
@@ -1,0 +1,84 @@
+import Link from 'next/link';
+import { ContentPageLayout, ContentSection } from '@/components/ui/ContentPageLayout';
+import { NewsletterSection } from '@/components/ui/NewsletterSection';
+
+const perks = [
+  {
+    title: 'AI trends decoded',
+    description: 'Every Friday we share a curated briefing on the AI news that actually matters for builders.',
+  },
+  {
+    title: 'Implementation walkthroughs',
+    description: 'Step-by-step breakdowns of features we ship on Syntax & Sips—complete with repo links and diagrams.',
+  },
+  {
+    title: 'Templates & tooling alerts',
+    description: 'Be the first to access new prompts, dashboards, and productivity automations from the team.',
+  },
+];
+
+const commitment = [
+  'No spam—ever. We send 1 primary email per week and occasional launch notes.',
+  'You can unsubscribe in a single click. Every email includes a plain-text link.',
+  'We protect your data. Read the privacy policy for full details.',
+];
+
+export const metadata = {
+  title: 'Newsletter',
+  description: 'Join thousands of builders receiving actionable AI insights from Syntax & Sips each week.',
+};
+
+export default function NewsletterPage() {
+  return (
+    <ContentPageLayout
+      badge={<span>Stay Updated</span>}
+      title="Subscribe to the Syntax & Sips newsletter"
+      description="Get weekly insights, implementation guides, and behind-the-scenes updates. We keep it practical, tactical, and easy to apply."
+      action={
+        <Link href="#signup" className="neo-button bg-black text-white px-5 py-3 text-sm md:text-base">
+          Jump to signup
+        </Link>
+      }
+    >
+      <ContentSection
+        eyebrow={<span role="img" aria-label="mailbox">📬</span>}
+        title="Why readers stay subscribed"
+        description="We respect your inbox. Each issue is written by our core team and includes concrete takeaways."
+        fullWidth
+      >
+        <div className="grid gap-6 md:grid-cols-3">
+          {perks.map((perk) => (
+            <div key={perk.title} className="border-4 border-black bg-white p-6 shadow-[6px_6px_0_0_#000]">
+              <h3 className="text-lg font-black">{perk.title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-gray-700">{perk.description}</p>
+            </div>
+          ))}
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow={<span role="img" aria-label="shield">🛡️</span>}
+        title="Our promise"
+        description="We built guardrails so you can trust every email."
+        fullWidth
+      >
+        <ul className="space-y-3 text-sm font-semibold leading-relaxed text-gray-800">
+          {commitment.map((item) => (
+            <li key={item} className="flex items-start gap-3">
+              <span aria-hidden className="mt-1 text-[#6C63FF]">✔</span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+        <p className="text-sm text-gray-600">
+          Curious how we handle data? Review our <Link href="/privacy" className="underline">privacy policy</Link> and
+          <Link href="/terms" className="underline"> terms of service</Link>.
+        </p>
+      </ContentSection>
+
+      <div id="signup">
+        <NewsletterSection />
+      </div>
+    </ContentPageLayout>
+  );
+}

--- a/src/app/podcasts/page.tsx
+++ b/src/app/podcasts/page.tsx
@@ -1,0 +1,181 @@
+import Link from 'next/link';
+import { ContentPageLayout, ContentSection } from '@/components/ui/ContentPageLayout';
+
+const episodes = [
+  {
+    title: 'Human + Machine: Collaborating with Generative AI',
+    description:
+      'We dive into the tooling and mental models that help developers pair with AI systems without sacrificing control or creativity.',
+    duration: '48 min',
+    releaseDate: 'January 22, 2025',
+    slug: 'human-machine-generative-ai',
+  },
+  {
+    title: 'From Prototype to Production LLMs',
+    description:
+      'A candid conversation about scaling large language models, evaluation strategies, and the infrastructure choices that actually work.',
+    duration: '56 min',
+    releaseDate: 'January 8, 2025',
+    slug: 'prototype-to-production-llms',
+  },
+  {
+    title: 'Edge AI in the Real World',
+    description:
+      'How tiny ML models are reshaping hardware products, with lessons from the teams shipping voice, vision, and predictive experiences.',
+    duration: '42 min',
+    releaseDate: 'December 18, 2024',
+    slug: 'edge-ai-in-the-real-world',
+  },
+];
+
+const platforms = [
+  {
+    name: 'Spotify',
+    href: 'https://spotify.com',
+    description: 'Follow Syntax & Sips on Spotify to catch new episodes the moment they drop.',
+  },
+  {
+    name: 'Apple Podcasts',
+    href: 'https://podcasts.apple.com',
+    description: 'Leave a review on Apple Podcasts to help more builders discover the show.',
+  },
+  {
+    name: 'Google Podcasts',
+    href: 'https://podcasts.google.com',
+    description: 'Sync the feed with your Google account and stream on any device.',
+  },
+  {
+    name: 'RSS Feed',
+    href: '/rss',
+    description: 'Prefer your own player? Subscribe directly through our RSS feed.',
+  },
+];
+
+const faqs = [
+  {
+    question: 'How often do new episodes launch?',
+    answer:
+      'We release a new, fully produced episode every other Wednesday. Expect bonus cuts and live recordings in your feed when big announcements happen.',
+  },
+  {
+    question: 'Can I suggest a topic or guest?',
+    answer:
+      'Absolutely. Send us a note at hello@syntaxandsips.dev with the subject line “Podcast idea” and include a short summary of what you would love to hear.',
+  },
+  {
+    question: 'Do you offer transcripts?',
+    answer:
+      'Yes! Every episode ships with human-reviewed transcripts and key takeaways within 48 hours of launch. They are available directly from the episode page.',
+  },
+];
+
+export const metadata = {
+  title: 'Syntax & Sips Podcast',
+  description: 'Listen to long-form conversations on AI, machine learning, and the future of developer tooling.',
+};
+
+export default function PodcastsPage() {
+  return (
+    <ContentPageLayout
+      badge={<span>Audio Series</span>}
+      title="Syntax & Sips Podcast"
+      description="Deep technical conversations with builders who are shaping the future of AI. Grab a drink, plug in your headphones, and ship smarter."
+      action={
+        <>
+          <Link
+            href="/newsletter"
+            className="neo-button bg-black text-white px-5 py-3 text-sm md:text-base"
+          >
+            Subscribe for episode drops
+          </Link>
+          <a
+            href="https://spotify.com"
+            target="_blank"
+            rel="noreferrer"
+            className="neo-button bg-[#06D6A0] text-black px-5 py-3 text-sm md:text-base"
+          >
+            Listen on Spotify
+          </a>
+        </>
+      }
+    >
+      <ContentSection
+        eyebrow={<span role="img" aria-label="headphones">🎧</span>}
+        title="Latest episodes"
+        description="Catch up on the most recent conversations. Every episode is tightly produced with actionable insights and clear takeaways."
+      >
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {episodes.map((episode) => (
+            <article
+              key={episode.slug}
+              className="h-full border-4 border-black bg-white p-6 shadow-[6px_6px_0_0_#000] transition-transform hover:-translate-y-1"
+            >
+              <div className="flex items-center justify-between text-xs font-bold uppercase tracking-widest text-gray-600">
+                <span>{episode.releaseDate}</span>
+                <span>{episode.duration}</span>
+              </div>
+              <h3 className="mt-4 text-xl font-black leading-tight">{episode.title}</h3>
+              <p className="mt-3 text-sm text-gray-700 leading-relaxed">{episode.description}</p>
+              <div className="mt-6 flex flex-wrap gap-3">
+                <a
+                  href={`https://spotify.com/episode/${episode.slug}`}
+                  className="neo-button bg-[#6C63FF] text-white px-4 py-2 text-sm"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Play episode
+                </a>
+                <Link
+                  href={`/blogs/${episode.slug}`}
+                  className="neo-button bg-white text-black px-4 py-2 text-sm"
+                >
+                  Read show notes
+                </Link>
+              </div>
+            </article>
+          ))}
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow={<span role="img" aria-label="satellite">📡</span>}
+        title="Listen on your favorite platform"
+        description="Our feed is syndicated everywhere. Pick the player that fits your workflow and take Syntax & Sips on the go."
+      >
+        <div className="grid gap-4 sm:grid-cols-2">
+          {platforms.map((platform) => (
+            <a
+              key={platform.name}
+              href={platform.href}
+              className="block border-4 border-black bg-[#FFD166] p-5 font-semibold text-black shadow-[6px_6px_0_0_#000] transition-transform hover:-translate-y-1"
+              target={platform.href.startsWith('http') ? '_blank' : undefined}
+              rel={platform.href.startsWith('http') ? 'noreferrer' : undefined}
+            >
+              <h3 className="text-lg font-black">{platform.name}</h3>
+              <p className="mt-2 text-sm leading-relaxed">{platform.description}</p>
+            </a>
+          ))}
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow={<span role="img" aria-label="question mark">❓</span>}
+        title="Frequently asked questions"
+        description="Everything you need to know about the Syntax & Sips podcast experience."
+        fullWidth
+      >
+        <div className="space-y-4">
+          {faqs.map((faq) => (
+            <details
+              key={faq.question}
+              className="border-4 border-black bg-white p-6 shadow-[6px_6px_0_0_#000]"
+            >
+              <summary className="cursor-pointer text-lg font-black">{faq.question}</summary>
+              <p className="mt-3 text-sm leading-relaxed text-gray-700">{faq.answer}</p>
+            </details>
+          ))}
+        </div>
+      </ContentSection>
+    </ContentPageLayout>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,117 @@
+import { ContentPageLayout, ContentSection } from '@/components/ui/ContentPageLayout';
+
+const principles = [
+  {
+    title: 'Transparency',
+    description: 'We explain why we collect data, how we use it, and the controls you have at every step.',
+  },
+  {
+    title: 'Security',
+    description: 'We secure data with encryption in transit and at rest, strict access policies, and regular audits.',
+  },
+  {
+    title: 'Control',
+    description: 'You can update preferences, export data, or request deletion at any time. We make it simple and fast.',
+  },
+];
+
+const dataUsage = [
+  {
+    heading: 'What we collect',
+    items: [
+      'Account information such as name, email address, and authentication metadata.',
+      'Product interaction data to improve recommendations and measure feature adoption.',
+      'Support conversations and feedback that you voluntarily share with the team.',
+    ],
+  },
+  {
+    heading: 'How we use it',
+    items: [
+      'Deliver personalized content across blogs, podcasts, tutorials, and videos.',
+      'Send transactional emails like login confirmations, subscription updates, and billing receipts.',
+      'Diagnose issues, prevent abuse, and maintain the integrity of Syntax & Sips services.',
+    ],
+  },
+  {
+    heading: 'What we do not do',
+    items: [
+      'Sell or rent personal data to third parties.',
+      'Use generative models to train on your private data without explicit consent.',
+      'Ignore deletion requests—every request is processed within 7 days.',
+    ],
+  },
+];
+
+export const metadata = {
+  title: 'Privacy Policy',
+  description: 'Understand how Syntax & Sips collects, uses, and protects your data.',
+};
+
+export default function PrivacyPage() {
+  return (
+    <ContentPageLayout
+      badge={<span>Legal</span>}
+      title="Privacy policy"
+      description="We built Syntax & Sips to be trustworthy by design. This policy outlines the data we collect, why we collect it, and the choices you can make."
+    >
+      <ContentSection
+        eyebrow={<span role="img" aria-label="shield">🛡️</span>}
+        title="Our principles"
+        description="Three commitments guide every product decision."
+        fullWidth
+      >
+        <div className="grid gap-6 md:grid-cols-3">
+          {principles.map((principle) => (
+            <div key={principle.title} className="border-4 border-black bg-white p-6 shadow-[6px_6px_0_0_#000]">
+              <h3 className="text-lg font-black">{principle.title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-gray-700">{principle.description}</p>
+            </div>
+          ))}
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow={<span role="img" aria-label="document">📄</span>}
+        title="How we handle your data"
+        description="We only collect what we need to run Syntax & Sips. Here is the breakdown."
+        fullWidth
+      >
+        <div className="space-y-6">
+          {dataUsage.map((section) => (
+            <section key={section.heading} className="border-4 border-black bg-white p-6 shadow-[6px_6px_0_0_#000]">
+              <h3 className="text-lg font-black">{section.heading}</h3>
+              <ul className="mt-3 space-y-2 text-sm leading-relaxed text-gray-700">
+                {section.items.map((item) => (
+                  <li key={item} className="flex items-start gap-3">
+                    <span aria-hidden className="mt-1 text-[#6C63FF]">•</span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow={<span role="img" aria-label="gear">⚙️</span>}
+        title="Your controls"
+        description="You stay in control of your information."
+        fullWidth
+      >
+        <ul className="space-y-3 text-sm leading-relaxed text-gray-700">
+          <li>
+            <strong>Access & updates:</strong> Manage account settings anytime from your profile dashboard.
+          </li>
+          <li>
+            <strong>Data export:</strong> Request a machine-readable export by emailing privacy@syntaxandsips.dev.
+          </li>
+          <li>
+            <strong>Deletion:</strong> Delete your account in-app or contact support. We remove data from active systems within 7 days.
+          </li>
+        </ul>
+        <p className="text-sm text-gray-600">Questions? Email us at privacy@syntaxandsips.dev.</p>
+      </ContentSection>
+    </ContentPageLayout>
+  );
+}

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -1,0 +1,109 @@
+import Link from 'next/link';
+import { ContentPageLayout, ContentSection } from '@/components/ui/ContentPageLayout';
+
+const resourceGroups = [
+  {
+    title: 'Playbooks',
+    description: 'Opinionated guides that walk you through product decisions, architecture diagrams, and shipping checklists.',
+    items: [
+      'Launching an AI feature in 30 days',
+      'Evaluating foundation models for production',
+      'Instrumenting trustworthy metrics for ML systems',
+    ],
+    accentClass: 'bg-[#6C63FF] text-white',
+  },
+  {
+    title: 'Templates',
+    description: 'Reusable docs to help your team align on experimentation, stakeholder updates, and postmortems.',
+    items: ['Experiment brief', 'Inference service runbook', 'Incident retrospective'],
+    accentClass: 'bg-[#FFD166] text-black',
+  },
+  {
+    title: 'Toolkits',
+    description: 'Curated collections of libraries, CLIs, and dashboards that we trust on our own projects.',
+    items: ['Prompt engineering starter kit', 'Observability dashboards', 'Security review checklist'],
+    accentClass: 'bg-[#06D6A0] text-black',
+  },
+];
+
+const onboardingSteps = [
+  {
+    title: 'Create a free workspace',
+    description: 'Spin up a Syntax & Sips workspace to access premium templates, API examples, and roadmap trackers.',
+  },
+  {
+    title: 'Sync with your stack',
+    description: 'Connect GitHub, Supabase, or your favorite data warehouse to pull real-world examples directly into our notebooks.',
+  },
+  {
+    title: 'Stay accountable',
+    description: 'Join focus sprints, track progress with the community, and get tailored nudges when you fall off track.',
+  },
+];
+
+export const metadata = {
+  title: 'Resource Library',
+  description: 'Download playbooks, templates, and toolkits that help AI teams move faster with confidence.',
+};
+
+export default function ResourcesPage() {
+  return (
+    <ContentPageLayout
+      badge={<span>Resource Hub</span>}
+      title="Resource Library"
+      description="Battle-tested assets for teams shipping AI experiences. Everything is reviewed quarterly so you always have the latest guidance."
+      action={
+        <Link href="/newsletter" className="neo-button bg-black text-white px-5 py-3 text-sm md:text-base">
+          Unlock new drops first
+        </Link>
+      }
+    >
+      <ContentSection
+        eyebrow={<span role="img" aria-label="books">📚</span>}
+        title="Curated collections"
+        description="Pick a collection and start downloading. Each bundle includes version history, usage notes, and recommended follow-up content."
+        fullWidth
+      >
+        <div className="grid gap-6 md:grid-cols-3">
+          {resourceGroups.map((group) => (
+            <article
+              key={group.title}
+              className={`border-4 border-black p-6 shadow-[6px_6px_0_0_#000] ${group.accentClass}`}
+            >
+              <h3 className="text-xl font-black leading-tight">{group.title}</h3>
+              <p className="mt-3 text-sm leading-relaxed">{group.description}</p>
+              <ul className="mt-4 space-y-2 text-sm font-semibold">
+                {group.items.map((item) => (
+                  <li key={item} className="flex items-center gap-2">
+                    <span aria-hidden className="text-black/70">▹</span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow={<span role="img" aria-label="spark">⚡</span>}
+        title="How to get the most out of the library"
+        description="We combine the library with a guided onboarding flow so your team can activate the right resources at the right time."
+        fullWidth
+      >
+        <ol className="grid gap-6 md:grid-cols-3">
+          {onboardingSteps.map((step, index) => (
+            <li
+              key={step.title}
+              className="border-4 border-black bg-white p-6 shadow-[6px_6px_0_0_#000]"
+            >
+              <span className="text-xs font-black uppercase tracking-widest text-gray-600">Step {index + 1}</span>
+              <h3 className="mt-3 text-lg font-black">{step.title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-gray-700">{step.description}</p>
+            </li>
+          ))}
+        </ol>
+      </ContentSection>
+    </ContentPageLayout>
+  );
+}

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -1,0 +1,105 @@
+import { ContentPageLayout, ContentSection } from '@/components/ui/ContentPageLayout';
+
+const roadmap = [
+  {
+    phase: 'Now',
+    title: 'Personalized reading experience',
+    description:
+      'Rolling out user profiles, saved filters, and dynamic recommendations across blogs, podcasts, and videos.',
+    items: ['Reader accounts beta', 'Topic follow system', 'Recently played podcast resume'],
+  },
+  {
+    phase: 'Next',
+    title: 'Collaboration tools',
+    description:
+      'Co-editing for changelog drafts, shared annotations, and real-time commenting for teams.',
+    items: ['Shared spaces', 'AI-powered editorial suggestions', 'Commenting + mentions'],
+  },
+  {
+    phase: 'Later',
+    title: 'Learning workspace',
+    description:
+      'Integrated notebooks, auto-graded challenges, and a structured curriculum that adapts to progress.',
+    items: ['Notebook runtime', 'Project templates', 'Progress dashboards'],
+  },
+];
+
+const feedbackChannels = [
+  {
+    label: 'Public roadmap board',
+    description: 'Vote on ideas, follow progress, and share feedback in the open.',
+    href: 'https://github.com/syntax-and-sips/roadmap/discussions',
+  },
+  {
+    label: 'Creator office hours',
+    description: 'Join live sessions twice a month to discuss upcoming features with the team.',
+    href: 'https://syntaxandsips.dev/events',
+  },
+  {
+    label: 'Private beta program',
+    description: 'Get early access to prototypes in exchange for detailed product feedback.',
+    href: 'mailto:beta@syntaxandsips.dev',
+  },
+];
+
+export const metadata = {
+  title: 'Product Roadmap',
+  description: 'Follow the Syntax & Sips roadmap to see what we are building now, next, and later.',
+};
+
+export default function RoadmapPage() {
+  return (
+    <ContentPageLayout
+      badge={<span>Vision</span>}
+      title="Product Roadmap"
+      description="Transparency keeps us accountable. Explore what is launching soon, what is in research, and where you can get involved."
+    >
+      <ContentSection
+        eyebrow={<span role="img" aria-label="compass">🧭</span>}
+        title="Shipping cadence"
+        description="We prioritize features that help creators publish faster and help readers learn with less friction."
+        fullWidth
+      >
+        <div className="grid gap-6 md:grid-cols-3">
+          {roadmap.map((entry) => (
+            <article key={entry.title} className="border-4 border-black bg-white p-6 shadow-[6px_6px_0_0_#000]">
+              <span className="text-xs font-black uppercase tracking-widest text-gray-600">{entry.phase}</span>
+              <h3 className="mt-3 text-xl font-black">{entry.title}</h3>
+              <p className="mt-3 text-sm leading-relaxed text-gray-700">{entry.description}</p>
+              <ul className="mt-4 space-y-2 text-sm font-semibold text-gray-800">
+                {entry.items.map((item) => (
+                  <li key={item} className="flex items-center gap-2">
+                    <span aria-hidden className="text-[#FF5252]">▹</span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow={<span role="img" aria-label="speech bubble">💬</span>}
+        title="Partner with us"
+        description="Your feedback shapes the roadmap. Pick a channel and share what would make Syntax & Sips more valuable for you."
+        fullWidth
+      >
+        <div className="grid gap-6 md:grid-cols-3">
+          {feedbackChannels.map((channel) => (
+            <a
+              key={channel.label}
+              href={channel.href}
+              className="block border-4 border-black bg-[#06D6A0] p-6 text-black shadow-[6px_6px_0_0_#000] transition-transform hover:-translate-y-1"
+              target={channel.href.startsWith('http') ? '_blank' : undefined}
+              rel={channel.href.startsWith('http') ? 'noreferrer' : undefined}
+            >
+              <h3 className="text-lg font-black">{channel.label}</h3>
+              <p className="mt-2 text-sm leading-relaxed">{channel.description}</p>
+            </a>
+          ))}
+        </div>
+      </ContentSection>
+    </ContentPageLayout>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,107 @@
+import Link from 'next/link';
+import { ContentPageLayout, ContentSection } from '@/components/ui/ContentPageLayout';
+
+const commitments = [
+  {
+    title: 'Respectful community',
+    description: 'We foster a space where curiosity is welcome and harassment is not. Behave professionally across comments, DMs, and events.',
+  },
+  {
+    title: 'Responsible usage',
+    description: 'Use Syntax & Sips content and tooling in lawful ways. No scraping, spam, or attempts to exploit vulnerabilities.',
+  },
+  {
+    title: 'Attribution matters',
+    description: 'Share freely, but keep credits intact. Cite Syntax & Sips when you republish insights, code snippets, or frameworks.',
+  },
+];
+
+const sections = [
+  {
+    heading: 'Accounts',
+    body: [
+      'Provide accurate information and keep your credentials secure. You are responsible for all activity on your account.',
+      'Notify us immediately if you suspect unauthorized use. We may suspend accounts that appear compromised.',
+    ],
+  },
+  {
+    heading: 'Content & licensing',
+    body: [
+      'Original content is owned by Syntax & Sips. You may reference it with attribution, but you cannot resell or misrepresent it as your own.',
+      'Community contributions remain yours, but you grant Syntax & Sips a non-exclusive license to display and promote them.',
+    ],
+  },
+  {
+    heading: 'Termination',
+    body: [
+      'We reserve the right to suspend or terminate accounts that violate these terms or pose a security risk.',
+      'You may cancel anytime. Deleting your account removes access to subscriber-only resources.',
+    ],
+  },
+];
+
+export const metadata = {
+  title: 'Terms of Service',
+  description: 'Review the rules and expectations for using Syntax & Sips products.',
+};
+
+export default function TermsPage() {
+  return (
+    <ContentPageLayout
+      badge={<span>Legal</span>}
+      title="Terms of service"
+      description="We built these guidelines to keep the Syntax & Sips community respectful, secure, and enjoyable for everyone."
+    >
+      <ContentSection
+        eyebrow={<span role="img" aria-label="handshake">🤝</span>}
+        title="Our commitments"
+        description="These pillars shape how we run Syntax & Sips."
+        fullWidth
+      >
+        <div className="grid gap-6 md:grid-cols-3">
+          {commitments.map((commitment) => (
+            <div key={commitment.title} className="border-4 border-black bg-white p-6 shadow-[6px_6px_0_0_#000]">
+              <h3 className="text-lg font-black">{commitment.title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-gray-700">{commitment.description}</p>
+            </div>
+          ))}
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow={<span role="img" aria-label="scales">⚖️</span>}
+        title="Key policies"
+        description="By using Syntax & Sips you agree to the following terms."
+        fullWidth
+      >
+        <div className="space-y-6">
+          {sections.map((section) => (
+            <section key={section.heading} className="border-4 border-black bg-white p-6 shadow-[6px_6px_0_0_#000]">
+              <h3 className="text-lg font-black">{section.heading}</h3>
+              <ul className="mt-3 space-y-2 text-sm leading-relaxed text-gray-700">
+                {section.body.map((paragraph) => (
+                  <li key={paragraph} className="flex items-start gap-3">
+                    <span aria-hidden className="mt-1 text-[#FF5252]">•</span>
+                    <span>{paragraph}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow={<span role="img" aria-label="megaphone">📣</span>}
+        title="Need clarification?"
+        description="Reach out if something is unclear."
+        fullWidth
+      >
+        <p className="text-sm leading-relaxed text-gray-700">
+          Email legal@syntaxandsips.dev and we will respond within two business days. You can also review our
+          <Link href="/privacy" className="underline"> privacy policy</Link> for additional detail.
+        </p>
+      </ContentSection>
+    </ContentPageLayout>
+  );
+}

--- a/src/app/tutorials/page.tsx
+++ b/src/app/tutorials/page.tsx
@@ -1,0 +1,150 @@
+import Link from 'next/link';
+import { ContentPageLayout, ContentSection } from '@/components/ui/ContentPageLayout';
+
+const learningPaths = [
+  {
+    title: 'Start here: Machine learning foundations',
+    duration: '4 weeks',
+    description:
+      'Understand the math intuition, Python tooling, and core algorithms that power every production ML system.',
+    topics: ['Linear models', 'Gradient descent', 'Model evaluation', 'Responsible AI basics'],
+  },
+  {
+    title: 'Applied deep learning for builders',
+    duration: '6 weeks',
+    description:
+      'Ship vision, language, and multimodal features with modern frameworks while keeping an eye on deployment realities.',
+    topics: ['PyTorch workflows', 'Vision transformers', 'Prompt engineering', 'Inference optimization'],
+  },
+  {
+    title: 'MLOps in practice',
+    duration: '5 weeks',
+    description:
+      'Connect experimentation, observability, and continuous delivery so your models thrive after launch.',
+    topics: ['Feature stores', 'Experiment tracking', 'Evaluation pipelines', 'Monitoring + alerting'],
+  },
+];
+
+const projectIdeas = [
+  {
+    title: 'Coffee bean classifier',
+    difficulty: 'Intermediate',
+    description:
+      'Collect your own dataset, fine-tune a small vision model, and deploy it to a serverless GPU endpoint.',
+  },
+  {
+    title: 'AI pair programming assistant',
+    difficulty: 'Advanced',
+    description:
+      'Prototype an LLM-powered helper that understands your repo context, surfaces docs, and drafts pull request summaries.',
+  },
+  {
+    title: 'Real-time sentiment dashboard',
+    difficulty: 'Beginner',
+    description:
+      'Stream tweets into a lightweight classifier and visualize insights with a modern data stack.',
+  },
+];
+
+const resources = [
+  {
+    name: 'Workshop replays',
+    description: 'Recorded live sessions with chapter markers and companion notebooks.',
+  },
+  {
+    name: 'Cheat sheets',
+    description: 'One-page references for essential formulas, CLI commands, and design patterns.',
+  },
+  {
+    name: 'Community office hours',
+    description: 'Join the Syntax & Sips Discord for weekly drop-in support from the team.',
+  },
+];
+
+export const metadata = {
+  title: 'Tutorials & Learning Paths',
+  description: 'Structured tutorials that help you learn, build, and ship modern AI experiences with confidence.',
+};
+
+export default function TutorialsPage() {
+  return (
+    <ContentPageLayout
+      badge={<span>Guided Learning</span>}
+      title="Tutorials & Learning Paths"
+      description="Follow curated roadmaps designed for developers who want to master AI and machine learning without losing momentum."
+      action={
+        <Link href="/newsletter" className="neo-button bg-black text-white px-5 py-3 text-sm md:text-base">
+          Get notified about new tutorials
+        </Link>
+      }
+    >
+      <ContentSection
+        eyebrow={<span role="img" aria-label="sparkles">✨</span>}
+        title="Pick a path that matches your goals"
+        description="Each path combines written guides, videos, and code sandboxes. Expect weekly milestones, checklists, and built-in retrospectives."
+      >
+        <div className="grid gap-6 lg:grid-cols-3">
+          {learningPaths.map((path) => (
+            <article
+              key={path.title}
+              className="flex h-full flex-col border-4 border-black bg-white p-6 shadow-[6px_6px_0_0_#000]"
+            >
+              <div className="flex items-center justify-between text-xs font-bold uppercase tracking-widest text-gray-600">
+                <span>{path.duration}</span>
+                <span>Weekly cadence</span>
+              </div>
+              <h3 className="mt-4 text-xl font-black leading-tight">{path.title}</h3>
+              <p className="mt-3 flex-1 text-sm text-gray-700 leading-relaxed">{path.description}</p>
+              <ul className="mt-4 space-y-2 text-sm font-semibold text-gray-800">
+                {path.topics.map((topic) => (
+                  <li key={topic} className="flex items-center gap-2">
+                    <span aria-hidden className="text-[#6C63FF]">▹</span>
+                    <span>{topic}</span>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow={<span role="img" aria-label="rocket">🚀</span>}
+        title="Hands-on projects"
+        description="Apply what you learn and build a portfolio that showcases real-world skills. Projects include starter repos, architecture diagrams, and testing checklists."
+      >
+        <div className="grid gap-6 md:grid-cols-3">
+          {projectIdeas.map((project) => (
+            <article
+              key={project.title}
+              className="border-4 border-black bg-[#06D6A0] p-6 text-black shadow-[6px_6px_0_0_#000]"
+            >
+              <p className="text-xs font-bold uppercase tracking-widest">{project.difficulty}</p>
+              <h3 className="mt-3 text-xl font-black leading-tight">{project.title}</h3>
+              <p className="mt-3 text-sm leading-relaxed">{project.description}</p>
+            </article>
+          ))}
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow={<span role="img" aria-label="toolbox">🧰</span>}
+        title="What you get with every tutorial"
+        description="We obsess over the end-to-end learning experience so you can focus on building."
+        fullWidth
+      >
+        <div className="grid gap-6 md:grid-cols-3">
+          {resources.map((resource) => (
+            <div
+              key={resource.name}
+              className="border-4 border-black bg-white p-6 shadow-[6px_6px_0_0_#000]"
+            >
+              <h3 className="text-lg font-black">{resource.name}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-gray-700">{resource.description}</p>
+            </div>
+          ))}
+        </div>
+      </ContentSection>
+    </ContentPageLayout>
+  );
+}

--- a/src/app/videos/page.tsx
+++ b/src/app/videos/page.tsx
@@ -1,0 +1,86 @@
+import { ContentPageLayout, ContentSection } from '@/components/ui/ContentPageLayout';
+import YouTubeEmbed from '@/components/ui/YouTubeEmbed';
+
+const series = [
+  {
+    title: 'Ship it live',
+    description:
+      'Live coding sessions where we build features end-to-end. Expect real-time debugging and honest conversations about trade-offs.',
+    videos: ['dQw4w9WgXcQ', 'kXYiU_JCYtU'],
+  },
+  {
+    title: 'AI architecture reviews',
+    description:
+      'We unpack the systems behind products you love and highlight the design decisions that keep them resilient.',
+    videos: ['L_jWHffIx5E', '3fumBcKC6RE'],
+  },
+];
+
+const productionTips = [
+  {
+    title: 'Record-ready checklists',
+    description: 'Keep your audio and screen capture crisp with studio-tested setups that do not break the budget.',
+  },
+  {
+    title: 'Annotated repos',
+    description: 'Clone the exact code we use in every video, complete with branches for each stage of the build.',
+  },
+  {
+    title: 'Captions & transcripts',
+    description: 'Accessibility matters. We ship every upload with open captions, transcripts, and additional reading.',
+  },
+];
+
+export const metadata = {
+  title: 'Video Library',
+  description: 'Watch Syntax & Sips build modern AI experiences in real time with battle-tested workflows.',
+};
+
+export default function VideosPage() {
+  return (
+    <ContentPageLayout
+      badge={<span>Video</span>}
+      title="Watch Syntax & Sips"
+      description="Grab your favorite beverage and code alongside us. These episodes focus on real projects, real feedback, and shippable results."
+    >
+      <ContentSection
+        eyebrow={<span role="img" aria-label="camera">🎥</span>}
+        title="Featured series"
+        description="Curated playlists designed to help you level up quickly. We share context, code, and design thinking for every episode."
+        fullWidth
+      >
+        <div className="space-y-10">
+          {series.map((entry) => (
+            <article key={entry.title} className="space-y-4">
+              <div className="border-4 border-black bg-white p-6 shadow-[6px_6px_0_0_#000]">
+                <h3 className="text-2xl font-black">{entry.title}</h3>
+                <p className="mt-3 text-sm leading-relaxed text-gray-700">{entry.description}</p>
+              </div>
+              <div className="grid gap-6 md:grid-cols-2">
+                {entry.videos.map((videoId) => (
+                  <YouTubeEmbed key={videoId} videoId={videoId} />
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow={<span role="img" aria-label="clapper board">🎬</span>}
+        title="Production that respects your time"
+        description="We obsess over clarity so you never wonder what to do next."
+        fullWidth
+      >
+        <div className="grid gap-6 md:grid-cols-3">
+          {productionTips.map((tip) => (
+            <div key={tip.title} className="border-4 border-black bg-[#FF5252] p-6 text-white shadow-[6px_6px_0_0_#000]">
+              <h3 className="text-lg font-black">{tip.title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-white/90">{tip.description}</p>
+            </div>
+          ))}
+        </div>
+      </ContentSection>
+    </ContentPageLayout>
+  );
+}

--- a/src/components/ui/ContentPageLayout.tsx
+++ b/src/components/ui/ContentPageLayout.tsx
@@ -1,0 +1,88 @@
+import type { ReactNode } from 'react';
+import { NewFooter } from './NewFooter';
+
+interface ContentPageLayoutProps {
+  title: string;
+  description: string;
+  badge?: ReactNode;
+  action?: ReactNode;
+  children: ReactNode;
+}
+
+export function ContentPageLayout({
+  title,
+  description,
+  badge,
+  action,
+  children,
+}: ContentPageLayoutProps) {
+  return (
+    <div className="min-h-screen bg-[#f0f0f0] flex flex-col">
+      <main className="flex-1">
+        <section className="border-b-4 border-black bg-[#f0f0f0]">
+          <div className="container mx-auto px-4 py-12">
+            <div className="neo-container bg-white">
+              <div className="space-y-6">
+                {badge && (
+                  <div className="inline-flex items-center gap-2 bg-[#FFD166] border-4 border-black px-4 py-2 font-bold uppercase tracking-widest text-xs md:text-sm shadow-[6px_6px_0_0_#000]">
+                    {badge}
+                  </div>
+                )}
+                <h1 className="text-4xl md:text-5xl font-black leading-tight">{title}</h1>
+                <p className="text-lg md:text-xl text-gray-700 max-w-3xl">{description}</p>
+                {action && <div className="flex flex-wrap gap-3">{action}</div>}
+              </div>
+            </div>
+          </div>
+        </section>
+        <section className="container mx-auto px-4 pb-16">
+          <div className="space-y-8 lg:space-y-10">{children}</div>
+        </section>
+      </main>
+      <NewFooter />
+    </div>
+  );
+}
+
+interface ContentSectionProps {
+  title: string;
+  description?: string;
+  eyebrow?: ReactNode;
+  actions?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  fullWidth?: boolean;
+}
+
+export function ContentSection({
+  title,
+  description,
+  eyebrow,
+  actions,
+  children,
+  className,
+  fullWidth = false,
+}: ContentSectionProps) {
+  const containerClassName = `neo-container bg-white ${className ?? ''}`.trim();
+  const layoutClassName = fullWidth
+    ? 'space-y-6'
+    : 'flex flex-col lg:flex-row lg:items-start gap-8';
+
+  return (
+    <section className={containerClassName}>
+      {eyebrow && (
+        <div className="mb-4 inline-flex items-center gap-2 bg-[#06D6A0] border-4 border-black px-3 py-1 text-xs font-bold uppercase tracking-widest text-black shadow-[4px_4px_0_0_#000]">
+          {eyebrow}
+        </div>
+      )}
+      <div className={layoutClassName}>
+        <div className={`${fullWidth ? 'space-y-4' : 'space-y-4 lg:w-1/3'}`}>
+          <h2 className="text-2xl md:text-3xl font-black">{title}</h2>
+          {description && <p className="text-gray-700 leading-relaxed">{description}</p>}
+          {actions && <div className="flex flex-wrap gap-3">{actions}</div>}
+        </div>
+        <div className={`${fullWidth ? 'space-y-4' : 'lg:flex-1 space-y-4'}`}>{children}</div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared content page layout component for consistent hero and section styling
- implement podcasts, tutorials, videos, resources, newsletter, and roadmap pages to cover all navigation links
- add privacy, terms, cookies, and disclaimer pages so footer links resolve with clear legal copy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4199edb5c832dbc7185b81f09aa56