### PR TITLE
Fix missing server chunks by syncing Next build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
+    "dev": "node scripts/sync-webpack-chunks.js --watch -- next dev",
+    "build": "node scripts/sync-webpack-chunks.js -- next build",
+    "start": "node scripts/sync-webpack-chunks.js && next start",
     "lint": "next lint",
     "test": "playwright test",
     "test:ui": "playwright test --ui",

--- a/scripts/sync-webpack-chunks.js
+++ b/scripts/sync-webpack-chunks.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const { spawn } = require("child_process");
+
+const args = process.argv.slice(2);
+const watchIndex = args.indexOf("--watch");
+const hasWatch = watchIndex !== -1;
+if (hasWatch) {
+  args.splice(watchIndex, 1);
+}
+
+const separatorIndex = args.indexOf("--");
+let commandArgs = null;
+if (separatorIndex !== -1) {
+  commandArgs = args.slice(separatorIndex + 1);
+  args.length = separatorIndex;
+}
+
+const serverDir = path.join(process.cwd(), ".next", "server");
+const chunksDir = path.join(serverDir, "chunks");
+const copiedFiles = new Map();
+
+async function ensureDirectory(dir) {
+  try {
+    await fs.promises.mkdir(dir, { recursive: true });
+  } catch (error) {
+    if (error.code !== "EEXIST") {
+      throw error;
+    }
+  }
+}
+
+async function copyChunkFile(fileName) {
+  if (!fileName.endsWith(".js")) return;
+
+  const source = path.join(chunksDir, fileName);
+  const destination = path.join(serverDir, fileName);
+
+  try {
+    const stats = await fs.promises.stat(source);
+    const previous = copiedFiles.get(fileName);
+    if (previous && previous === stats.mtimeMs) {
+      return;
+    }
+
+    await ensureDirectory(serverDir);
+    await fs.promises.copyFile(source, destination);
+    copiedFiles.set(fileName, stats.mtimeMs);
+    console.log(`[chunk-sync] Synced ${fileName}`);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return;
+    }
+    console.error(`[chunk-sync] Failed to copy ${fileName}:`, error);
+  }
+}
+
+async function syncOnce() {
+  try {
+    const entries = await fs.promises.readdir(chunksDir);
+    await Promise.all(entries.map(copyChunkFile));
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return;
+    }
+    console.error("[chunk-sync] Unable to read chunks directory:", error);
+  }
+}
+
+async function main() {
+  if (commandArgs && !hasWatch) {
+    const child = spawn(commandArgs[0], commandArgs.slice(1), {
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
+
+    child.on("exit", async (code, signal) => {
+      if (code === 0) {
+        await syncOnce();
+      }
+      if (signal) {
+        process.kill(process.pid, signal);
+      } else {
+        process.exit(code ?? 0);
+      }
+    });
+
+    return;
+  }
+
+  await syncOnce();
+
+  let intervalId = null;
+  if (hasWatch) {
+    intervalId = setInterval(() => {
+      void syncOnce();
+    }, 1000);
+  }
+
+  if (commandArgs) {
+    const child = spawn(commandArgs[0], commandArgs.slice(1), {
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
+
+    const shutdown = (exitCode) => {
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+      process.exit(exitCode ?? 0);
+    };
+
+    child.on("exit", (code) => {
+      void syncOnce().then(() => shutdown(code));
+    });
+
+    process.on("SIGINT", () => {
+      child.kill("SIGINT");
+    });
+    process.on("SIGTERM", () => {
+      child.kill("SIGTERM");
+    });
+  } else {
+    if (!hasWatch) {
+      process.exit(0);
+    }
+  }
+}
+
+void main();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import "@/styles/neo-brutalism.css";
@@ -21,11 +22,30 @@ export const metadata: Metadata = {
   description: "Exploring the cutting edge of artificial intelligence, machine learning, and deep learning",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const headersList = await headers();
+  const nextUrlHeader =
+    headersList.get("x-next-url") ??
+    headersList.get("next-url") ??
+    headersList.get("x-invoke-path") ??
+    headersList.get("x-matched-path") ??
+    "/";
+
+  let initialPathname = "/";
+
+  try {
+    const parsedUrl = new URL(nextUrlHeader, "http://localhost");
+    initialPathname = parsedUrl.pathname || "/";
+  } catch {
+    if (typeof nextUrlHeader === "string" && nextUrlHeader.startsWith("/")) {
+      initialPathname = nextUrlHeader;
+    }
+  }
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body
@@ -34,7 +54,7 @@ export default function RootLayout({
       >
         <LoaderProvider>
           <Loader />
-          <ConditionalNavbar />
+          <ConditionalNavbar initialPathname={initialPathname} />
           {children}
         </LoaderProvider>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
-"use client";
+import { pathHasPrefix } from 'next/dist/shared/lib/router/utils/path-has-prefix';
 
-import React from 'react';
 import { NewNavbar } from '@/components/ui/NewNavbar';
 import { HeroSection } from '@/components/ui/HeroSection';
 import { TopicsSection } from '@/components/ui/TopicsSection';
@@ -10,6 +9,12 @@ import { TrendingPosts } from '@/components/ui/TrendingPosts';
 import { NewFooter } from '@/components/ui/NewFooter';
 
 export default function Home() {
+  // Ensure the path-has-prefix module is bundled with this entry to avoid
+  // deferred chunk loading issues in certain runtimes.
+  if (!pathHasPrefix('/', '/')) {
+    throw new Error('Unexpected path prefix evaluation result.');
+  }
+
   return (
     <div className="min-h-screen bg-[#f0f0f0]">
       <NewNavbar />

--- a/src/components/ConditionalNavbar.tsx
+++ b/src/components/ConditionalNavbar.tsx
@@ -3,8 +3,14 @@
 import { useClientPathname } from "@/hooks/useClientPathname";
 import { NewNavbar } from "@/components/ui/NewNavbar";
 
-export default function ConditionalNavbar() {
-  const pathname = useClientPathname();
+type ConditionalNavbarProps = {
+  initialPathname?: string;
+};
+
+export default function ConditionalNavbar({
+  initialPathname,
+}: ConditionalNavbarProps) {
+  const pathname = useClientPathname(initialPathname);
 
   if (pathname === "/" || pathname.startsWith("/admin")) {
     return null;

--- a/src/components/ConditionalNavbar.tsx
+++ b/src/components/ConditionalNavbar.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { useClientPathname } from "@/hooks/useClientPathname";
 import { NewNavbar } from "@/components/ui/NewNavbar";
 
 export default function ConditionalNavbar() {
-  const pathname = usePathname();
+  const pathname = useClientPathname();
 
-  // Don't render navbar on the home page or admin page
-  // We now include the navbar directly in the home page component
   if (pathname === "/" || pathname.startsWith("/admin")) {
     return null;
   }

--- a/src/components/ui/GlobalSearch.tsx
+++ b/src/components/ui/GlobalSearch.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { Loader2, Search, X, ArrowUpRight } from 'lucide-react';
 import type { BlogListPost } from '@/lib/posts';
 
@@ -12,7 +12,6 @@ interface SearchResult extends BlogListPost {
 type SearchStatus = 'idle' | 'loading' | 'error' | 'success';
 
 export function GlobalSearch() {
-  const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
@@ -134,14 +133,6 @@ export function GlobalSearch() {
     return () => window.clearTimeout(timeout);
   }, [isOpen, query, runSearch]);
 
-  const handleResultClick = useCallback(
-    (slug: string) => {
-      router.push(`/blogs/${slug}`);
-      close();
-    },
-    [close, router],
-  );
-
   const hasResults = results.length > 0;
 
   return (
@@ -218,16 +209,13 @@ export function GlobalSearch() {
               {status === 'success' && !hasResults && (
                 <p className="text-sm text-gray-600">
                   No matches just yet. Try a different keyword or visit the{' '}
-                  <button
-                    type="button"
+                  <Link
+                    href="/blogs"
                     className="font-semibold text-[#6C63FF] underline"
-                    onClick={() => {
-                      router.push('/blogs');
-                      close();
-                    }}
+                    onClick={close}
                   >
                     blog archive
-                  </button>
+                  </Link>
                   .
                 </p>
               )}
@@ -236,9 +224,9 @@ export function GlobalSearch() {
                 <ul className="space-y-3" role="list">
                   {results.map((result) => (
                     <li key={result.id}>
-                      <button
-                        type="button"
-                        onClick={() => handleResultClick(result.slug)}
+                      <Link
+                        href={`/blogs/${result.slug}`}
+                        onClick={close}
                         className="group flex w-full flex-col gap-2 rounded-xl border-2 border-black bg-white px-4 py-3 text-left transition hover:-translate-y-[2px] hover:border-[#6C63FF] hover:shadow-[6px_6px_0px_0px_rgba(108,99,255,0.28)]"
                       >
                         <div className="flex items-center justify-between gap-3">
@@ -260,7 +248,7 @@ export function GlobalSearch() {
                           )}
                           <span>{result.views.toLocaleString()} views</span>
                         </div>
-                      </button>
+                      </Link>
                     </li>
                   ))}
                 </ul>

--- a/src/components/ui/NewNavbar.tsx
+++ b/src/components/ui/NewNavbar.tsx
@@ -3,12 +3,12 @@
 import React, { useState, useEffect } from 'react';
 import { Menu, X, Coffee, Code } from 'lucide-react';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 import { GlobalSearch } from './GlobalSearch';
+import { useClientPathname } from '@/hooks/useClientPathname';
 
 export const NewNavbar = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const pathname = usePathname();
+  const pathname = useClientPathname();
 
   // Function to check if a path is active
   const isActive = (path: string) => {

--- a/src/hooks/useClientPathname.ts
+++ b/src/hooks/useClientPathname.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type PathListener = (pathname: string) => void;
+
+const listeners = new Set<PathListener>();
+
+let cleanupHandlers: (() => void) | null = null;
+
+function notifyAll(pathname: string) {
+  listeners.forEach((listener) => listener(pathname));
+}
+
+function ensureHistoryPatched() {
+  if (cleanupHandlers || typeof window === "undefined") {
+    return;
+  }
+
+  const handleNavigation = () => {
+    notifyAll(window.location.pathname);
+  };
+
+  const originalPushState = window.history.pushState;
+  const originalReplaceState = window.history.replaceState;
+
+  const wrapHistoryMethod = <TArgs extends unknown[]>(
+    original: (...args: TArgs) => void,
+  ) => {
+    return function patched(this: History, ...args: TArgs) {
+      original.apply(this, args);
+      handleNavigation();
+    };
+  };
+
+  window.history.pushState = wrapHistoryMethod(originalPushState);
+  window.history.replaceState = wrapHistoryMethod(originalReplaceState);
+  window.addEventListener("popstate", handleNavigation);
+
+  cleanupHandlers = () => {
+    window.history.pushState = originalPushState;
+    window.history.replaceState = originalReplaceState;
+    window.removeEventListener("popstate", handleNavigation);
+    cleanupHandlers = null;
+  };
+}
+
+export function useClientPathname() {
+  const [pathname, setPathname] = useState<string>(() => {
+    if (typeof window === "undefined") {
+      return "/";
+    }
+
+    return window.location.pathname;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return () => undefined;
+    }
+
+    ensureHistoryPatched();
+
+    const listener: PathListener = (nextPathname) => {
+      setPathname(nextPathname);
+    };
+
+    listeners.add(listener);
+
+    // Ensure the initial path is in sync when the hook mounts.
+    listener(window.location.pathname);
+
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0 && cleanupHandlers) {
+        cleanupHandlers();
+      }
+    };
+  }, []);
+
+  return pathname;
+}

--- a/src/hooks/useClientPathname.ts
+++ b/src/hooks/useClientPathname.ts
@@ -45,10 +45,10 @@ function ensureHistoryPatched() {
   };
 }
 
-export function useClientPathname() {
+export function useClientPathname(initialPathname = "/") {
   const [pathname, setPathname] = useState<string>(() => {
     if (typeof window === "undefined") {
-      return "/";
+      return initialPathname;
     }
 
     return window.location.pathname;


### PR DESCRIPTION
## Summary
- add a chunk sync utility that copies Next.js server chunks into `.next/server` and run it for dev/build/start flows
- replace router-dependent navigation hooks with a custom history-based hook and use `<Link>` navigation to avoid runtime chunk lookups
- ensure the home page eagerly loads the `pathHasPrefix` helper to keep required router utilities bundled

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4d1244818832d81b477e887c43a61