### PR TITLE
Fix post detail normalization typing

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -315,7 +315,7 @@ export const getPublishedPostBySlug = cache(async (slug: string) => {
       return null
     }
 
-    record = ensureOptionalImageColumns(data as PostDetailRecord)
+    record = ensureOptionalImageColumns(data)
   }
 
   let author: AuthorRecord | null = null


### PR DESCRIPTION
## Summary
- stop asserting the Supabase post detail response as a fully normalized PostDetailRecord before running the cleanup helper
- rely on ensureOptionalImageColumns to coerce the response into the correct shape so the build can pass type-checking

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4cbb58578832da81d7c7296cf6bb2