### PR TITLE
Update favicon metadata to use window icon

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,6 +20,11 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Syntax and Sips - AI & ML Insights",
   description: "Exploring the cutting edge of artificial intelligence, machine learning, and deep learning",
+  icons: {
+    icon: "/window.svg",
+    shortcut: "/window.svg",
+    apple: "/apple-touch-icon.png",
+  },
 };
 
 export default async function RootLayout({


### PR DESCRIPTION
## Summary
- update the root layout metadata to point at the window.svg asset from the public directory so the site favicon changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e551a5af4c832daa48bed50db5732a