### PR TITLE
Fix Next.js admin edit page params typing

### DIFF
--- a/src/app/admin/edit/[id]/page.tsx
+++ b/src/app/admin/edit/[id]/page.tsx
@@ -2,12 +2,11 @@ import { redirect } from 'next/navigation'
 import type { Metadata } from 'next'
 
 type PageProps = {
-  params: { id: string }
-  searchParams?: { [key: string]: string | string[] | undefined }
+  params: Promise<{ id: string }>
 }
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
 export default async function EditPostPage({ params }: PageProps) {
-  // This is a redirect-only page, so we don't use the params
+  await params
   redirect('/admin')
 }
 


### PR DESCRIPTION
## Summary
- update the admin edit dynamic route to expect Next.js 15 async params
- await the params before redirecting to avoid type errors during build

## Testing
- npm run build *(fails: unable to download Geist fonts in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e422cd48b8832d92c15dc384cd5a0f