### PR TITLE
Refine navbar auth buttons for responsive layout

### DIFF
--- a/src/components/ui/NewNavbar.tsx
+++ b/src/components/ui/NewNavbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from 'react';
-import { Menu, X, Coffee, Code, LogIn, Search } from 'lucide-react';
+import { Menu, X, Coffee, Code, Search } from 'lucide-react';
 import Link from 'next/link';
 import { GlobalSearch } from './GlobalSearch';
 import { useClientPathname } from '@/hooks/useClientPathname';
@@ -27,22 +27,10 @@ export const NewNavbar = () => {
     <header className="sticky top-0 z-50 bg-[#f0f0f0] border-b-4 border-black">
       <div className="container mx-auto px-4 py-3">
         <div className="flex items-center justify-between gap-4">
-          <div className="flex items-center gap-2">
-            <Coffee className="h-8 w-8 text-[#FF5252]" />
-            <Code className="h-8 w-8 text-[#6C63FF]" />
-            <Link href="/" className="font-black text-2xl tracking-tighter">
-              <span className="bg-[#6C63FF] text-white px-2 py-1 mr-1 rotate-1 inline-block">
-                Syntax
-              </span>
-              <span className="text-[#FF5252]">&</span>
-              <span className="bg-[#FF5252] text-white px-2 py-1 ml-1 -rotate-1 inline-block">
-                Sips
-              </span>
-            </Link>
-          </div>
+          <NavbarLogo />
           {/* Desktop Navigation */}
-          <nav className="hidden md:flex items-center space-x-6">
-            <NavLink href="/" isActive={isActive('/')}>
+          <nav className="hidden md:flex items-center gap-6">
+            <NavLink href="/" isActive={isActive('/')}> 
               Home
             </NavLink>
             <NavLink href="/blogs" isActive={isActive('/blogs')}>
@@ -54,10 +42,21 @@ export const NewNavbar = () => {
             <NavLink href="/changelog" isActive={isActive('/changelog')}>
               Changelogs
             </NavLink>
-            <NavLink href="/me" isActive={isActive('/me')}>
-              Sign in / Sign up
-            </NavLink>
             <GlobalSearch />
+            <div className="flex items-center gap-3">
+              <Link
+                href="/me?view=signup"
+                className="inline-flex items-center justify-center rounded-md border-2 border-black bg-[#6C63FF] px-4 py-2 text-sm font-extrabold uppercase tracking-wide text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px] hover:shadow-[4px_4px_0px_0px_rgba(108,99,255,0.45)]"
+              >
+                Sign up
+              </Link>
+              <Link
+                href="/me"
+                className="inline-flex items-center justify-center rounded-md border-2 border-black bg-[#FF5252] px-4 py-2 text-sm font-extrabold uppercase tracking-wide text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px] hover:shadow-[4px_4px_0px_0px_rgba(255,82,82,0.45)]"
+              >
+                Sign in
+              </Link>
+            </div>
             <button
               type="button"
               className="bg-black text-white px-4 py-2 font-bold rounded-md transform transition hover:translate-y-[-2px] hover:shadow-[4px_4px_0px_0px_rgba(255,82,82)]"
@@ -72,18 +71,11 @@ export const NewNavbar = () => {
               onClick={() => {
                 window.dispatchEvent(new Event('global-search:open'));
               }}
-              className="inline-flex items-center gap-2 rounded-md border-2 border-black bg-white px-3 py-2 text-sm font-semibold text-black shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px]"
+              className="inline-flex items-center justify-center rounded-md border-2 border-black bg-white p-2 text-sm font-semibold text-black shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px]"
+              aria-label="Open search"
             >
               <Search className="h-4 w-4" aria-hidden="true" />
-              <span>Search</span>
             </button>
-            <Link
-              href="/me"
-              className="inline-flex items-center gap-1 rounded-md border-2 border-black bg-white px-3 py-2 text-sm font-semibold text-black shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px]"
-            >
-              <LogIn className="h-4 w-4" aria-hidden="true" />
-              <span>Sign in</span>
-            </Link>
             <button
               type="button"
               className="p-2 rounded-md bg-black text-white"
@@ -98,7 +90,7 @@ export const NewNavbar = () => {
         {isOpen && (
           <div className="md:hidden mt-4 pb-4">
             <div className="flex flex-col space-y-4">
-              <MobileNavLink href="/" isActive={isActive('/')}>
+              <MobileNavLink href="/" isActive={isActive('/')}> 
                 Home
               </MobileNavLink>
               <MobileNavLink href="/blogs" isActive={isActive('/blogs')}>
@@ -110,9 +102,20 @@ export const NewNavbar = () => {
               <MobileNavLink href="/changelog" isActive={isActive('/changelog')}>
                 Changelogs
               </MobileNavLink>
-              <MobileNavLink href="/me" isActive={isActive('/me')}>
-                Sign in / Sign up
-              </MobileNavLink>
+              <div className="grid grid-cols-2 gap-3">
+                <Link
+                  href="/me?view=signup"
+                  className="inline-flex items-center justify-center rounded-md border-2 border-black bg-[#6C63FF] px-4 py-2 text-sm font-extrabold uppercase tracking-wide text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px] hover:shadow-[4px_4px_0px_0px_rgba(108,99,255,0.45)]"
+                >
+                  Sign up
+                </Link>
+                <Link
+                  href="/me"
+                  className="inline-flex items-center justify-center rounded-md border-2 border-black bg-[#FF5252] px-4 py-2 text-sm font-extrabold uppercase tracking-wide text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px] hover:shadow-[4px_4px_0px_0px_rgba(255,82,82,0.45)]"
+                >
+                  Sign in
+                </Link>
+              </div>
               <button
                 type="button"
                 className="bg-black text-white px-4 py-2 font-bold rounded-md w-full"
@@ -126,6 +129,26 @@ export const NewNavbar = () => {
     </header>
   );
 };
+
+const NavbarLogo = () => (
+  <div className="flex items-center gap-2 flex-shrink-0">
+    <Coffee className="h-8 w-8 text-[#FF5252]" />
+    <Code className="h-8 w-8 text-[#6C63FF]" />
+    <Link
+      href="/"
+      className="font-black text-2xl tracking-tighter whitespace-nowrap"
+      aria-label="Syntax & Sips home"
+    >
+      <span className="bg-[#6C63FF] text-white px-2 py-1 mr-1 rotate-1 inline-block">
+        Syntax
+      </span>
+      <span className="text-[#FF5252]">&</span>
+      <span className="bg-[#FF5252] text-white px-2 py-1 ml-1 -rotate-1 inline-block">
+        Sips
+      </span>
+    </Link>
+  </div>
+);
 
 interface NavLinkProps {
   href: string;


### PR DESCRIPTION
## Summary
- convert the navbar authentication links into distinct sign-up and sign-in buttons on desktop
- limit the collapsed mobile header to the search trigger while surfacing sign-in and sign-up buttons inside the expanded menu
- arrange mobile sign-up and sign-in actions side-by-side with bespoke branding colors
- encapsulate the brand mark in a dedicated, non-shrinking logo component so mobile controls no longer compress it

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e52e113bd0832d8e18fb1310ea82a7