### PR TITLE
Add trigger to auto-create profiles for new Supabase users

### DIFF
--- a/supabase/migrations/0009_auto_profile_for_new_users.sql
+++ b/supabase/migrations/0009_auto_profile_for_new_users.sql
@@ -1,0 +1,46 @@
+-- Automatically provision a profile row whenever a new auth user is created
+create or replace function public.create_profile_for_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  default_display_name text;
+begin
+  -- Prefer a custom display name supplied via metadata, then fall back to email prefix
+  default_display_name := coalesce(
+    nullif(new.raw_user_meta_data->>'display_name', ''),
+    nullif(split_part(coalesce(new.email, ''), '@', 1), ''),
+    'New User'
+  );
+
+  insert into public.profiles (user_id, display_name, is_admin)
+  values (new.id, default_display_name, false)
+  on conflict (user_id) do update
+    set display_name = excluded.display_name;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists create_profile_for_new_user on auth.users;
+
+create trigger create_profile_for_new_user
+  after insert on auth.users
+  for each row
+  execute function public.create_profile_for_new_user();
+
+-- Backfill profiles for any existing auth users that do not yet have a profile row
+insert into public.profiles (user_id, display_name, is_admin)
+select
+  u.id,
+  coalesce(
+    nullif(u.raw_user_meta_data->>'display_name', ''),
+    nullif(split_part(coalesce(u.email, ''), '@', 1), ''),
+    'New User'
+  ),
+  false
+from auth.users u
+left join public.profiles p on p.user_id = u.id
+where p.id is null;


### PR DESCRIPTION
## Summary
- add a trigger that provisions a public.profiles row for every new auth user using the best available display name
- ensure existing auth accounts without a profile receive one so they can be promoted to admin later

## Testing
- not run (SQL-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e522abbe64832dbe395962e7253cdb