### PR TITLE
Fix admin dashboard bundler reference error

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
-import { AdminDashboard } from '@/components/admin/AdminDashboard'
+import AdminDashboard from '@/components/admin/AdminDashboard'
 import { createServerComponentClient } from '@/lib/supabase/server-client'
 
 export const dynamic = 'force-dynamic'

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -1,4 +1,4 @@
-"use client"
+'use client'
 
 import React, {
   useCallback,
@@ -30,7 +30,7 @@ import {
   UpdateAdminUserPayload,
 } from '@/utils/types'
 
-interface AdminDashboardProps {
+export interface AdminDashboardProps {
   profileId: string
   displayName: string
   isAdmin: boolean
@@ -41,7 +41,7 @@ interface FeedbackState {
   message: string
 }
 
-export const AdminDashboard = ({
+const AdminDashboard = ({
   profileId,
   displayName,
   isAdmin,
@@ -958,3 +958,5 @@ export const AdminDashboard = ({
     </div>
   )
 }
+
+export default AdminDashboard


### PR DESCRIPTION
## Summary
- convert the admin dashboard component into a default-exported client module to ensure it is emitted in the client manifest
- update the admin page to consume the default export, preventing the manifest lookup failure during navigation

## Testing
- CI=1 npm run build *(emitted fetch warnings for external content but completed successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ce5b8d44832db661515cf2fb41a0