### PR TITLE
Fix admin role detection when managing users

### DIFF
--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -91,8 +91,8 @@ export async function PATCH(
   const body = (await request.json()) as Partial<UpdateAdminUserPayload>
 
   const displayName = sanitizeDisplayName(body?.displayName)
-  const isAdmin = Boolean(body?.isAdmin)
   const requestedRoles = sanitizeRoleSlugs(body?.roleSlugs)
+  const isAdmin = Boolean(body?.isAdmin) || requestedRoles.includes('admin')
   const newPassword = sanitizePassword(body?.newPassword)
 
   if (!displayName) {

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -120,8 +120,8 @@ export async function POST(request: Request) {
   const email = sanitizeEmail(body?.email)
   const password = sanitizePassword(body?.password)
   const displayName = sanitizeDisplayName(body?.displayName)
-  const isAdmin = Boolean(body?.isAdmin)
   const requestedRoles = sanitizeRoleSlugs(body?.roleSlugs)
+  const isAdmin = Boolean(body?.isAdmin) || requestedRoles.includes('admin')
 
   if (!email) {
     return NextResponse.json({ error: 'Email is required.' }, { status: 400 })
@@ -177,7 +177,13 @@ export async function POST(request: Request) {
       )
     }
 
-    await ensureRoleAssignments(serviceClient, profileData.id, roles, requestedRoles, isAdmin)
+    await ensureRoleAssignments(
+      serviceClient,
+      profileData.id,
+      roles,
+      requestedRoles,
+      isAdmin,
+    )
 
     const refreshedProfile = await fetchProfileById(serviceClient, profileData.id)
     const summary = await buildUserSummary(serviceClient, refreshedProfile)


### PR DESCRIPTION
## Summary
- infer the admin flag on user creation and updates when the request includes the admin role
- keep role assignment calls in the POST handler readable after the new flag check

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e522abbe64832dbe395962e7253cdb