### PR TITLE
Add personalized contributor onboarding flow

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -152,10 +152,15 @@ export default async function AccountPage() {
       }
     : null;
 
+  const resolvedDisplayName =
+    typeof profileRecord.display_name === 'string' && profileRecord.display_name.trim().length > 0
+      ? profileRecord.display_name.trim()
+      : user.email ?? 'Community friend';
+
   const profileSummary: AuthenticatedProfileSummary = {
     userId: user.id,
     email: user.email ?? '',
-    displayName: profileRecord.display_name as string,
+    displayName: resolvedDisplayName,
     avatarUrl: (profileRecord.avatar_url as string | null) ?? null,
     isAdmin: Boolean(profileRecord.is_admin),
     createdAt: profileRecord.created_at as string,

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,6 +1,15 @@
 import { redirect } from 'next/navigation';
 import { createServerComponentClient } from '@/lib/supabase/server-client';
 import { UserAccountPanel } from '@/components/auth/UserAccountPanel';
+import type {
+  AdminUserRole,
+  AuthenticatedProfileSummary,
+  ProfileOnboardingJourney,
+  UserCommentSummary,
+  UserContributionSnapshot,
+  UserPostSummary,
+} from '@/utils/types';
+import { CommentStatus, PostStatus } from '@/utils/types';
 
 export const dynamic = 'force-dynamic';
 
@@ -14,21 +23,154 @@ export default async function AccountPage() {
     redirect('/login?redirect_to=/account');
   }
 
-  const { data: profile, error } = await supabase
+  const { data: profileRecord, error: profileError } = await supabase
     .from('profiles')
-    .select('display_name, is_admin')
+    .select(
+      `id, display_name, avatar_url, is_admin, created_at, primary_role_id,
+       profile_roles(role:roles(id, slug, name, description, priority))`,
+    )
     .eq('user_id', user.id)
     .maybeSingle();
 
-  if (error) {
-    throw new Error(`Unable to load profile: ${error.message}`);
+  if (profileError) {
+    throw new Error(`Unable to load profile: ${profileError.message}`);
   }
 
-  return (
-    <UserAccountPanel
-      email={user.email ?? ''}
-      displayName={profile?.display_name ?? user.email ?? 'Friend'}
-      isAdmin={Boolean(profile?.is_admin)}
-    />
-  );
+  if (!profileRecord) {
+    throw new Error('Profile not found.');
+  }
+
+  const rawRoles = Array.isArray(profileRecord.profile_roles) ? profileRecord.profile_roles : [];
+  const roles: AdminUserRole[] = [];
+
+  for (const entry of rawRoles) {
+    const role = entry?.role;
+
+    if (!role || typeof role !== 'object') {
+      continue;
+    }
+
+    const idValue = (role as { id?: unknown }).id;
+    const slugValue = (role as { slug?: unknown }).slug;
+    const nameValue = (role as { name?: unknown }).name;
+    const descriptionValue = (role as { description?: unknown }).description;
+    const priorityValue = (role as { priority?: unknown }).priority;
+
+    if (typeof idValue !== 'string' || typeof slugValue !== 'string' || typeof nameValue !== 'string') {
+      continue;
+    }
+
+    const description = typeof descriptionValue === 'string' ? descriptionValue : null;
+    const priority = typeof priorityValue === 'number' ? priorityValue : Number(priorityValue ?? 0);
+
+    roles.push({
+      id: idValue,
+      slug: slugValue,
+      name: nameValue,
+      description,
+      priority,
+    });
+  }
+
+  roles.sort((a, b) => a.priority - b.priority);
+
+  const { data: postsData, error: postsError } = await supabase
+    .from('posts')
+    .select('id, title, slug, status, views, created_at, published_at')
+    .eq('author_id', profileRecord.id)
+    .order('created_at', { ascending: false });
+
+  if (postsError) {
+    throw new Error(`Unable to load authored posts: ${postsError.message}`);
+  }
+
+  const posts: UserPostSummary[] = (postsData ?? []).map((post) => ({
+    id: post.id as string,
+    title: (post.title as string) ?? 'Untitled post',
+    slug: (post.slug as string | null) ?? null,
+    status: (post.status as PostStatus) ?? PostStatus.DRAFT,
+    views: typeof post.views === 'number' ? post.views : 0,
+    createdAt: post.created_at as string,
+    publishedAt: (post.published_at as string | null) ?? null,
+  }));
+
+  const { data: commentsData, error: commentsError } = await supabase
+    .from('comments')
+    .select('id, content, status, created_at, posts:post_id(title, slug)')
+    .eq('author_profile_id', profileRecord.id)
+    .order('created_at', { ascending: false });
+
+  if (commentsError) {
+    throw new Error(`Unable to load your comments: ${commentsError.message}`);
+  }
+
+  const comments: UserCommentSummary[] = (commentsData ?? []).map((comment) => ({
+    id: comment.id as string,
+    content: (comment.content as string) ?? '',
+    status: (comment.status as CommentStatus) ?? CommentStatus.PENDING,
+    createdAt: comment.created_at as string,
+    postTitle: (() => {
+      const postEntry = Array.isArray(comment.posts) ? comment.posts[0] : comment.posts;
+      return (postEntry?.title as string | null) ?? null;
+    })(),
+    postSlug: (() => {
+      const postEntry = Array.isArray(comment.posts) ? comment.posts[0] : comment.posts;
+      return (postEntry?.slug as string | null) ?? null;
+    })(),
+  }));
+
+  const totals = {
+    totalPosts: posts.length,
+    publishedPosts: posts.filter((post) => post.status === PostStatus.PUBLISHED).length,
+    draftPosts: posts.filter((post) => post.status === PostStatus.DRAFT).length,
+    scheduledPosts: posts.filter((post) => post.status === PostStatus.SCHEDULED).length,
+    totalViews: posts.reduce((sum, post) => sum + (Number.isFinite(post.views) ? post.views : 0), 0),
+    totalComments: comments.length,
+    approvedComments: comments.filter((comment) => comment.status === CommentStatus.APPROVED).length,
+    pendingComments: comments.filter((comment) => comment.status === CommentStatus.PENDING).length,
+    rejectedComments: comments.filter((comment) => comment.status === CommentStatus.REJECTED).length,
+  } satisfies UserContributionSnapshot['totals'];
+
+  const { data: onboardingRecord, error: onboardingError } = await supabase
+    .from('profile_onboarding_journeys')
+    .select('status, current_step, completed_at, updated_at, version, responses')
+    .eq('profile_id', profileRecord.id)
+    .maybeSingle();
+
+  if (onboardingError) {
+    console.error('Unable to load onboarding journey for profile', onboardingError);
+  }
+
+  const onboarding: ProfileOnboardingJourney | null = onboardingRecord
+    ? {
+        status: (onboardingRecord.status as ProfileOnboardingJourney['status']) ?? 'pending',
+        currentStep: (onboardingRecord.current_step as string | null) ?? null,
+        completedAt: (onboardingRecord.completed_at as string | null) ?? null,
+        updatedAt: (onboardingRecord.updated_at as string | null) ?? null,
+        version: (onboardingRecord.version as string | null) ?? null,
+        responses: (onboardingRecord.responses as ProfileOnboardingJourney['responses']) ?? null,
+      }
+    : null;
+
+  const profileSummary: AuthenticatedProfileSummary = {
+    userId: user.id,
+    email: user.email ?? '',
+    displayName: profileRecord.display_name as string,
+    avatarUrl: (profileRecord.avatar_url as string | null) ?? null,
+    isAdmin: Boolean(profileRecord.is_admin),
+    createdAt: profileRecord.created_at as string,
+    lastSignInAt: user.last_sign_in_at ?? null,
+    emailConfirmedAt: user.email_confirmed_at ?? null,
+    primaryRoleId: (profileRecord.primary_role_id as string | null) ?? null,
+    roles,
+    onboarding,
+  };
+
+  const contributions: UserContributionSnapshot = {
+    posts,
+    comments,
+    totals,
+  };
+
+  return <UserAccountPanel profile={profileSummary} contributions={contributions} />;
 }

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase/server-client'
+import type {
+  AdminUserRole,
+  AuthenticatedProfileSummary,
+  ProfileOnboardingJourney,
+} from '@/utils/types'
+
+export async function GET() {
+  const supabase = createServerClient()
+
+  try {
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError) {
+      console.error('Unable to load current auth user', authError)
+      return NextResponse.json(
+        { error: 'Unable to verify authentication.' },
+        { status: 500 },
+      )
+    }
+
+    if (!user) {
+      return NextResponse.json({ error: 'Not authenticated.' }, { status: 401 })
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select(
+        `id, display_name, avatar_url, is_admin, created_at, primary_role_id,
+         profile_roles(role:roles(id, slug, name, description, priority))`,
+      )
+      .eq('user_id', user.id)
+      .maybeSingle()
+
+    if (profileError) {
+      console.error('Unable to load profile for authenticated user', profileError)
+      return NextResponse.json(
+        { error: 'Unable to load profile.' },
+        { status: 500 },
+      )
+    }
+
+    if (!profile) {
+      return NextResponse.json({ error: 'Profile not found.' }, { status: 404 })
+    }
+
+    const rawRoles = Array.isArray(profile.profile_roles) ? profile.profile_roles : []
+    const roles: AdminUserRole[] = []
+
+    for (const entry of rawRoles) {
+      const role = entry?.role
+
+      if (!role || typeof role !== 'object') {
+        continue
+      }
+
+      const idValue = (role as { id?: unknown }).id
+      const slugValue = (role as { slug?: unknown }).slug
+      const nameValue = (role as { name?: unknown }).name
+      const descriptionValue = (role as { description?: unknown }).description
+      const priorityValue = (role as { priority?: unknown }).priority
+
+      if (typeof idValue !== 'string' || typeof slugValue !== 'string' || typeof nameValue !== 'string') {
+        continue
+      }
+
+      const description = typeof descriptionValue === 'string' ? descriptionValue : null
+      const priority = typeof priorityValue === 'number' ? priorityValue : Number(priorityValue ?? 0)
+
+      roles.push({
+        id: idValue,
+        slug: slugValue,
+        name: nameValue,
+        description,
+        priority,
+      })
+    }
+
+    roles.sort((a, b) => a.priority - b.priority)
+
+    const { data: onboardingRecord, error: onboardingError } = await supabase
+      .from('profile_onboarding_journeys')
+      .select('status, current_step, completed_at, updated_at, version, responses')
+      .eq('profile_id', profile.id)
+      .maybeSingle()
+
+    if (onboardingError) {
+      console.error('Unable to load onboarding journey for authenticated user', onboardingError)
+    }
+
+    const onboarding: ProfileOnboardingJourney | null = onboardingRecord
+      ? {
+          status: onboardingRecord.status ?? 'pending',
+          currentStep: onboardingRecord.current_step ?? null,
+          completedAt: onboardingRecord.completed_at ?? null,
+          updatedAt: onboardingRecord.updated_at ?? null,
+          version: onboardingRecord.version ?? null,
+          responses: (onboardingRecord.responses as ProfileOnboardingJourney['responses']) ?? null,
+        }
+      : null
+
+    const payload: AuthenticatedProfileSummary = {
+      userId: user.id,
+      email: user.email ?? '',
+      displayName: profile.display_name,
+      avatarUrl: profile.avatar_url ?? null,
+      isAdmin: profile.is_admin,
+      createdAt: profile.created_at,
+      lastSignInAt: user.last_sign_in_at ?? null,
+      emailConfirmedAt: user.email_confirmed_at ?? null,
+      primaryRoleId: profile.primary_role_id ?? null,
+      roles,
+      onboarding,
+    }
+
+    return NextResponse.json({ profile: payload })
+  } catch (error) {
+    console.error('Unexpected error while resolving authenticated profile', error)
+    return NextResponse.json(
+      { error: 'Unexpected error while resolving authenticated profile.' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,0 +1,96 @@
+import { redirect } from 'next/navigation';
+import { createServerComponentClient } from '@/lib/supabase/server-client';
+import { OnboardingFlow } from '@/components/auth/OnboardingFlow';
+import type { ProfileOnboardingJourney } from '@/utils/types';
+
+export const dynamic = 'force-dynamic';
+
+interface OnboardingPageProps {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}
+
+const sanitizeRedirect = (value: string | string[] | null | undefined) => {
+  const candidate = Array.isArray(value) ? value[0] : value;
+
+  if (!candidate || typeof candidate !== 'string') {
+    return '/account';
+  }
+
+  try {
+    const url = new URL(candidate, 'http://localhost');
+    return url.pathname.startsWith('/') ? url.pathname + url.search + url.hash : '/account';
+  } catch {
+    return candidate.startsWith('/') ? candidate : '/account';
+  }
+};
+
+export default async function OnboardingPage({ searchParams }: OnboardingPageProps) {
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const supabase = createServerComponentClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login?redirect_to=/onboarding');
+  }
+
+  const { data: profileRecord, error: profileError } = await supabase
+    .from('profiles')
+    .select('id, user_id, display_name, avatar_url, created_at')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (profileError) {
+    throw new Error(`Unable to load profile for onboarding: ${profileError.message}`);
+  }
+
+  if (!profileRecord) {
+    throw new Error('Profile not found for onboarding.');
+  }
+
+  const { data: onboardingRecord, error: onboardingError } = await supabase
+    .from('profile_onboarding_journeys')
+    .select('status, current_step, completed_at, updated_at, version, responses')
+    .eq('profile_id', profileRecord.id)
+    .maybeSingle();
+
+  if (onboardingError) {
+    console.error('Unable to load onboarding journey for onboarding page', onboardingError);
+  }
+
+  const journey: ProfileOnboardingJourney = onboardingRecord
+    ? {
+        status: (onboardingRecord.status as ProfileOnboardingJourney['status']) ?? 'pending',
+        currentStep: (onboardingRecord.current_step as string | null) ?? null,
+        completedAt: (onboardingRecord.completed_at as string | null) ?? null,
+        updatedAt: (onboardingRecord.updated_at as string | null) ?? null,
+        version: (onboardingRecord.version as string | null) ?? null,
+        responses: (onboardingRecord.responses as ProfileOnboardingJourney['responses']) ?? null,
+      }
+    : {
+        status: 'pending',
+        currentStep: null,
+        completedAt: null,
+        updatedAt: null,
+        version: '2025.02',
+        responses: null,
+      };
+
+  const redirectPath = sanitizeRedirect(resolvedSearchParams?.redirect);
+
+  return (
+    <OnboardingFlow
+      profile={{
+        id: profileRecord.id as string,
+        userId: profileRecord.user_id as string,
+        displayName: profileRecord.display_name as string,
+        avatarUrl: (profileRecord.avatar_url as string | null) ?? null,
+        createdAt: profileRecord.created_at as string,
+      }}
+      initialJourney={journey}
+      defaultRedirect={redirectPath}
+    />
+  );
+}

--- a/src/components/auth/OnboardingFlow.tsx
+++ b/src/components/auth/OnboardingFlow.tsx
@@ -1,0 +1,1089 @@
+"use client";
+
+import { useEffect, useMemo, useState, type ComponentType } from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import {
+  ArrowRight,
+  CalendarCheck2,
+  Check,
+  CheckCircle2,
+  ChevronLeft,
+  Compass,
+  Goal,
+  Loader2,
+  NotebookPen,
+  RefreshCcw,
+  Rocket,
+  ShieldCheck,
+  Sparkles,
+  Target,
+  UsersRound,
+} from 'lucide-react';
+import { createBrowserClient } from '@/lib/supabase/client';
+import { useAuthenticatedProfile } from '@/hooks/useAuthenticatedProfile';
+import { cn } from '@/lib/utils';
+import type {
+  OnboardingAccountability,
+  OnboardingCommunication,
+  OnboardingContribution,
+  OnboardingExperienceLevel,
+  OnboardingGoal,
+  OnboardingLearningFormat,
+  OnboardingPersona,
+  OnboardingSupportPreference,
+  ProfileOnboardingJourney,
+  ProfileOnboardingResponses,
+} from '@/utils/types';
+
+interface OnboardingFlowProps {
+  profile: {
+    id: string;
+    userId: string;
+    displayName: string;
+    avatarUrl: string | null;
+    createdAt: string;
+  };
+  initialJourney: ProfileOnboardingJourney;
+  defaultRedirect: string;
+}
+
+type StepId = 'persona' | 'outcomes' | 'enablement' | 'support' | 'summary';
+
+type JourneyRecord = {
+  status: ProfileOnboardingJourney['status'];
+  current_step: string | null;
+  completed_at: string | null;
+  updated_at: string | null;
+  version: string | null;
+  responses: ProfileOnboardingJourney['responses'];
+};
+
+const personaOptions: Array<{
+  value: OnboardingPersona;
+  title: string;
+  description: string;
+  icon: ComponentType<{ className?: string }>;
+}> = [
+  {
+    value: 'learning-explorer',
+    title: 'Curious explorer',
+    description: 'I scan emerging research, tools, and ideas to stay ahead of the curve.',
+    icon: Compass,
+  },
+  {
+    value: 'hands-on-builder',
+    title: 'Hands-on builder',
+    description: 'I learn by prototyping quickly and sharing what I discover with others.',
+    icon: Rocket,
+  },
+  {
+    value: 'community-connector',
+    title: 'Community connector',
+    description: 'I spark conversations, curate resources, and keep the energy high.',
+    icon: UsersRound,
+  },
+  {
+    value: 'career-switcher',
+    title: 'Career switcher',
+    description: 'I am pivoting into AI/ML and want a guided runway and supportive peers.',
+    icon: RefreshCcw,
+  },
+  {
+    value: 'team-enabler',
+    title: 'Team enabler',
+    description: 'I coach squads, manage stakeholders, and need signal to guide the crew.',
+    icon: ShieldCheck,
+  },
+];
+
+const experienceOptions: Array<{
+  value: OnboardingExperienceLevel;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'early-career',
+    label: 'Early career',
+    description: '0-2 years working in AI/ML or adjacent fields.',
+  },
+  {
+    value: 'mid-level',
+    label: 'Practicing contributor',
+    description: 'Actively shipping projects and leveling up craft.',
+  },
+  {
+    value: 'senior-practitioner',
+    label: 'Senior practitioner',
+    description: 'Trusted specialist guiding initiatives or teams.',
+  },
+  {
+    value: 'strategic-leader',
+    label: 'Strategic leader',
+    description: 'Setting vision, roadmaps, or org-wide enablement.',
+  },
+];
+
+const goalOptions: Array<{
+  value: OnboardingGoal;
+  title: string;
+  description: string;
+}> = [
+  {
+    value: 'publish-signature-series',
+    title: 'Publish a signature series',
+    description: 'Craft landmark stories that cement your point of view.',
+  },
+  {
+    value: 'grow-technical-voice',
+    title: 'Grow your technical voice',
+    description: 'Share frameworks, best practices, and bold opinions.',
+  },
+  {
+    value: 'level-up-ai-skills',
+    title: 'Level up AI & ML skills',
+    description: 'Find playbooks, walkthroughs, and practice prompts.',
+  },
+  {
+    value: 'ship-side-projects',
+    title: 'Ship side projects faster',
+    description: 'Use accountability loops to move experiments forward.',
+  },
+  {
+    value: 'find-peers',
+    title: 'Meet collaborators & peers',
+    description: 'Connect with people shipping similar ideas.',
+  },
+  {
+    value: 'transition-role',
+    title: 'Transition into a new role',
+    description: 'Build a portfolio and skill stack to pivot confidently.',
+  },
+];
+
+const contributionOptions: Array<{
+  value: OnboardingContribution;
+  title: string;
+  description: string;
+}> = [
+  {
+    value: 'write-articles',
+    title: 'Long-form articles',
+    description: 'Break down complex topics for thousands of readers.',
+  },
+  {
+    value: 'share-code-snippets',
+    title: 'Code walkthroughs',
+    description: 'Publish labs, notebooks, and reproducible examples.',
+  },
+  {
+    value: 'host-events',
+    title: 'Live sessions & events',
+    description: 'Host office hours, workshops, or live coding demos.',
+  },
+  {
+    value: 'produce-videos',
+    title: 'Video & podcast drops',
+    description: 'Record conversations or screen shares for the community.',
+  },
+  {
+    value: 'mentor-community',
+    title: 'Mentorship moments',
+    description: 'Offer feedback, portfolio reviews, or pair-building.',
+  },
+];
+
+const learningFormatOptions: Array<{
+  value: OnboardingLearningFormat;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'deep-dives',
+    label: 'Deep dives',
+    description: 'Research-backed explorations with diagrams and code.',
+  },
+  {
+    value: 'quick-tips',
+    label: 'Quick tips',
+    description: 'Bite-sized tactics, templates, and copy/paste snippets.',
+  },
+  {
+    value: 'live-builds',
+    label: 'Live builds',
+    description: 'Real-time co-building with Q&A and community chat.',
+  },
+  {
+    value: 'case-studies',
+    label: 'Case studies',
+    description: 'Behind-the-scenes breakdowns from working teams.',
+  },
+  {
+    value: 'audio-notes',
+    label: 'Audio notes',
+    description: 'Pod-style explainers you can play on the go.',
+  },
+];
+
+const supportOptions: Array<{
+  value: OnboardingSupportPreference;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'editorial-reviews',
+    label: 'Editorial reviews',
+    description: 'Get structured edits and publishing guidance.',
+  },
+  {
+    value: 'pair-programming',
+    label: 'Pair programming jams',
+    description: 'Co-build prototypes and unblock tricky problems.',
+  },
+  {
+    value: 'career-coaching',
+    label: 'Career strategy chats',
+    description: 'Plan your next move and align your portfolio.',
+  },
+  {
+    value: 'community-challenges',
+    label: 'Community challenges',
+    description: 'Join themed sprints with badges and celebrations.',
+  },
+  {
+    value: 'office-hours',
+    label: 'Office hours & AMAs',
+    description: 'Drop in for real-time support from editors and guests.',
+  },
+];
+
+const accountabilityOptions: Array<{
+  value: OnboardingAccountability;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'progress-updates',
+    label: 'Weekly progress pulses',
+    description: 'Share snapshots and keep momentum visible.',
+  },
+  {
+    value: 'quiet-focus',
+    label: 'Heads-down focus',
+    description: 'Minimal check-ins—just surface milestones when ready.',
+  },
+  {
+    value: 'public-goals',
+    label: 'Public goal setting',
+    description: 'Declare bold goals and celebrate wins with the crew.',
+  },
+  {
+    value: 'one-on-one',
+    label: '1:1 accountability',
+    description: 'Pair with an editor or mentor for deeper coaching.',
+  },
+];
+
+const communicationOptions: Array<{
+  value: OnboardingCommunication;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'weekly-digest',
+    label: 'Weekly digest',
+    description: 'One email that rounds up the essentials you care about.',
+  },
+  {
+    value: 'event-reminders',
+    label: 'Event reminders',
+    description: 'Get nudges before livestreams, AMAs, and studio sessions.',
+  },
+  {
+    value: 'opportunity-alerts',
+    label: 'Opportunities & collabs',
+    description: 'Speaking gigs, beta testing, and project matchmaking.',
+  },
+  {
+    value: 'product-updates',
+    label: 'Product updates',
+    description: 'Roadmap notes, feature previews, and design experiments.',
+  },
+];
+
+const defaultResponses = (
+  responses: ProfileOnboardingJourney['responses'],
+): ProfileOnboardingResponses => ({
+  persona: responses?.persona ?? null,
+  experienceLevel: responses?.experienceLevel ?? null,
+  motivations: responses?.motivations ?? [],
+  focusAreas: responses?.focusAreas ?? [],
+  preferredLearningFormats: responses?.preferredLearningFormats ?? [],
+  supportPreferences: responses?.supportPreferences ?? [],
+  accountabilityStyle: responses?.accountabilityStyle ?? null,
+  communicationPreferences: responses?.communicationPreferences ?? [],
+});
+
+const mapRecordToJourney = (record: JourneyRecord): ProfileOnboardingJourney => ({
+  status: record.status ?? 'pending',
+  currentStep: record.current_step ?? null,
+  completedAt: record.completed_at ?? null,
+  updatedAt: record.updated_at ?? null,
+  version: record.version ?? null,
+  responses: record.responses ?? null,
+});
+
+export const OnboardingFlow = ({ profile, initialJourney, defaultRedirect }: OnboardingFlowProps) => {
+  const router = useRouter();
+  const supabase = useMemo(() => createBrowserClient(), []);
+  const { refresh: refreshProfile } = useAuthenticatedProfile();
+
+  const [journey, setJourney] = useState<ProfileOnboardingJourney>(initialJourney);
+  const [responses, setResponses] = useState<ProfileOnboardingResponses>(defaultResponses(initialJourney.responses));
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const stepOrder: StepId[] = useMemo(() => ['persona', 'outcomes', 'enablement', 'support', 'summary'], []);
+
+  const initialStep = useMemo(() => {
+    if (initialJourney.status === 'completed') {
+      return 'summary';
+    }
+
+    if (initialJourney.currentStep && stepOrder.includes(initialJourney.currentStep as StepId)) {
+      return initialJourney.currentStep as StepId;
+    }
+
+    return 'persona';
+  }, [initialJourney.currentStep, initialJourney.status, stepOrder]);
+
+  const [currentStepIndex, setCurrentStepIndex] = useState(() => Math.max(stepOrder.indexOf(initialStep), 0));
+
+  useEffect(() => {
+    router.prefetch(defaultRedirect);
+  }, [defaultRedirect, router]);
+
+  const progressPercentage = Math.round((currentStepIndex / (stepOrder.length - 1)) * 100);
+
+  const updateJourney = (record: JourneyRecord) => {
+    const mapped = mapRecordToJourney(record);
+    setJourney(mapped);
+    if (mapped.responses) {
+      setResponses(defaultResponses(mapped.responses));
+    }
+  };
+
+  const persistJourney = async (
+    nextStatus: ProfileOnboardingJourney['status'],
+    nextStep: string | null,
+    payload: ProfileOnboardingResponses,
+    completedAt: string | null,
+  ) => {
+    setIsSaving(true);
+    setError(null);
+    setSuccessMessage(null);
+
+    const baseUpdate = {
+      status: nextStatus,
+      current_step: nextStep,
+      responses: payload,
+      completed_at: completedAt,
+      version: journey.version ?? '2025.02',
+    };
+
+    let record: JourneyRecord | null = null;
+
+    const { data, error: updateError } = await supabase
+      .from('profile_onboarding_journeys')
+      .update(baseUpdate)
+      .eq('profile_id', profile.id)
+      .select('status, current_step, completed_at, updated_at, version, responses')
+      .maybeSingle();
+
+    if (updateError) {
+      console.error('Failed to update onboarding journey', updateError);
+    }
+
+    if (data) {
+      record = data as JourneyRecord;
+    } else if (!updateError) {
+      const { data: upserted, error: upsertError } = await supabase
+        .from('profile_onboarding_journeys')
+        .upsert(
+          { profile_id: profile.id, user_id: profile.userId, ...baseUpdate },
+          { onConflict: 'profile_id' },
+        )
+        .select('status, current_step, completed_at, updated_at, version, responses')
+        .single();
+
+      if (upsertError) {
+        console.error('Failed to upsert onboarding journey', upsertError);
+        setError('We could not save your progress. Please retry.');
+        setIsSaving(false);
+        return null;
+      }
+
+      record = upserted as JourneyRecord;
+    } else {
+      setError('We could not save your progress. Please retry.');
+      setIsSaving(false);
+      return null;
+    }
+
+    if (!record) {
+      setError('We could not save your progress. Please retry.');
+      setIsSaving(false);
+      return null;
+    }
+
+    updateJourney(record);
+    await refreshProfile();
+    setIsSaving(false);
+    return record;
+  };
+
+  const toggleMotivation = (value: OnboardingGoal) => {
+    setResponses((previous) => ({
+      ...previous,
+      motivations: previous.motivations.includes(value)
+        ? previous.motivations.filter((item) => item !== value)
+        : [...previous.motivations, value],
+    }));
+  };
+
+  const toggleContribution = (value: OnboardingContribution) => {
+    setResponses((previous) => ({
+      ...previous,
+      focusAreas: previous.focusAreas.includes(value)
+        ? previous.focusAreas.filter((item) => item !== value)
+        : [...previous.focusAreas, value],
+    }));
+  };
+
+  const toggleLearningFormat = (value: OnboardingLearningFormat) => {
+    setResponses((previous) => ({
+      ...previous,
+      preferredLearningFormats: previous.preferredLearningFormats.includes(value)
+        ? previous.preferredLearningFormats.filter((item) => item !== value)
+        : [...previous.preferredLearningFormats, value],
+    }));
+  };
+
+  const toggleSupportPreference = (value: OnboardingSupportPreference) => {
+    setResponses((previous) => ({
+      ...previous,
+      supportPreferences: previous.supportPreferences.includes(value)
+        ? previous.supportPreferences.filter((item) => item !== value)
+        : [...previous.supportPreferences, value],
+    }));
+  };
+
+  const toggleCommunicationPreference = (value: OnboardingCommunication) => {
+    setResponses((previous) => ({
+      ...previous,
+      communicationPreferences: previous.communicationPreferences.includes(value)
+        ? previous.communicationPreferences.filter((item) => item !== value)
+        : [...previous.communicationPreferences, value],
+    }));
+  };
+
+  const validateStep = (stepId: StepId): string | null => {
+    switch (stepId) {
+      case 'persona':
+        if (!responses.persona || !responses.experienceLevel) {
+          return 'Choose the persona and experience level that best represent you.';
+        }
+        return null;
+      case 'outcomes':
+        if (responses.motivations.length === 0) {
+          return 'Select at least one outcome you want to unlock with Syntax & Sips.';
+        }
+        return null;
+      case 'enablement':
+        if (responses.focusAreas.length === 0) {
+          return 'Let us know how you want to contribute.';
+        }
+        if (responses.preferredLearningFormats.length === 0) {
+          return 'Pick at least one content format you value most.';
+        }
+        return null;
+      case 'support':
+        if (!responses.accountabilityStyle) {
+          return 'Pick the support style that keeps you motivated.';
+        }
+        if (responses.communicationPreferences.length === 0) {
+          return 'Tell us how you want us to stay in touch.';
+        }
+        return null;
+      default:
+        return null;
+    }
+  };
+
+  const handleNext = async () => {
+    const activeStep = stepOrder[currentStepIndex];
+    const validationMessage = validateStep(activeStep);
+
+    if (validationMessage) {
+      setError(validationMessage);
+      return;
+    }
+
+    const isFinalStep = currentStepIndex === stepOrder.length - 1;
+
+    if (isFinalStep) {
+      return;
+    }
+
+    const nextStepId = stepOrder[currentStepIndex + 1];
+    const completionTimestamp = nextStepId === 'summary' ? new Date().toISOString() : null;
+    const nextStatus = nextStepId === 'summary' ? 'completed' : 'in_progress';
+
+    const record = await persistJourney(nextStatus, nextStepId, responses, completionTimestamp);
+
+    if (!record) {
+      return;
+    }
+
+    if (nextStepId === 'summary') {
+      setSuccessMessage('Onboarding complete! Your dashboard is now personalised.');
+    }
+
+    setCurrentStepIndex((index) => Math.min(index + 1, stepOrder.length - 1));
+  };
+
+  const handleBack = () => {
+    if (currentStepIndex === 0) {
+      return;
+    }
+    setError(null);
+    setSuccessMessage(null);
+    setCurrentStepIndex((index) => Math.max(index - 1, 0));
+  };
+
+  const handleSkip = async () => {
+    await persistJourney(journey.status === 'completed' ? 'completed' : 'in_progress', stepOrder[currentStepIndex], responses, journey.completedAt ?? null);
+    router.replace(defaultRedirect);
+  };
+
+  const handleFinish = async () => {
+    const record = await persistJourney('completed', 'summary', responses, new Date().toISOString());
+
+    if (!record) {
+      return;
+    }
+
+    setSuccessMessage('Onboarding complete! Redirecting you to your dashboard.');
+    setCurrentStepIndex(stepOrder.length - 1);
+
+    setTimeout(() => {
+      router.replace(defaultRedirect);
+    }, 1200);
+  };
+
+  const currentStep = stepOrder[currentStepIndex];
+
+  const renderPersonaStep = () => (
+    <div className="space-y-6">
+      <p className="text-base font-semibold text-gray-600">
+        We use your answers to tailor playbooks, match you with collaborators, and decide which experiments to invite you into first.
+      </p>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {personaOptions.map((option) => {
+          const Icon = option.icon;
+          const isActive = responses.persona === option.value;
+
+          return (
+            <button
+              type="button"
+              key={option.value}
+              onClick={() => {
+                setResponses((previous) => ({ ...previous, persona: option.value }));
+                setError(null);
+              }}
+              className={cn(
+                'flex h-full flex-col items-start gap-3 rounded-3xl border-2 border-black bg-white p-5 text-left shadow-[8px_8px_0px_0px_rgba(0,0,0,0.15)] transition-transform hover:-translate-y-1',
+                isActive ? 'bg-[#FFD66B] shadow-[10px_10px_0px_0px_rgba(0,0,0,0.2)]' : 'bg-white',
+              )}
+            >
+              <span className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-black px-3 py-1 text-xs font-black uppercase tracking-wide text-white">
+                <Icon className="h-4 w-4" aria-hidden="true" />
+                {isActive ? 'Your pick' : 'Persona'}
+              </span>
+              <div>
+                <h3 className="text-xl font-black text-gray-900">{option.title}</h3>
+                <p className="mt-1 text-sm font-medium text-gray-700">{option.description}</p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="rounded-3xl border-2 border-dashed border-black/20 bg-[#F8F4FF] p-5">
+        <p className="text-sm font-black uppercase tracking-wide text-[#6C63FF]">Experience signal</p>
+        <p className="mt-2 text-base font-semibold text-gray-700">
+          We calibrate recommendations based on how confident you feel in your craft.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          {experienceOptions.map((option) => {
+            const isActive = responses.experienceLevel === option.value;
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  setResponses((previous) => ({ ...previous, experienceLevel: option.value }));
+                  setError(null);
+                }}
+                className={cn(
+                  'rounded-full border-2 border-black bg-white px-4 py-2 text-left text-sm font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,0.15)] transition-transform hover:-translate-y-[1px] focus:outline-none',
+                  isActive ? 'bg-[#6C63FF] text-white' : 'bg-white text-gray-900',
+                )}
+              >
+                <span className="block text-xs font-black uppercase tracking-wide text-gray-500">
+                  {option.label}
+                </span>
+                <span className="block text-xs font-semibold text-gray-700">
+                  {option.description}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderOutcomeStep = () => (
+    <div className="space-y-6">
+      <p className="text-base font-semibold text-gray-600">
+        What would make Syntax &amp; Sips wildly valuable for you? Pick the wins you are chasing so we can craft the right nudges.
+      </p>
+      <div className="grid gap-4 md:grid-cols-2">
+        {goalOptions.map((option) => {
+          const isActive = responses.motivations.includes(option.value);
+
+          return (
+            <button
+              type="button"
+              key={option.value}
+              onClick={() => {
+                toggleMotivation(option.value);
+                setError(null);
+              }}
+              className={cn(
+                'flex h-full flex-col items-start gap-3 rounded-3xl border-2 border-black bg-white p-5 text-left shadow-[8px_8px_0px_0px_rgba(0,0,0,0.12)] transition-transform hover:-translate-y-1',
+                isActive ? 'bg-[#C5F8FF]' : 'bg-white',
+              )}
+            >
+              <span className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-[#6C63FF] px-3 py-1 text-xs font-black uppercase tracking-wide text-white">
+                <Goal className="h-4 w-4" aria-hidden="true" />
+                {isActive ? 'Selected' : 'Goal'}
+              </span>
+              <h3 className="text-xl font-black text-gray-900">{option.title}</h3>
+              <p className="text-sm font-medium text-gray-700">{option.description}</p>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  const renderEnablementStep = () => (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-black text-gray-900">How do you want to contribute?</h3>
+        <p className="mt-1 text-sm font-medium text-gray-600">
+          Your selections help us match you with editors, resources, and programs that amplify your strengths.
+        </p>
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          {contributionOptions.map((option) => {
+            const isActive = responses.focusAreas.includes(option.value);
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  toggleContribution(option.value);
+                  setError(null);
+                }}
+                className={cn(
+                  'flex h-full flex-col items-start gap-3 rounded-3xl border-2 border-black bg-white p-5 text-left shadow-[8px_8px_0px_0px_rgba(0,0,0,0.12)] transition-transform hover:-translate-y-1',
+                  isActive ? 'bg-[#FFE6F0]' : 'bg-white',
+                )}
+              >
+                <span className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-[#FF8A65] px-3 py-1 text-xs font-black uppercase tracking-wide text-black">
+                  <NotebookPen className="h-4 w-4" aria-hidden="true" />
+                  {isActive ? 'In your plan' : 'Contribution'}
+                </span>
+                <h3 className="text-xl font-black text-gray-900">{option.title}</h3>
+                <p className="text-sm font-medium text-gray-700">{option.description}</p>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="rounded-3xl border-2 border-black bg-[#F6EDE3] p-5 shadow-[10px_10px_0px_0px_rgba(0,0,0,0.15)]">
+        <h3 className="flex items-center gap-2 text-lg font-black text-gray-900">
+          <Sparkles className="h-5 w-5 text-[#6C63FF]" aria-hidden="true" />
+          Learning signals
+        </h3>
+        <p className="mt-2 text-sm font-medium text-gray-700">
+          Pick the delivery formats that keep you motivated and in flow.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          {learningFormatOptions.map((option) => {
+            const isActive = responses.preferredLearningFormats.includes(option.value);
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  toggleLearningFormat(option.value);
+                  setError(null);
+                }}
+                className={cn(
+                  'rounded-full border-2 border-black bg-white px-4 py-2 text-left text-sm font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,0.15)] transition-transform hover:-translate-y-[1px]',
+                  isActive ? 'bg-[#6C63FF] text-white' : 'bg-white text-gray-900',
+                )}
+              >
+                <span className="block text-xs font-black uppercase tracking-wide text-gray-500">
+                  {option.label}
+                </span>
+                <span className="block text-xs font-semibold text-gray-700">
+                  {option.description}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderSupportStep = () => (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-black text-gray-900">How can we support your momentum?</h3>
+        <p className="mt-1 text-sm font-medium text-gray-600">
+          Signal the experiences that would unblock you—we coordinate programming around real member needs.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          {supportOptions.map((option) => {
+            const isActive = responses.supportPreferences.includes(option.value);
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  toggleSupportPreference(option.value);
+                  setError(null);
+                }}
+                className={cn(
+                  'rounded-2xl border-2 border-black bg-white px-4 py-3 text-left text-sm font-semibold shadow-[6px_6px_0px_0px_rgba(0,0,0,0.12)] transition-transform hover:-translate-y-[1px]',
+                  isActive ? 'bg-[#D7F8E4]' : 'bg-white',
+                )}
+              >
+                <span className="block text-xs font-black uppercase tracking-wide text-[#2E7D32]">
+                  {isActive ? 'Priority' : 'Support'}
+                </span>
+                <span className="block text-sm font-bold text-gray-900">{option.label}</span>
+                <span className="block text-xs font-medium text-gray-600">{option.description}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {accountabilityOptions.map((option) => {
+          const isActive = responses.accountabilityStyle === option.value;
+
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => {
+                setResponses((previous) => ({
+                  ...previous,
+                  accountabilityStyle: previous.accountabilityStyle === option.value ? null : option.value,
+                }));
+                setError(null);
+              }}
+              className={cn(
+                'flex h-full flex-col items-start gap-3 rounded-3xl border-2 border-black bg-white p-5 text-left shadow-[8px_8px_0px_0px_rgba(0,0,0,0.12)] transition-transform hover:-translate-y-1',
+                isActive ? 'bg-[#FFF5D1]' : 'bg-white',
+              )}
+            >
+              <span className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-[#FFD66B] px-3 py-1 text-xs font-black uppercase tracking-wide text-black">
+                <Target className="h-4 w-4" aria-hidden="true" />
+                {isActive ? 'Your flow' : 'Accountability'}
+              </span>
+              <h3 className="text-xl font-black text-gray-900">{option.label}</h3>
+              <p className="text-sm font-medium text-gray-700">{option.description}</p>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="rounded-3xl border-2 border-black bg-white p-5 shadow-[10px_10px_0px_0px_rgba(0,0,0,0.12)]">
+        <h3 className="flex items-center gap-2 text-lg font-black text-gray-900">
+          <CalendarCheck2 className="h-5 w-5 text-[#6C63FF]" aria-hidden="true" />
+          Communication cadence
+        </h3>
+        <p className="mt-2 text-sm font-medium text-gray-600">
+          Choose the touchpoints you actually want to receive—no noise, just relevance.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          {communicationOptions.map((option) => {
+            const isActive = responses.communicationPreferences.includes(option.value);
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  toggleCommunicationPreference(option.value);
+                  setError(null);
+                }}
+                className={cn(
+                  'rounded-full border-2 border-black bg-white px-4 py-2 text-left text-sm font-bold shadow-[4px_4px_0px_0px_rgba(0,0,0,0.15)] transition-transform hover:-translate-y-[1px]',
+                  isActive ? 'bg-[#6C63FF] text-white' : 'bg-white text-gray-900',
+                )}
+              >
+                <span className="block text-xs font-black uppercase tracking-wide text-gray-500">
+                  {option.label}
+                </span>
+                <span className="block text-xs font-semibold text-gray-700">
+                  {option.description}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderSummaryStep = () => (
+    <div className="space-y-6">
+      <div className="rounded-3xl border-2 border-black bg-[#E8F8FF] p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.15)]">
+        <h3 className="flex items-center gap-2 text-lg font-black text-gray-900">
+          <CheckCircle2 className="h-5 w-5 text-[#2E7D32]" aria-hidden="true" />
+          Ready to roll
+        </h3>
+        <p className="mt-2 text-sm font-medium text-gray-700">
+          Your dashboard, notifications, and invitations will now reflect what you told us matters most.
+        </p>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="rounded-3xl border-2 border-black bg-white p-5 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.12)]">
+          <h4 className="text-base font-black uppercase tracking-wide text-gray-500">Persona</h4>
+          <p className="mt-2 text-xl font-black text-gray-900">
+            {personaOptions.find((option) => option.value === responses.persona)?.title ?? '—'}
+          </p>
+          <p className="mt-1 text-sm font-medium text-gray-600">
+            {experienceOptions.find((option) => option.value === responses.experienceLevel)?.label ?? '—'}
+          </p>
+        </div>
+
+        <div className="rounded-3xl border-2 border-black bg-white p-5 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.12)]">
+          <h4 className="text-base font-black uppercase tracking-wide text-gray-500">Primary goals</h4>
+          <ul className="mt-2 space-y-2 text-sm font-semibold text-gray-700">
+            {responses.motivations.map((goal) => {
+              const detail = goalOptions.find((option) => option.value === goal);
+              return (
+                <li key={goal} className="flex items-center gap-2">
+                  <Check className="h-4 w-4 text-[#6C63FF]" aria-hidden="true" />
+                  {detail?.title ?? goal}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        <div className="rounded-3xl border-2 border-black bg-white p-5 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.12)]">
+          <h4 className="text-base font-black uppercase tracking-wide text-gray-500">Contribution focus</h4>
+          <ul className="mt-2 space-y-2 text-sm font-semibold text-gray-700">
+            {responses.focusAreas.map((item) => {
+              const detail = contributionOptions.find((option) => option.value === item);
+              return (
+                <li key={item} className="flex items-center gap-2">
+                  <NotebookPen className="h-4 w-4 text-[#FF8A65]" aria-hidden="true" />
+                  {detail?.title ?? item}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        <div className="rounded-3xl border-2 border-black bg-white p-5 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.12)]">
+          <h4 className="text-base font-black uppercase tracking-wide text-gray-500">Preferred support</h4>
+          <ul className="mt-2 space-y-2 text-sm font-semibold text-gray-700">
+            {responses.supportPreferences.map((item) => {
+              const detail = supportOptions.find((option) => option.value === item);
+              return (
+                <li key={item} className="flex items-center gap-2">
+                  <Target className="h-4 w-4 text-[#2E7D32]" aria-hidden="true" />
+                  {detail?.label ?? item}
+                </li>
+              );
+            })}
+          </ul>
+          <div className="mt-4 rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-3 text-sm font-semibold text-gray-600">
+            Accountability: {accountabilityOptions.find((option) => option.value === responses.accountabilityStyle)?.label ?? '—'}
+          </div>
+          <div className="mt-3 rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-3 text-sm font-semibold text-gray-600">
+            Updates: {responses.communicationPreferences.length > 0 ? responses.communicationPreferences.map((item) => communicationOptions.find((option) => option.value === item)?.label ?? item).join(', ') : '—'}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="neo-brutalism min-h-screen bg-gradient-to-br from-[#FFF5F1] via-[#F8F0FF] to-[#E3F2FF] px-4 py-10">
+      <div className="mx-auto w-full max-w-5xl">
+        <div className="rounded-[32px] border-4 border-black bg-white shadow-[18px_18px_0px_0px_rgba(0,0,0,0.2)]">
+          <div className="border-b-4 border-black bg-[#F6EDE3] p-6">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div className="flex items-center gap-4">
+                <div className="relative h-14 w-14 overflow-hidden rounded-full border-2 border-black bg-white">
+                  {profile.avatarUrl ? (
+                    <Image src={profile.avatarUrl} alt={profile.displayName} fill className="object-cover" sizes="56px" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center bg-[#FFD66B] text-lg font-black uppercase text-black">
+                      {profile.displayName.slice(0, 1).toUpperCase()}
+                    </div>
+                  )}
+                </div>
+                <div>
+                  <p className="text-xs font-black uppercase tracking-[0.3em] text-gray-500">Syntax &amp; Sips onboarding</p>
+                  <h1 className="text-2xl font-black text-gray-900">Welcome, {profile.displayName.split(' ')[0] ?? profile.displayName}!</h1>
+                  <p className="text-sm font-semibold text-gray-600">We are configuring your personal dashboard and community access.</p>
+                </div>
+              </div>
+              <div className="flex flex-col items-end gap-2">
+                <div className="flex items-center gap-2 text-xs font-black uppercase tracking-wide text-gray-600">
+                  <span className="inline-flex h-2 w-2 rounded-full bg-[#6C63FF]" aria-hidden="true" />
+                  Step {currentStepIndex + 1} of {stepOrder.length}
+                </div>
+                <div className="h-2 w-48 overflow-hidden rounded-full border-2 border-black bg-white">
+                  <div className="h-full bg-[#6C63FF]" style={{ width: `${Math.min(progressPercentage, 100)}%` }} />
+                </div>
+                <button
+                  type="button"
+                  onClick={handleSkip}
+                  className="text-xs font-bold uppercase tracking-wide text-[#6C63FF] underline"
+                >
+                  Save &amp; continue later
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-6 p-6">
+            <div className="rounded-3xl border-2 border-black bg-white p-5 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.15)]">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                  <p className="text-xs font-black uppercase tracking-[0.3em] text-[#6C63FF]">{currentStep === 'summary' ? 'Review' : 'Discovery'}</p>
+                  <h2 className="text-2xl font-black text-gray-900">
+                    {currentStep === 'persona'
+                      ? 'Know thy member'
+                      : currentStep === 'outcomes'
+                      ? 'Define your wins'
+                      : currentStep === 'enablement'
+                      ? 'Design your playbook'
+                      : currentStep === 'support'
+                      ? 'Set your support system'
+                      : 'Your personalized launch plan'}
+                  </h2>
+                  <p className="mt-1 text-sm font-medium text-gray-600">
+                    {currentStep === 'persona'
+                      ? 'Tell us who you are so we can tailor everything from tone to templates.'
+                      : currentStep === 'outcomes'
+                      ? 'Highlight the outcomes that will prove Syntax & Sips was worth your time.'
+                      : currentStep === 'enablement'
+                      ? 'Pick the creative muscles you want to flex so we can line up the right opportunities.'
+                      : currentStep === 'support'
+                      ? 'Share how we should champion you and what signals to send.'
+                      : 'Review your answers—change anything before we lock them in.'}
+                  </p>
+                </div>
+                <div className="rounded-2xl border-2 border-dashed border-gray-300 bg-gray-50 p-4 text-sm font-semibold text-gray-600">
+                  We will revisit this during retros. You can update preferences anytime from your account dashboard.
+                </div>
+              </div>
+            </div>
+
+            {error ? (
+              <div className="rounded-2xl border-2 border-red-500 bg-red-100 p-4 text-sm font-semibold text-red-700" role="alert">
+                {error}
+              </div>
+            ) : null}
+
+            {successMessage ? (
+              <div className="rounded-2xl border-2 border-emerald-500 bg-emerald-100 p-4 text-sm font-semibold text-emerald-700" role="status">
+                {successMessage}
+              </div>
+            ) : null}
+
+            <div>
+              {currentStep === 'persona'
+                ? renderPersonaStep()
+                : currentStep === 'outcomes'
+                ? renderOutcomeStep()
+                : currentStep === 'enablement'
+                ? renderEnablementStep()
+                : currentStep === 'support'
+                ? renderSupportStep()
+                : renderSummaryStep()}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-3 border-t-4 border-black bg-[#F6EDE3] p-6">
+            <button
+              type="button"
+              onClick={handleBack}
+              disabled={currentStepIndex === 0 || isSaving}
+              className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-white px-4 py-2 text-sm font-black uppercase tracking-wide text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,0.15)] disabled:opacity-50"
+            >
+              <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+              Back
+            </button>
+
+            {currentStep === 'summary' ? (
+              <button
+                type="button"
+                onClick={handleFinish}
+                disabled={isSaving}
+                className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-[#6C63FF] px-6 py-3 text-sm font-black uppercase tracking-wide text-white shadow-[6px_6px_0px_0px_rgba(0,0,0,0.2)] disabled:opacity-60"
+              >
+                {isSaving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <CheckCircle2 className="h-4 w-4" aria-hidden="true" />}
+                Confirm &amp; launch dashboard
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleNext}
+                disabled={isSaving}
+                className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-[#FF8A65] px-6 py-3 text-sm font-black uppercase tracking-wide text-black shadow-[6px_6px_0px_0px_rgba(0,0,0,0.2)] disabled:opacity-60"
+              >
+                {isSaving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <ArrowRight className="h-4 w-4" aria-hidden="true" />}
+                Save &amp; continue
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/auth/UserAccountPanel.tsx
+++ b/src/components/auth/UserAccountPanel.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import type { LucideIcon } from 'lucide-react'
 import {
   Activity,
@@ -344,7 +345,10 @@ const renderRuleBadge = (status: RuleStatus) => {
 }
 
 const RuleCard = ({ title, description, status }: RuleItem) => (
-  <div className="rounded-2xl border-2 border-black bg-white p-4 shadow-[6px_6px_0px_0px_rgba(0,0,0,0.12)]">
+  <div
+    className="rounded-2xl border-2 border-black bg-white p-4 shadow-[6px_6px_0px_0px_rgba(0,0,0,0.12)]"
+    title={description}
+  >
     <div className="flex items-start justify-between gap-3">
       <div>
         <p className="text-base font-extrabold leading-tight text-gray-900">{title}</p>
@@ -369,6 +373,7 @@ const StatCard = ({
   <div
     className="rounded-3xl border-2 border-black bg-white p-5 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.18)]"
     style={{ boxShadow: `8px 8px 0 0 ${accent}` }}
+    title={helper}
   >
     <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">{label}</p>
     <p className="mt-3 text-4xl font-black text-gray-900">{value.toLocaleString('en-US')}</p>
@@ -398,7 +403,10 @@ const ContributionCard = ({
     <article className="rounded-2xl border-2 border-black bg-white p-4 shadow-[5px_5px_0px_0px_rgba(0,0,0,0.15)]">
       <div className="flex items-start justify-between gap-3">
         <div className="space-y-1">
-          <div className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ${badgeClass}`}>
+          <div
+            className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ${badgeClass}`}
+            title={badgeLabel}
+          >
             <FileText className="h-3.5 w-3.5" aria-hidden="true" />
             {badgeLabel}
           </div>
@@ -447,7 +455,10 @@ const CommentCard = ({ comment }: { comment: UserCommentSummary }) => {
     <article className="rounded-2xl border-2 border-black bg-white p-4 shadow-[5px_5px_0px_0px_rgba(0,0,0,0.15)]">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="space-y-2">
-          <div className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ${badgeClass}`}>
+          <div
+            className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ${badgeClass}`}
+            title={badgeLabel}
+          >
             <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />
             {badgeLabel}
           </div>
@@ -507,7 +518,10 @@ const SidebarAvatar = ({
 const StatusBadge = ({ status }: { status: CapabilityStatus }) => {
   if (status === 'available') {
     return (
-      <span className="inline-flex items-center gap-1 rounded-full border-2 border-emerald-500 bg-emerald-100 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-emerald-700">
+      <span
+        className="inline-flex items-center gap-1 rounded-full border-2 border-emerald-500 bg-emerald-100 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-emerald-700"
+        title="Feature enabled"
+      >
         <CheckCircle2 className="h-3 w-3" aria-hidden="true" /> Enabled
       </span>
     )
@@ -515,21 +529,30 @@ const StatusBadge = ({ status }: { status: CapabilityStatus }) => {
 
   if (status === 'locked') {
     return (
-      <span className="inline-flex items-center gap-1 rounded-full border-2 border-gray-400 bg-gray-100 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-gray-600">
+      <span
+        className="inline-flex items-center gap-1 rounded-full border-2 border-gray-400 bg-gray-100 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-gray-600"
+        title="Feature locked"
+      >
         Locked
       </span>
     )
   }
 
   return (
-    <span className="inline-flex items-center gap-1 rounded-full border-2 border-blue-400 bg-blue-100 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-blue-700">
+    <span
+      className="inline-flex items-center gap-1 rounded-full border-2 border-blue-400 bg-blue-100 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-blue-700"
+      title="Feature coming soon"
+    >
       Upcoming
     </span>
   )
 }
 
 const CapabilityCard = ({ title, description, icon: Icon, status, ctaHref, ctaLabel }: CapabilityItem) => (
-  <div className="rounded-3xl border-2 border-black bg-white p-5 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.15)]">
+  <div
+    className="rounded-3xl border-2 border-black bg-white p-5 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.15)]"
+    title={description}
+  >
     <div className="flex items-start justify-between gap-3">
       <div className="flex items-start gap-3">
         <span className="inline-flex h-11 w-11 items-center justify-center rounded-2xl border-2 border-black bg-[#F5F3FF] text-[#6C63FF]">
@@ -546,6 +569,7 @@ const CapabilityCard = ({ title, description, icon: Icon, status, ctaHref, ctaLa
       <Link
         href={ctaHref}
         className="mt-4 inline-flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-[#6C63FF] hover:underline"
+        title={ctaLabel}
       >
         {ctaLabel} <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
       </Link>
@@ -562,8 +586,8 @@ const AccountSidebar = ({
   totals: UserContributionSnapshot['totals']
   sections: SidebarSection[]
 }) => (
-  <aside className="lg:w-72 xl:w-80">
-    <div className="sticky top-6 space-y-6">
+  <aside className="mb-6 w-full lg:mb-0 lg:w-[320px] xl:w-[360px]">
+    <div className="space-y-6 lg:sticky lg:top-6">
       <div className="rounded-3xl border-4 border-black bg-white p-5 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.18)]">
         <div className="flex items-center gap-4">
           <SidebarAvatar name={profile.displayName} avatarUrl={profile.avatarUrl} />
@@ -575,12 +599,18 @@ const AccountSidebar = ({
             </p>
           </div>
         </div>
-        <div className="mt-4 grid grid-cols-2 gap-3 text-center">
-          <div className="rounded-2xl border-2 border-black bg-[#F6EDE3] px-3 py-2">
+        <div className="mt-4 grid grid-cols-2 gap-4 text-center">
+          <div
+            className="rounded-2xl border-2 border-black bg-[#F6EDE3] px-3 py-2"
+            title="Published posts"
+          >
             <p className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-600">Posts</p>
             <p className="text-xl font-black text-gray-900">{totals.publishedPosts}</p>
           </div>
-          <div className="rounded-2xl border-2 border-black bg-[#E8F5FF] px-3 py-2">
+          <div
+            className="rounded-2xl border-2 border-black bg-[#E8F5FF] px-3 py-2"
+            title="Total comments contributed"
+          >
             <p className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-600">Comments</p>
             <p className="text-xl font-black text-gray-900">{totals.totalComments}</p>
           </div>
@@ -594,6 +624,7 @@ const AccountSidebar = ({
               <a
                 href={`#${section.id}`}
                 className="group flex items-center gap-3 rounded-2xl border-2 border-transparent px-3 py-2 text-sm font-bold text-gray-800 transition hover:border-black hover:bg-[#F5F3FF]"
+                title={`Jump to ${section.label}`}
               >
                 <section.icon className="h-4 w-4 text-[#6C63FF] transition group-hover:scale-110" aria-hidden="true" />
                 {section.label}
@@ -606,18 +637,30 @@ const AccountSidebar = ({
         <p className="text-sm font-black uppercase tracking-[0.25em] opacity-70">Shortcuts</p>
         <ul className="mt-4 space-y-3 text-sm font-semibold">
           <li>
-            <Link href="/blogs" className="inline-flex items-center gap-2 text-[#FFD66B] hover:underline">
+            <Link
+              href="/blogs"
+              className="inline-flex items-center gap-2 text-[#FFD66B] hover:underline"
+              title="Browse the latest articles"
+            >
               Browse editorial feed <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
             </Link>
           </li>
           <li>
-            <Link href="#publishing" className="inline-flex items-center gap-2 text-[#6C63FF] hover:underline">
+            <Link
+              href="#publishing"
+              className="inline-flex items-center gap-2 text-[#6C63FF] hover:underline"
+              title="Jump to publishing insights"
+            >
               Check drafting stats <Activity className="h-3.5 w-3.5" aria-hidden="true" />
             </Link>
           </li>
           {profile.isAdmin ? (
             <li>
-              <Link href="/admin" className="inline-flex items-center gap-2 text-[#7CFBFF] hover:underline">
+              <Link
+                href="/admin"
+                className="inline-flex items-center gap-2 text-[#7CFBFF] hover:underline"
+                title="Launch the admin console"
+              >
                 Review newsroom queue <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
               </Link>
             </li>
@@ -920,7 +963,11 @@ const ProfileIdentityManager = ({
 
 export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelProps) => {
   const { refresh: refreshAuthenticatedProfile } = useAuthenticatedProfile()
+  const router = useRouter()
+  const supabase = useMemo(() => createBrowserClient(), [])
   const [currentProfile, setCurrentProfile] = useState(profile)
+  const [isSigningOut, setIsSigningOut] = useState(false)
+  const [signOutError, setSignOutError] = useState<string | null>(null)
 
   useEffect(() => {
     setCurrentProfile(profile)
@@ -933,6 +980,28 @@ export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelPro
       null,
     [currentProfile.primaryRoleId, currentProfile.roles],
   )
+
+  const handleSignOut = useCallback(async () => {
+    setIsSigningOut(true)
+    setSignOutError(null)
+
+    try {
+      const { error } = await supabase.auth.signOut()
+
+      if (error) {
+        throw error
+      }
+
+      await refreshAuthenticatedProfile().catch(() => {})
+      router.push('/')
+      router.refresh()
+    } catch (error) {
+      console.error('Failed to sign out', error)
+      setSignOutError('Unable to sign out right now. Please try again in a moment.')
+    } finally {
+      setIsSigningOut(false)
+    }
+  }, [refreshAuthenticatedProfile, router, supabase])
 
   const activity = useMemo(
     () => buildActivity(contributions.posts, contributions.comments),
@@ -1136,16 +1205,20 @@ export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelPro
     [],
   )
 
-  const heroGreeting = `Bonjour ${
-    currentProfile.displayName.split(' ')[0] ?? currentProfile.displayName
-  },`
+  const greetingSource = currentProfile.displayName?.trim().length
+    ? currentProfile.displayName.trim()
+    : currentProfile.email
+  const greetingFirstWord = greetingSource.split(' ')[0] ?? greetingSource
+  const heroGreeting = `नमस्ते ${greetingFirstWord}!`
 
   return (
-    <div className="neo-brutalism min-h-screen bg-gradient-to-br from-[#FFF5F1] via-[#F8F0FF] to-[#E3F2FF] px-4 py-10">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 lg:flex-row">
-        <AccountSidebar profile={currentProfile} totals={contributions.totals} sections={navigationSections} />
+    <div className="neo-brutalism min-h-screen bg-gradient-to-br from-[#FFF5F1] via-[#F8F0FF] to-[#E3F2FF] px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto grid w-full max-w-7xl gap-10 lg:grid-cols-[320px_minmax(0,1fr)] lg:items-start lg:gap-12 xl:gap-16">
+        <div className="lg:self-start">
+          <AccountSidebar profile={currentProfile} totals={contributions.totals} sections={navigationSections} />
+        </div>
 
-        <div className="flex-1 space-y-16">
+        <div className="space-y-16">
           <section id="overview" className="scroll-mt-28 space-y-6">
             <SectionHeader
               eyebrow="Overview"
@@ -1179,7 +1252,7 @@ export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelPro
                 </div>
               </div>
 
-              <div className="mt-8 grid gap-4 md:grid-cols-3">
+              <div className="mt-8 grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
                 <div className="rounded-2xl border-2 border-black bg-[#6C63FF] p-4 text-white shadow-[8px_8px_0px_0px_rgba(108,99,255,0.35)]">
                   <p className="text-xs font-black uppercase tracking-[0.2em] opacity-80">Account email</p>
                   <p className="mt-2 break-all text-lg font-bold">{currentProfile.email}</p>
@@ -1227,7 +1300,7 @@ export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelPro
               </div>
             </div>
 
-            <div className="mt-8 grid gap-4 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+            <div className="mt-8 grid gap-6 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
               <div className="rounded-3xl border-2 border-black bg-white p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.15)]">
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
@@ -1394,7 +1467,7 @@ export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelPro
               </div>
             </div>
 
-            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
               <StatCard
                 label="Published pieces"
                 value={contributions.totals.publishedPosts}
@@ -1435,7 +1508,7 @@ export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelPro
               onRefreshRequested={refreshAuthenticatedProfile}
             />
 
-            <div className="grid gap-4 lg:grid-cols-2">
+            <div className="grid gap-6 lg:grid-cols-2">
               <div className="rounded-[28px] border-4 border-black bg-white p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.18)]">
                 <h3 className="text-xl font-black text-gray-900">Account access</h3>
                 <p className="mt-2 text-sm font-medium text-gray-600">
@@ -1452,6 +1525,25 @@ export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelPro
                 <p className="mt-3 rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-4 text-xs font-semibold uppercase tracking-wide text-gray-600">
                   Session stays active until you sign out. Close your browser without worry—your reading queue and drafts follow you.
                 </p>
+                <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <button
+                    type="button"
+                    onClick={handleSignOut}
+                    disabled={isSigningOut}
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-md border-2 border-black bg-[#FF5252] px-4 py-2 text-sm font-black uppercase tracking-wide text-white shadow-[4px_4px_0px_0px_rgba(0,0,0,0.2)] transition hover:-translate-y-[1px] disabled:cursor-not-allowed disabled:opacity-70 sm:w-auto"
+                    title="Sign out of your Syntax &amp; Sips account"
+                  >
+                    {isSigningOut ? 'Signing out…' : 'Sign out securely'}
+                  </button>
+                  <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Need to switch accounts? Sign out first.
+                  </span>
+                </div>
+                {signOutError ? (
+                  <p className="mt-3 rounded-2xl border-2 border-red-400 bg-red-50 px-4 py-2 text-xs font-semibold text-red-700">
+                    {signOutError}
+                  </p>
+                ) : null}
                 {currentProfile.isAdmin ? (
                   <Link
                     href="/admin"
@@ -1489,7 +1581,7 @@ export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelPro
             />
 
             {contributions.posts.length > 0 ? (
-              <div className="grid gap-4 lg:grid-cols-2">
+              <div className="grid gap-6 lg:grid-cols-2">
                 {contributions.posts.slice(0, 6).map((post) => (
                   <ContributionCard key={post.id} post={post} />
                 ))}
@@ -1508,7 +1600,7 @@ export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelPro
               description="Keep tabs on discussions you have started and how moderators responded to your contributions."
             />
 
-            <div className="grid gap-4 lg:grid-cols-2">
+            <div className="grid gap-6 lg:grid-cols-2">
               <div className="space-y-4">
                 <h3 className="text-lg font-black text-gray-900">Recent comments</h3>
                 {contributions.comments.length > 0 ? (
@@ -1596,7 +1688,7 @@ export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelPro
               description="A quick reference of powers already unlocked and features coming soon for your membership tier."
             />
 
-            <div className="grid gap-4 md:grid-cols-2">
+            <div className="grid gap-6 md:grid-cols-2">
               {capabilities.map((capability) => (
                 <CapabilityCard key={capability.title} {...capability} />
               ))}
@@ -1664,7 +1756,7 @@ export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelPro
               description="Need a refresher on guidelines or a human to chat with? Start here to find the right channel."
             />
 
-            <div className="grid gap-4 lg:grid-cols-3">
+            <div className="grid gap-6 lg:grid-cols-3">
               <div className="rounded-3xl border-2 border-black bg-white p-5 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.15)]">
                 <h3 className="flex items-center gap-2 text-lg font-black text-gray-900">
                   <NotebookPen className="h-5 w-5 text-[#6C63FF]" aria-hidden="true" />

--- a/src/components/auth/UserAccountPanel.tsx
+++ b/src/components/auth/UserAccountPanel.tsx
@@ -317,8 +317,10 @@ const computeOnboardingProgress = (journey: ProfileOnboardingJourney | null) => 
   return 0
 }
 
-const formatOnboardingList = <T extends string>(values: T[], dictionary: Record<T, string>) =>
-  values.map((value) => dictionary[value] ?? value)
+const formatOnboardingList = <T extends string>(
+  values: ReadonlyArray<T> | null | undefined,
+  dictionary: Record<T, string>,
+) => (values ?? []).map((value) => dictionary[value] ?? value)
 
 const renderRuleBadge = (status: RuleStatus) => {
   if (status === 'complete') {

--- a/src/components/auth/UserAccountPanel.tsx
+++ b/src/components/auth/UserAccountPanel.tsx
@@ -1,99 +1,1722 @@
-"use client";
+'use client'
 
-import { useMemo, useState } from 'react';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { createBrowserClient } from '@/lib/supabase/client';
-import { syncAuthState } from '@/lib/supabase/sync-auth-state';
-import '@/styles/neo-brutalism.css';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import type { LucideIcon } from 'lucide-react'
+import {
+  Activity,
+  AlertTriangle,
+  ArrowRight,
+  Award,
+  CalendarCheck2,
+  CheckCircle2,
+  Clock3,
+  Compass,
+  ExternalLink,
+  FileText,
+  Goal,
+  IdCard,
+  LifeBuoy,
+  MessageCircle,
+  NotebookPen,
+  PenSquare,
+  Scale,
+  ShieldCheck,
+  Sparkles,
+  Target,
+  UserRound,
+  UsersRound,
+} from 'lucide-react'
+import type {
+  AuthenticatedProfileSummary,
+  OnboardingAccountability,
+  OnboardingCommunication,
+  OnboardingContribution,
+  OnboardingExperienceLevel,
+  OnboardingGoal,
+  OnboardingLearningFormat,
+  OnboardingPersona,
+  OnboardingSupportPreference,
+  ProfileOnboardingJourney,
+  ProfileOnboardingResponses,
+  UserCommentSummary,
+  UserContributionSnapshot,
+  UserPostSummary,
+} from '@/utils/types'
+import { CommentStatus, PostStatus } from '@/utils/types'
+import { createBrowserClient } from '@/lib/supabase/client'
+import { useAuthenticatedProfile } from '@/hooks/useAuthenticatedProfile'
+import '@/styles/neo-brutalism.css'
 
 interface UserAccountPanelProps {
-  email: string;
-  displayName: string;
-  isAdmin: boolean;
+  profile: AuthenticatedProfileSummary
+  contributions: UserContributionSnapshot
 }
 
-export const UserAccountPanel = ({ email, displayName, isAdmin }: UserAccountPanelProps) => {
-  const router = useRouter();
-  const supabase = useMemo(() => createBrowserClient(), []);
-  const [error, setError] = useState('');
-  const [isSigningOut, setIsSigningOut] = useState(false);
+type RuleStatus = 'complete' | 'pending' | 'attention'
 
-  const handleSignOut = async () => {
-    setError('');
-    setIsSigningOut(true);
+interface RuleItem {
+  title: string
+  description: string
+  status: RuleStatus
+}
 
-    const { error: signOutError } = await supabase.auth.signOut();
+interface ActivityEntry {
+  id: string
+  type: 'post' | 'comment'
+  title: string
+  description: string
+  timestamp: string | null
+  href?: string | null
+  statusLabel: string
+  badgeTone: 'purple' | 'blue' | 'orange' | 'emerald' | 'red'
+  excerpt?: string
+}
 
-    if (signOutError) {
-      setError(signOutError.message);
-      setIsSigningOut(false);
-      return;
+interface SidebarSection {
+  id: string
+  label: string
+  icon: LucideIcon
+}
+
+type CapabilityStatus = 'available' | 'locked' | 'upcoming'
+
+interface CapabilityItem {
+  title: string
+  description: string
+  icon: LucideIcon
+  status: CapabilityStatus
+  ctaHref?: string
+  ctaLabel?: string
+}
+
+type StatusTone = 'success' | 'error'
+
+interface StatusMessage {
+  tone: StatusTone
+  message: string
+}
+
+const formatDate = (iso: string | null) => {
+  if (!iso) return '—'
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) {
+    return '—'
+  }
+  return new Intl.DateTimeFormat('en', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date)
+}
+
+const relativeTimeFormatter = new Intl.RelativeTimeFormat('en', {
+  numeric: 'auto',
+})
+
+const relativeUnits: Array<{ unit: Intl.RelativeTimeFormatUnit; ms: number }> = [
+  { unit: 'year', ms: 1000 * 60 * 60 * 24 * 365 },
+  { unit: 'month', ms: 1000 * 60 * 60 * 24 * 30 },
+  { unit: 'day', ms: 1000 * 60 * 60 * 24 },
+  { unit: 'hour', ms: 1000 * 60 * 60 },
+  { unit: 'minute', ms: 1000 * 60 },
+]
+
+const formatRelative = (iso: string | null) => {
+  if (!iso) return '—'
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) {
+    return '—'
+  }
+
+  const diffMs = Date.now() - date.getTime()
+
+  for (const { unit, ms } of relativeUnits) {
+    if (Math.abs(diffMs) >= ms || unit === 'minute') {
+      const value = Math.round(diffMs / ms)
+      return relativeTimeFormatter.format(-value, unit)
     }
+  }
 
-    await syncAuthState('SIGNED_OUT', null);
-    router.replace('/login');
-  };
+  return 'just now'
+}
+
+const buildActivity = (
+  posts: UserPostSummary[],
+  comments: UserCommentSummary[],
+): ActivityEntry[] => {
+  const entries: ActivityEntry[] = []
+
+  for (const post of posts) {
+    const isPublished = post.status === PostStatus.PUBLISHED
+    entries.push({
+      id: `post-${post.id}`,
+      type: 'post',
+      title: post.title,
+      description: isPublished ? 'Published article' : 'Draft in progress',
+      timestamp: post.publishedAt ?? post.createdAt,
+      href: post.slug ? `/blogs/${post.slug}` : null,
+      statusLabel:
+        post.status === PostStatus.DRAFT
+          ? 'Draft'
+          : post.status === PostStatus.SCHEDULED
+          ? 'Scheduled'
+          : 'Published',
+      badgeTone:
+        post.status === PostStatus.DRAFT
+          ? 'orange'
+          : post.status === PostStatus.SCHEDULED
+          ? 'blue'
+          : 'emerald',
+      excerpt: isPublished
+        ? `Read count: ${post.views.toLocaleString('en-US')}`
+        : 'Finalize your edits to share this story.',
+    })
+  }
+
+  for (const comment of comments) {
+    entries.push({
+      id: `comment-${comment.id}`,
+      type: 'comment',
+      title: comment.postTitle ?? 'Community conversation',
+      description:
+        comment.status === CommentStatus.APPROVED
+          ? 'Comment approved'
+          : comment.status === CommentStatus.REJECTED
+          ? 'Comment rejected'
+          : 'Awaiting moderator review',
+      timestamp: comment.createdAt,
+      href: comment.postSlug ? `/blogs/${comment.postSlug}#comments` : null,
+      statusLabel:
+        comment.status === CommentStatus.APPROVED
+          ? 'Approved'
+          : comment.status === CommentStatus.REJECTED
+          ? 'Rejected'
+          : 'Pending',
+      badgeTone:
+        comment.status === CommentStatus.APPROVED
+          ? 'emerald'
+          : comment.status === CommentStatus.REJECTED
+          ? 'red'
+          : 'orange',
+      excerpt: comment.content,
+    })
+  }
+
+  return entries
+    .filter((entry) => Boolean(entry.timestamp))
+    .sort((a, b) => {
+      const aTime = new Date(a.timestamp ?? 0).getTime()
+      const bTime = new Date(b.timestamp ?? 0).getTime()
+      return bTime - aTime
+    })
+    .slice(0, 8)
+}
+
+const onboardingPersonaDictionary: Record<OnboardingPersona, { title: string; summary: string }> = {
+  'learning-explorer': {
+    title: 'Curious explorer',
+    summary: 'Scans emerging research, tools, and ideas to stay ahead of the curve.',
+  },
+  'hands-on-builder': {
+    title: 'Hands-on builder',
+    summary: 'Learns by prototyping quickly and sharing practical discoveries.',
+  },
+  'community-connector': {
+    title: 'Community connector',
+    summary: 'Curates resources, sparks conversations, and energises the community.',
+  },
+  'career-switcher': {
+    title: 'Career switcher',
+    summary: 'Pivoting into AI/ML with a need for guided pathways and peers.',
+  },
+  'team-enabler': {
+    title: 'Team enabler',
+    summary: 'Coaches squads and needs signal to guide and unblock the crew.',
+  },
+}
+
+const onboardingExperienceDictionary: Record<OnboardingExperienceLevel, string> = {
+  'early-career': 'Early career (0-2 years in AI/ML)',
+  'mid-level': 'Practicing contributor',
+  'senior-practitioner': 'Senior practitioner',
+  'strategic-leader': 'Strategic leader',
+}
+
+const onboardingGoalDictionary: Record<OnboardingGoal, string> = {
+  'publish-signature-series': 'Publish a signature series',
+  'grow-technical-voice': 'Grow your technical voice',
+  'level-up-ai-skills': 'Level up AI & ML skills',
+  'ship-side-projects': 'Ship side projects faster',
+  'find-peers': 'Meet collaborators & peers',
+  'transition-role': 'Transition into a new role',
+}
+
+const onboardingContributionDictionary: Record<OnboardingContribution, string> = {
+  'write-articles': 'Long-form articles',
+  'share-code-snippets': 'Code walkthroughs & repos',
+  'host-events': 'Live sessions & events',
+  'produce-videos': 'Video & podcast experiments',
+  'mentor-community': 'Mentorship & feedback',
+}
+
+const onboardingLearningDictionary: Record<OnboardingLearningFormat, string> = {
+  'deep-dives': 'Deep dives',
+  'quick-tips': 'Quick tips',
+  'live-builds': 'Live builds',
+  'case-studies': 'Case studies',
+  'audio-notes': 'Audio notes',
+}
+
+const onboardingSupportDictionary: Record<OnboardingSupportPreference, string> = {
+  'editorial-reviews': 'Editorial reviews',
+  'pair-programming': 'Pair programming jams',
+  'career-coaching': 'Career strategy chats',
+  'community-challenges': 'Community challenges',
+  'office-hours': 'Office hours & AMAs',
+}
+
+const onboardingCommunicationDictionary: Record<OnboardingCommunication, string> = {
+  'weekly-digest': 'Weekly digest',
+  'event-reminders': 'Event reminders',
+  'opportunity-alerts': 'Opportunities & collaborations',
+  'product-updates': 'Product updates & roadmap notes',
+}
+
+const onboardingAccountabilityDictionary: Record<OnboardingAccountability, string> = {
+  'progress-updates': 'Weekly progress pulses',
+  'quiet-focus': 'Heads-down focus',
+  'public-goals': 'Public goal setting',
+  'one-on-one': '1:1 accountability partner',
+}
+
+const onboardingStepProgress: Record<string, number> = {
+  persona: 0.2,
+  outcomes: 0.45,
+  enablement: 0.7,
+  support: 0.9,
+  summary: 1,
+}
+
+const computeOnboardingProgress = (journey: ProfileOnboardingJourney | null) => {
+  if (!journey) {
+    return 0
+  }
+
+  if (journey.status === 'completed') {
+    return 1
+  }
+
+  const weight = onboardingStepProgress[journey.currentStep ?? 'persona']
+  if (typeof weight === 'number') {
+    return weight
+  }
+
+  return 0
+}
+
+const formatOnboardingList = <T extends string>(values: T[], dictionary: Record<T, string>) =>
+  values.map((value) => dictionary[value] ?? value)
+
+const renderRuleBadge = (status: RuleStatus) => {
+  if (status === 'complete') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border-2 border-emerald-600 bg-emerald-100 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+        <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" /> Complete
+      </span>
+    )
+  }
+
+  if (status === 'pending') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border-2 border-blue-500 bg-blue-100 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-blue-700">
+        <Clock3 className="h-3.5 w-3.5" aria-hidden="true" /> Pending
+      </span>
+    )
+  }
 
   return (
-    <div className="neo-brutalism min-h-screen flex items-center justify-center bg-white p-4">
-      <div className="neo-container w-full max-w-xl p-8 space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold">Welcome back, {displayName}!</h1>
-          <p className="text-gray-600 mt-1">Signed in as {email}</p>
-        </div>
+    <span className="inline-flex items-center gap-1 rounded-full border-2 border-red-500 bg-red-100 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-red-700">
+      <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" /> Needs attention
+    </span>
+  )
+}
 
-        <div className="space-y-4">
-          <section className="border border-black p-4 bg-white">
-            <h2 className="font-semibold text-lg">Account access</h2>
-            <p className="text-sm text-gray-600 mt-1">
-              You are signed in with a community account.{' '}
-              {isAdmin ? (
-                <span className="font-semibold text-purple-600">
-                  You also have admin permissions.
-                </span>
-              ) : (
-                <span>
-                  If you contribute content or moderate comments, an admin can upgrade your permissions.
-                </span>
-              )}
+const RuleCard = ({ title, description, status }: RuleItem) => (
+  <div className="rounded-2xl border-2 border-black bg-white p-4 shadow-[6px_6px_0px_0px_rgba(0,0,0,0.12)]">
+    <div className="flex items-start justify-between gap-3">
+      <div>
+        <p className="text-base font-extrabold leading-tight text-gray-900">{title}</p>
+        <p className="mt-1 text-sm font-medium text-gray-600">{description}</p>
+      </div>
+      {renderRuleBadge(status)}
+    </div>
+  </div>
+)
+
+const StatCard = ({
+  label,
+  value,
+  accent,
+  helper,
+}: {
+  label: string
+  value: number
+  accent: string
+  helper: string
+}) => (
+  <div
+    className="rounded-3xl border-2 border-black bg-white p-5 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.18)]"
+    style={{ boxShadow: `8px 8px 0 0 ${accent}` }}
+  >
+    <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">{label}</p>
+    <p className="mt-3 text-4xl font-black text-gray-900">{value.toLocaleString('en-US')}</p>
+    <p className="mt-2 text-sm font-semibold text-gray-600">{helper}</p>
+  </div>
+)
+
+const ContributionCard = ({
+  post,
+}: {
+  post: UserPostSummary
+}) => {
+  const isPublished = post.status === PostStatus.PUBLISHED
+  const badgeClass = isPublished
+    ? 'bg-emerald-100 text-emerald-700 border-emerald-500'
+    : post.status === PostStatus.SCHEDULED
+    ? 'bg-blue-100 text-blue-700 border-blue-500'
+    : 'bg-orange-100 text-orange-700 border-orange-500'
+
+  const badgeLabel = isPublished
+    ? 'Published'
+    : post.status === PostStatus.SCHEDULED
+    ? 'Scheduled'
+    : 'Draft'
+
+  return (
+    <article className="rounded-2xl border-2 border-black bg-white p-4 shadow-[5px_5px_0px_0px_rgba(0,0,0,0.15)]">
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <div className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ${badgeClass}`}>
+            <FileText className="h-3.5 w-3.5" aria-hidden="true" />
+            {badgeLabel}
+          </div>
+          <h3 className="text-lg font-black text-gray-900">{post.title}</h3>
+          <p className="text-sm font-medium text-gray-600">
+            {post.publishedAt ? `Shared ${formatDate(post.publishedAt)}` : `Updated ${formatDate(post.createdAt)}`}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Reads</p>
+          <p className="text-2xl font-black text-gray-900">{post.views.toLocaleString('en-US')}</p>
+        </div>
+      </div>
+      {isPublished && post.slug ? (
+        <Link
+          href={`/blogs/${post.slug}`}
+          className="mt-3 inline-flex items-center gap-2 text-sm font-bold text-[#6C63FF] hover:underline"
+        >
+          View article <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+        </Link>
+      ) : (
+        <p className="mt-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
+          Keep refining and publish when ready.
+        </p>
+      )}
+    </article>
+  )
+}
+
+const CommentCard = ({ comment }: { comment: UserCommentSummary }) => {
+  const badgeClass =
+    comment.status === CommentStatus.APPROVED
+      ? 'bg-emerald-100 text-emerald-700 border-emerald-500'
+      : comment.status === CommentStatus.REJECTED
+      ? 'bg-red-100 text-red-700 border-red-500'
+      : 'bg-orange-100 text-orange-700 border-orange-500'
+
+  const badgeLabel =
+    comment.status === CommentStatus.APPROVED
+      ? 'Approved'
+      : comment.status === CommentStatus.REJECTED
+      ? 'Rejected'
+      : 'Pending review'
+
+  return (
+    <article className="rounded-2xl border-2 border-black bg-white p-4 shadow-[5px_5px_0px_0px_rgba(0,0,0,0.15)]">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <div className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ${badgeClass}`}>
+            <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />
+            {badgeLabel}
+          </div>
+          <h3 className="text-lg font-black text-gray-900">
+            {comment.postTitle ?? 'General discussion'}
+          </h3>
+          <p className="text-sm font-medium text-gray-600">{formatDate(comment.createdAt)}</p>
+          <p className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-3 text-sm font-medium text-gray-700">
+            {comment.content}
+          </p>
+        </div>
+        {comment.postSlug ? (
+          <Link
+            href={`/blogs/${comment.postSlug}#comments`}
+            className="inline-flex items-center gap-2 text-sm font-bold text-[#FF5252] hover:underline"
+          >
+            Open thread <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+          </Link>
+        ) : null}
+      </div>
+    </article>
+  )
+}
+
+const AvatarBubble = ({
+  name,
+  avatarUrl,
+}: {
+  name: string
+  avatarUrl: string | null
+}) => (
+  <span className="relative inline-flex h-16 w-16 items-center justify-center overflow-hidden rounded-3xl border-4 border-black bg-[#F6EDE3] text-2xl font-black text-black">
+    {avatarUrl ? (
+      <Image src={avatarUrl} alt={`${name}'s avatar`} fill sizes="64px" className="object-cover" />
+    ) : (
+      <UserRound className="h-8 w-8" aria-hidden="true" />
+    )}
+  </span>
+)
+
+const SidebarAvatar = ({
+  name,
+  avatarUrl,
+}: {
+  name: string
+  avatarUrl: string | null
+}) => (
+  <span className="relative inline-flex h-12 w-12 items-center justify-center overflow-hidden rounded-2xl border-2 border-black bg-[#F6EDE3] text-xl font-black text-black">
+    {avatarUrl ? (
+      <Image src={avatarUrl} alt={`${name}'s avatar`} fill sizes="48px" className="object-cover" />
+    ) : (
+      <UserRound className="h-6 w-6" aria-hidden="true" />
+    )}
+  </span>
+)
+
+const StatusBadge = ({ status }: { status: CapabilityStatus }) => {
+  if (status === 'available') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border-2 border-emerald-500 bg-emerald-100 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-emerald-700">
+        <CheckCircle2 className="h-3 w-3" aria-hidden="true" /> Enabled
+      </span>
+    )
+  }
+
+  if (status === 'locked') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border-2 border-gray-400 bg-gray-100 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-gray-600">
+        Locked
+      </span>
+    )
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border-2 border-blue-400 bg-blue-100 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-blue-700">
+      Upcoming
+    </span>
+  )
+}
+
+const CapabilityCard = ({ title, description, icon: Icon, status, ctaHref, ctaLabel }: CapabilityItem) => (
+  <div className="rounded-3xl border-2 border-black bg-white p-5 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.15)]">
+    <div className="flex items-start justify-between gap-3">
+      <div className="flex items-start gap-3">
+        <span className="inline-flex h-11 w-11 items-center justify-center rounded-2xl border-2 border-black bg-[#F5F3FF] text-[#6C63FF]">
+          <Icon className="h-5 w-5" aria-hidden="true" />
+        </span>
+        <div>
+          <p className="text-base font-black text-gray-900">{title}</p>
+          <p className="mt-1 text-sm font-medium text-gray-600">{description}</p>
+        </div>
+      </div>
+      <StatusBadge status={status} />
+    </div>
+    {ctaHref && ctaLabel ? (
+      <Link
+        href={ctaHref}
+        className="mt-4 inline-flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-[#6C63FF] hover:underline"
+      >
+        {ctaLabel} <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+      </Link>
+    ) : null}
+  </div>
+)
+
+const AccountSidebar = ({
+  profile,
+  totals,
+  sections,
+}: {
+  profile: AuthenticatedProfileSummary
+  totals: UserContributionSnapshot['totals']
+  sections: SidebarSection[]
+}) => (
+  <aside className="lg:w-72 xl:w-80">
+    <div className="sticky top-6 space-y-6">
+      <div className="rounded-3xl border-4 border-black bg-white p-5 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.18)]">
+        <div className="flex items-center gap-4">
+          <SidebarAvatar name={profile.displayName} avatarUrl={profile.avatarUrl} />
+          <div>
+            <p className="text-xs font-black uppercase tracking-[0.25em] text-gray-500">Signed in</p>
+            <p className="text-lg font-black text-gray-900">{profile.displayName}</p>
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              Member since {formatDate(profile.createdAt)}
             </p>
-            {isAdmin ? (
-              <Link
-                href="/admin"
-                className="inline-flex items-center mt-3 px-4 py-2 border-2 border-black bg-black text-white font-bold shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px]"
+          </div>
+        </div>
+        <div className="mt-4 grid grid-cols-2 gap-3 text-center">
+          <div className="rounded-2xl border-2 border-black bg-[#F6EDE3] px-3 py-2">
+            <p className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-600">Posts</p>
+            <p className="text-xl font-black text-gray-900">{totals.publishedPosts}</p>
+          </div>
+          <div className="rounded-2xl border-2 border-black bg-[#E8F5FF] px-3 py-2">
+            <p className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-600">Comments</p>
+            <p className="text-xl font-black text-gray-900">{totals.totalComments}</p>
+          </div>
+        </div>
+      </div>
+      <nav className="rounded-3xl border-4 border-black bg-white p-5 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.18)]">
+        <p className="text-xs font-black uppercase tracking-[0.3em] text-gray-500">Workspace</p>
+        <ul className="mt-4 space-y-2">
+          {sections.map((section) => (
+            <li key={section.id}>
+              <a
+                href={`#${section.id}`}
+                className="group flex items-center gap-3 rounded-2xl border-2 border-transparent px-3 py-2 text-sm font-bold text-gray-800 transition hover:border-black hover:bg-[#F5F3FF]"
               >
-                Go to admin dashboard
+                <section.icon className="h-4 w-4 text-[#6C63FF] transition group-hover:scale-110" aria-hidden="true" />
+                {section.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <div className="rounded-3xl border-4 border-black bg-[#0B0B0F] p-5 text-white shadow-[12px_12px_0px_0px_rgba(0,0,0,0.25)]">
+        <p className="text-sm font-black uppercase tracking-[0.25em] opacity-70">Shortcuts</p>
+        <ul className="mt-4 space-y-3 text-sm font-semibold">
+          <li>
+            <Link href="/blogs" className="inline-flex items-center gap-2 text-[#FFD66B] hover:underline">
+              Browse editorial feed <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </Link>
+          </li>
+          <li>
+            <Link href="#publishing" className="inline-flex items-center gap-2 text-[#6C63FF] hover:underline">
+              Check drafting stats <Activity className="h-3.5 w-3.5" aria-hidden="true" />
+            </Link>
+          </li>
+          {profile.isAdmin ? (
+            <li>
+              <Link href="/admin" className="inline-flex items-center gap-2 text-[#7CFBFF] hover:underline">
+                Review newsroom queue <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
               </Link>
+            </li>
+          ) : null}
+        </ul>
+      </div>
+    </div>
+  </aside>
+)
+
+const SectionHeader = ({
+  eyebrow,
+  title,
+  description,
+}: {
+  eyebrow: string
+  title: string
+  description: string
+}) => (
+  <header className="space-y-1">
+    <p className="text-xs font-black uppercase tracking-[0.3em] text-[#6C63FF]">{eyebrow}</p>
+    <h2 className="text-3xl font-black text-gray-900">{title}</h2>
+    <p className="text-sm font-semibold text-gray-600">{description}</p>
+  </header>
+)
+
+const getObjectPathFromPublicUrl = (url: string): string | null => {
+  try {
+    const parsed = new URL(url)
+    const segments = parsed.pathname.split('/')
+    const bucketIndex = segments.findIndex((segment) => segment === 'profile-photos')
+    if (bucketIndex === -1) {
+      return null
+    }
+    return segments.slice(bucketIndex + 1).join('/')
+  } catch (error) {
+    console.error('Failed to derive storage path from url', error)
+    return null
+  }
+}
+
+interface ProfileIdentityManagerProps {
+  profile: AuthenticatedProfileSummary
+  onProfileChange: (patch: Partial<AuthenticatedProfileSummary>) => void
+  onRefreshRequested: () => Promise<void>
+}
+
+const ProfileIdentityManager = ({
+  profile,
+  onProfileChange,
+  onRefreshRequested,
+}: ProfileIdentityManagerProps) => {
+  const supabase = useMemo(() => createBrowserClient(), [])
+  const [displayName, setDisplayName] = useState(profile.displayName)
+  const [isSavingName, setIsSavingName] = useState(false)
+  const [nameStatus, setNameStatus] = useState<StatusMessage | null>(null)
+  const [isUploading, setIsUploading] = useState(false)
+  const [uploadStatus, setUploadStatus] = useState<StatusMessage | null>(null)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    setDisplayName(profile.displayName)
+  }, [profile.displayName])
+
+  const handleNameSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      const trimmed = displayName.trim()
+
+      if (!trimmed) {
+        setNameStatus({ tone: 'error', message: 'Display name cannot be empty.' })
+        return
+      }
+
+      if (trimmed === profile.displayName) {
+        setNameStatus({ tone: 'success', message: 'No changes needed — name already saved.' })
+        return
+      }
+
+      setIsSavingName(true)
+      setNameStatus(null)
+
+      try {
+        const { error } = await supabase
+          .from('profiles')
+          .update({ display_name: trimmed })
+          .eq('user_id', profile.userId)
+
+        if (error) {
+          throw error
+        }
+
+        onProfileChange({ displayName: trimmed })
+        await onRefreshRequested()
+        setNameStatus({ tone: 'success', message: 'Display name updated.' })
+      } catch (error) {
+        console.error('Failed to update display name', error)
+        setNameStatus({ tone: 'error', message: 'Unable to update name. Please try again.' })
+      } finally {
+        setIsSavingName(false)
+      }
+    },
+    [displayName, onProfileChange, onRefreshRequested, profile.displayName, profile.userId, supabase],
+  )
+
+  const handleFileChange = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0]
+      if (!file) {
+        return
+      }
+
+      if (!file.type.startsWith('image/')) {
+        setUploadStatus({ tone: 'error', message: 'Please choose an image file (PNG, JPG, or GIF).' })
+        return
+      }
+
+      const maxSize = 5 * 1024 * 1024
+      if (file.size > maxSize) {
+        setUploadStatus({ tone: 'error', message: 'Image is larger than 5MB. Choose a smaller file.' })
+        return
+      }
+
+      setIsUploading(true)
+      setUploadStatus(null)
+
+      try {
+        const extension = file.name.split('.').pop()?.toLowerCase().replace(/[^a-z0-9]/g, '') || 'jpg'
+        const objectPath = `${profile.userId}/${Date.now()}-${Math.random().toString(36).slice(2)}.${extension}`
+
+        const { error: uploadError } = await supabase.storage
+          .from('profile-photos')
+          .upload(objectPath, file, {
+            cacheControl: '3600',
+            upsert: true,
+            contentType: file.type,
+          })
+
+        if (uploadError) {
+          throw uploadError
+        }
+
+        const previousPath = profile.avatarUrl ? getObjectPathFromPublicUrl(profile.avatarUrl) : null
+        if (previousPath && previousPath !== objectPath) {
+          await supabase.storage.from('profile-photos').remove([previousPath])
+        }
+
+        const {
+          data: { publicUrl },
+        } = supabase.storage.from('profile-photos').getPublicUrl(objectPath)
+
+        const { error: profileError } = await supabase
+          .from('profiles')
+          .update({ avatar_url: publicUrl })
+          .eq('user_id', profile.userId)
+
+        if (profileError) {
+          throw profileError
+        }
+
+        onProfileChange({ avatarUrl: publicUrl })
+        await onRefreshRequested()
+        setUploadStatus({ tone: 'success', message: 'Profile photo updated.' })
+      } catch (error) {
+        console.error('Failed to upload avatar', error)
+        setUploadStatus({ tone: 'error', message: 'Unable to update profile photo. Please try again.' })
+      } finally {
+        setIsUploading(false)
+        if (event.target) {
+          event.target.value = ''
+        }
+      }
+    },
+    [onProfileChange, onRefreshRequested, profile.avatarUrl, profile.userId, supabase],
+  )
+
+  const handleRemovePhoto = useCallback(async () => {
+    if (!profile.avatarUrl) {
+      return
+    }
+
+    setIsUploading(true)
+    setUploadStatus(null)
+
+    try {
+      const objectPath = getObjectPathFromPublicUrl(profile.avatarUrl)
+      if (objectPath) {
+        await supabase.storage.from('profile-photos').remove([objectPath])
+      }
+
+      const { error } = await supabase
+        .from('profiles')
+        .update({ avatar_url: null })
+        .eq('user_id', profile.userId)
+
+      if (error) {
+        throw error
+      }
+
+      onProfileChange({ avatarUrl: null })
+      await onRefreshRequested()
+      setUploadStatus({ tone: 'success', message: 'Profile photo removed.' })
+    } catch (error) {
+      console.error('Failed to remove avatar', error)
+      setUploadStatus({ tone: 'error', message: 'Unable to remove profile photo right now.' })
+    } finally {
+      setIsUploading(false)
+    }
+  }, [onProfileChange, onRefreshRequested, profile.avatarUrl, profile.userId, supabase])
+
+  return (
+    <div className="rounded-[32px] border-4 border-black bg-white p-6 shadow-[16px_16px_0px_0px_rgba(0,0,0,0.2)]">
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex items-center gap-4">
+          <SidebarAvatar name={profile.displayName} avatarUrl={profile.avatarUrl} />
+          <div>
+            <p className="text-xs font-black uppercase tracking-[0.3em] text-gray-500">Profile identity</p>
+            <p className="text-xl font-black text-gray-900">{profile.displayName}</p>
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">{profile.email}</p>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <input
+            ref={fileInputRef}
+            id="profile-avatar-upload"
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="inline-flex items-center justify-center gap-2 rounded-md border-2 border-black bg-[#6C63FF] px-4 py-2 text-sm font-black uppercase tracking-wide text-white shadow-[4px_4px_0px_0px_rgba(0,0,0,0.15)] transition hover:-translate-y-[1px]"
+            disabled={isUploading}
+          >
+            Upload new photo
+          </button>
+          <button
+            type="button"
+            onClick={handleRemovePhoto}
+            className="inline-flex items-center justify-center rounded-md border-2 border-dashed border-black/40 bg-white px-4 py-2 text-sm font-black uppercase tracking-wide text-gray-700 transition hover:border-black"
+            disabled={isUploading || !profile.avatarUrl}
+          >
+            Remove photo
+          </button>
+        </div>
+      </div>
+
+      {uploadStatus ? (
+        <p
+          className={`mt-4 rounded-2xl border-2 px-4 py-2 text-sm font-semibold ${
+            uploadStatus.tone === 'success'
+              ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
+              : 'border-red-400 bg-red-50 text-red-700'
+          }`}
+        >
+          {uploadStatus.message}
+        </p>
+      ) : null}
+
+      <form onSubmit={handleNameSubmit} className="mt-6 space-y-3">
+        <label htmlFor="display-name" className="text-xs font-black uppercase tracking-[0.3em] text-gray-500">
+          Display name
+        </label>
+        <div className="flex flex-col gap-3 md:flex-row md:items-center">
+          <input
+            id="display-name"
+            name="display-name"
+            value={displayName}
+            onChange={(event) => setDisplayName(event.target.value)}
+            className="w-full rounded-xl border-2 border-black bg-[#F8F7FF] px-4 py-2 text-base font-semibold text-gray-900 focus:border-[#6C63FF] focus:outline-none focus:ring-2 focus:ring-[#B7AEFF]"
+          />
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-md border-2 border-black bg-[#FFD66B] px-4 py-2 text-sm font-black uppercase tracking-wide text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,0.15)] transition hover:-translate-y-[1px] disabled:opacity-60"
+            disabled={isSavingName}
+          >
+            Save name
+          </button>
+        </div>
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+          This name appears on your articles and comments.
+        </p>
+        {nameStatus ? (
+          <p
+            className={`rounded-2xl border-2 px-4 py-2 text-sm font-semibold ${
+              nameStatus.tone === 'success'
+                ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
+                : 'border-red-400 bg-red-50 text-red-700'
+            }`}
+          >
+            {nameStatus.message}
+          </p>
+        ) : null}
+      </form>
+    </div>
+  )
+}
+
+export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelProps) => {
+  const { refresh: refreshAuthenticatedProfile } = useAuthenticatedProfile()
+  const [currentProfile, setCurrentProfile] = useState(profile)
+
+  useEffect(() => {
+    setCurrentProfile(profile)
+  }, [profile])
+
+  const primaryRole = useMemo(
+    () =>
+      currentProfile.roles.find((role) => role.id === currentProfile.primaryRoleId) ??
+      currentProfile.roles[0] ??
+      null,
+    [currentProfile.primaryRoleId, currentProfile.roles],
+  )
+
+  const activity = useMemo(
+    () => buildActivity(contributions.posts, contributions.comments),
+    [contributions.comments, contributions.posts],
+  )
+
+  const onboardingJourney = currentProfile.onboarding ?? null
+  const onboardingResponses: ProfileOnboardingResponses | null = onboardingJourney?.responses ?? null
+  const onboardingProgress = computeOnboardingProgress(onboardingJourney)
+  const onboardingProgressPercent = Math.round(onboardingProgress * 100)
+  const onboardingStatusLabel = onboardingJourney
+    ? onboardingJourney.status === 'completed'
+      ? 'Completed'
+      : onboardingJourney.status === 'in_progress'
+      ? 'In progress'
+      : 'Action needed'
+    : 'Not started'
+  const onboardingStatusTone = onboardingJourney
+    ? onboardingJourney.status === 'completed'
+      ? 'border-emerald-500 bg-emerald-100 text-emerald-700'
+      : onboardingJourney.status === 'in_progress'
+      ? 'border-[#FFB400] bg-[#FFE9B3] text-[#8C6F21]'
+      : 'border-[#FF7043] bg-[#FFD5CC] text-[#8C2F22]'
+    : 'border-gray-400 bg-gray-200 text-gray-600'
+  const onboardingLastTouch = onboardingJourney?.updatedAt ?? onboardingJourney?.completedAt ?? currentProfile.createdAt
+  const onboardingCtaLabel = onboardingJourney?.status === 'completed' ? 'Update preferences' : 'Resume onboarding'
+
+  const onboardingPersona = onboardingResponses?.persona
+    ? onboardingPersonaDictionary[onboardingResponses.persona]
+    : null
+  const onboardingExperienceLabel = onboardingResponses?.experienceLevel
+    ? onboardingExperienceDictionary[onboardingResponses.experienceLevel]
+    : null
+  const onboardingGoals = onboardingResponses
+    ? formatOnboardingList(onboardingResponses.motivations, onboardingGoalDictionary)
+    : []
+  const onboardingContributions = onboardingResponses
+    ? formatOnboardingList(onboardingResponses.focusAreas, onboardingContributionDictionary)
+    : []
+  const onboardingLearning = onboardingResponses
+    ? formatOnboardingList(onboardingResponses.preferredLearningFormats, onboardingLearningDictionary)
+    : []
+  const onboardingSupport = onboardingResponses
+    ? formatOnboardingList(onboardingResponses.supportPreferences, onboardingSupportDictionary)
+    : []
+  const onboardingCommunications = onboardingResponses
+    ? formatOnboardingList(
+        onboardingResponses.communicationPreferences,
+        onboardingCommunicationDictionary,
+      )
+    : []
+  const onboardingAccountability = onboardingResponses?.accountabilityStyle
+    ? onboardingAccountabilityDictionary[onboardingResponses.accountabilityStyle]
+    : null
+
+  const requiredRules: RuleItem[] = [
+    {
+      title: 'Verified email address',
+      description: currentProfile.emailConfirmedAt
+        ? `Verified on ${formatDate(currentProfile.emailConfirmedAt)}`
+        : 'Confirm your email to secure account recovery.',
+      status: currentProfile.emailConfirmedAt ? 'complete' : 'pending',
+    },
+    {
+      title: 'Recognizable display name',
+      description: `Visible to the community as ${currentProfile.displayName}.`,
+      status: currentProfile.displayName ? 'complete' : 'pending',
+    },
+  ]
+
+  const recommendedRules: RuleItem[] = [
+    {
+      title: 'Profile photo',
+      description: currentProfile.avatarUrl
+        ? 'Looking sharp with a custom avatar.'
+        : 'Upload a photo to personalize your presence.',
+      status: currentProfile.avatarUrl ? 'complete' : 'pending',
+    },
+    {
+      title: 'Primary role selected',
+      description: primaryRole
+        ? `Leading as ${primaryRole.name}.`
+        : 'Assign yourself a primary role to tailor recommendations.',
+      status: primaryRole ? 'complete' : 'pending',
+    },
+  ]
+
+  const complimentaryBenefits: RuleItem[] = [
+    {
+      title: 'Members-only drops',
+      description: 'Enjoy early access to podcasts, changelog briefings, and community events.',
+      status: 'complete',
+    },
+    {
+      title: 'Curated learning paths',
+      description: 'Bookmark tutorials and we will stitch them into a weekly study plan for you.',
+      status: 'complete',
+    },
+  ]
+
+  const attentionItems: RuleItem[] = []
+
+  if (contributions.totals.pendingComments > 0) {
+    attentionItems.push({
+      title: 'Comments awaiting review',
+      description: `${contributions.totals.pendingComments} comment${
+        contributions.totals.pendingComments === 1 ? '' : 's'
+      } pending moderator approval.`,
+      status: 'attention',
+    })
+  }
+
+  if (contributions.totals.rejectedComments > 0) {
+    attentionItems.push({
+      title: 'Rejected feedback',
+      description: `${contributions.totals.rejectedComments} comment${
+        contributions.totals.rejectedComments === 1 ? '' : 's'
+      } need revision for compliance.`,
+      status: 'attention',
+    })
+  }
+
+  if (contributions.totals.publishedPosts === 0) {
+    attentionItems.push({
+      title: 'Share your first story',
+      description: 'Draft something brilliant—your voice is missing from the feed.',
+      status: 'pending',
+    })
+  }
+
+  const navigationSections: SidebarSection[] = [
+    { id: 'overview', label: 'Overview', icon: Compass },
+    { id: 'identity', label: 'Identity & access', icon: IdCard },
+    { id: 'publishing', label: 'Publishing', icon: PenSquare },
+    { id: 'community', label: 'Community impact', icon: UsersRound },
+    { id: 'capabilities', label: 'Capabilities', icon: ShieldCheck },
+    { id: 'rules', label: 'House rules', icon: Scale },
+    { id: 'resources', label: 'Resources', icon: NotebookPen },
+  ]
+
+  const capabilities: CapabilityItem[] = useMemo(() => {
+    const items: CapabilityItem[] = [
+      {
+        title: 'Publish long-form stories',
+        description: 'Draft, schedule, and share articles that appear in the main Syntax & Sips feed.',
+        icon: FileText,
+        status: 'available',
+        ctaHref: '#publishing',
+        ctaLabel: 'Review your drafts',
+      },
+      {
+        title: 'Join community discussions',
+        description: 'Comment on posts, reply to peers, and keep the threads constructive.',
+        icon: MessageCircle,
+        status: 'available',
+        ctaHref: '#community',
+        ctaLabel: 'Open community timeline',
+      },
+      {
+        title: 'Curate personal reading list',
+        description: 'Bookmark tutorials, podcasts, and changelog updates for future study sessions.',
+        icon: NotebookPen,
+        status: 'upcoming',
+      },
+      {
+        title: 'Analytics snapshot',
+        description: 'Track read-through rates, referral sources, and top-performing headlines.',
+        icon: Activity,
+        status: 'upcoming',
+      },
+    ]
+
+    if (currentProfile.isAdmin) {
+      items.push(
+        {
+          title: 'Moderate newsroom queue',
+          description: 'Approve articles, review comments, and update contributor roles.',
+          icon: ShieldCheck,
+          status: 'available',
+          ctaHref: '/admin',
+          ctaLabel: 'Launch admin tools',
+        },
+        {
+          title: 'Access compliance reports',
+          description: 'Audit contribution trends, flag policy violations, and export reports.',
+          icon: Scale,
+          status: 'available',
+          ctaHref: '/admin?tab=reports',
+          ctaLabel: 'View reports',
+        },
+      )
+    }
+
+    return items
+  }, [currentProfile.isAdmin])
+
+  const handleProfileChange = useCallback(
+    (patch: Partial<AuthenticatedProfileSummary>) => {
+      setCurrentProfile((previous) => ({ ...previous, ...patch }))
+    },
+    [],
+  )
+
+  const heroGreeting = `Bonjour ${
+    currentProfile.displayName.split(' ')[0] ?? currentProfile.displayName
+  },`
+
+  return (
+    <div className="neo-brutalism min-h-screen bg-gradient-to-br from-[#FFF5F1] via-[#F8F0FF] to-[#E3F2FF] px-4 py-10">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 lg:flex-row">
+        <AccountSidebar profile={currentProfile} totals={contributions.totals} sections={navigationSections} />
+
+        <div className="flex-1 space-y-16">
+          <section id="overview" className="scroll-mt-28 space-y-6">
+            <SectionHeader
+              eyebrow="Overview"
+              title="Your Syntax & Sips HQ"
+              description="A personalized cockpit for tracking contributions, audience resonance, and account health."
+            />
+
+            <div className="rounded-[32px] border-4 border-black bg-white p-8 shadow-[16px_16px_0px_0px_rgba(0,0,0,0.2)]">
+              <div className="flex flex-wrap items-start justify-between gap-6">
+                <div className="flex items-center gap-4">
+                  <AvatarBubble name={currentProfile.displayName} avatarUrl={currentProfile.avatarUrl} />
+                  <div>
+                    <p className="text-sm font-black uppercase tracking-[0.35em] text-gray-500">Profile dashboard</p>
+                    <h1 className="mt-2 text-3xl font-black leading-tight text-gray-900">{heroGreeting}</h1>
+                    <p className="mt-1 text-base font-semibold text-gray-600">
+                      You are steering your Syntax &amp; Sips journey like a pro.
+                    </p>
+                  </div>
+                </div>
+                <div className="flex flex-col items-end gap-2">
+                  <span className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-[#FFD66B] px-4 py-1 text-xs font-black uppercase tracking-wide text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,0.15)]">
+                    <Sparkles className="h-4 w-4" aria-hidden="true" />
+                    {primaryRole ? primaryRole.name : 'Community member'}
+                  </span>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Member since {formatDate(currentProfile.createdAt)}
+                  </p>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Last active {formatRelative(currentProfile.lastSignInAt)}
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-8 grid gap-4 md:grid-cols-3">
+                <div className="rounded-2xl border-2 border-black bg-[#6C63FF] p-4 text-white shadow-[8px_8px_0px_0px_rgba(108,99,255,0.35)]">
+                  <p className="text-xs font-black uppercase tracking-[0.2em] opacity-80">Account email</p>
+                  <p className="mt-2 break-all text-lg font-bold">{currentProfile.email}</p>
+                  <p className="mt-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
+                    <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+                    Session persisted until you sign out
+                  </p>
+                </div>
+                <div className="rounded-2xl border-2 border-black bg-white p-4 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.18)]">
+                  <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">Roles</p>
+                  <ul className="mt-3 space-y-2 text-sm font-semibold text-gray-700">
+                    {currentProfile.roles.length > 0 ? (
+                      currentProfile.roles.map((role) => (
+                        <li
+                          key={role.id}
+                          className="inline-flex items-center gap-2 rounded-full border border-black/20 bg-gray-50 px-3 py-1"
+                        >
+                          <ShieldCheck className="h-3.5 w-3.5 text-[#6C63FF]" aria-hidden="true" />
+                          {role.name}
+                        </li>
+                      ))
+                    ) : (
+                      <li>No roles assigned yet.</li>
+                    )}
+                  </ul>
+                </div>
+                <div className="rounded-2xl border-2 border-black bg-white p-4 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.18)]">
+                  <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">Most recent activity</p>
+                  {activity[0] ? (
+                    <div className="mt-3 space-y-1">
+                      <p className="text-sm font-bold text-gray-900">{activity[0].title}</p>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                        {activity[0].description}
+                      </p>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                        {formatRelative(activity[0].timestamp)}
+                      </p>
+                    </div>
+                  ) : (
+                    <p className="mt-3 text-sm font-semibold text-gray-600">
+                      Start contributing to see your timeline fill up.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-8 grid gap-4 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+              <div className="rounded-3xl border-2 border-black bg-white p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.15)]">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-black uppercase tracking-[0.3em] text-gray-500">Onboarding status</p>
+                    <h3 className="text-xl font-black text-gray-900">Personalised orientation</h3>
+                  </div>
+                  <span
+                    className={`inline-flex items-center gap-2 rounded-full border-2 px-3 py-1 text-xs font-black uppercase tracking-wide ${onboardingStatusTone}`}
+                  >
+                    <Sparkles className="h-4 w-4" aria-hidden="true" />
+                    {onboardingStatusLabel}
+                  </span>
+                </div>
+                <p className="mt-3 text-sm font-medium text-gray-600">
+                  {onboardingJourney?.status === 'completed'
+                    ? 'You have unlocked the full account experience—update your answers anytime to keep recommendations sharp.'
+                    : 'Share a few details so we can tailor programs, invites, and editorial feedback to your goals.'}
+                </p>
+                <div className="mt-4">
+                  <div className="flex items-center justify-between text-xs font-black uppercase tracking-wide text-gray-500">
+                    <span>Progress</span>
+                    <span>{onboardingProgressPercent}%</span>
+                  </div>
+                  <div className="mt-2 h-3 rounded-full border-2 border-black bg-white">
+                    <div
+                      className="h-full rounded-full bg-[#6C63FF]"
+                      style={{ width: `${Math.min(onboardingProgressPercent, 100)}%` }}
+                    />
+                  </div>
+                </div>
+                <p className="mt-4 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Last updated {formatRelative(onboardingLastTouch)}
+                </p>
+                <Link
+                  href="/onboarding?redirect=/account"
+                  className="mt-4 inline-flex items-center gap-2 rounded-full border-2 border-black bg-[#FFD66B] px-4 py-2 text-xs font-black uppercase tracking-wide text-black shadow-[6px_6px_0px_0px_rgba(0,0,0,0.15)] hover:-translate-y-[1px]"
+                >
+                  {onboardingCtaLabel}
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </Link>
+              </div>
+
+              <div className="rounded-3xl border-2 border-black bg-white p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.15)]">
+                <p className="text-xs font-black uppercase tracking-[0.3em] text-gray-500">Member blueprint</p>
+                <h3 className="text-xl font-black text-gray-900">How we personalise your journey</h3>
+                {onboardingResponses ? (
+                  <div className="mt-4 space-y-4">
+                    <div className="rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-4">
+                      <div className="flex items-start gap-3">
+                        <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border-2 border-black bg-[#FFD66B]">
+                          <Sparkles className="h-4 w-4" aria-hidden="true" />
+                        </span>
+                        <div>
+                          <p className="text-xs font-black uppercase tracking-wide text-gray-500">Primary persona</p>
+                          <p className="text-sm font-bold text-gray-900">
+                            {onboardingPersona?.title ?? 'Let’s capture your persona'}
+                          </p>
+                          <p className="text-xs font-semibold text-gray-600">
+                            {onboardingPersona?.summary ?? 'Complete onboarding to personalise your dashboard.'}
+                          </p>
+                          {onboardingExperienceLabel ? (
+                            <p className="mt-2 inline-flex items-center gap-2 rounded-full border border-black/10 bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-gray-600">
+                              <ShieldCheck className="h-3.5 w-3.5 text-[#6C63FF]" aria-hidden="true" />
+                              {onboardingExperienceLabel}
+                            </p>
+                          ) : null}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <div className="rounded-2xl border-2 border-black bg-[#F8F7FF] p-4">
+                        <h4 className="flex items-center gap-2 text-xs font-black uppercase tracking-wide text-[#6C63FF]">
+                          <Goal className="h-3.5 w-3.5" aria-hidden="true" /> Priority outcomes
+                        </h4>
+                        {onboardingGoals.length > 0 ? (
+                          <ul className="mt-2 space-y-1 text-sm font-semibold text-gray-700">
+                            {onboardingGoals.map((goal) => (
+                              <li key={goal} className="flex items-center gap-2">
+                                <CheckCircle2 className="h-3.5 w-3.5 text-[#6C63FF]" aria-hidden="true" />
+                                {goal}
+                              </li>
+                            ))}
+                          </ul>
+                        ) : (
+                          <p className="mt-2 text-xs font-semibold text-gray-500">
+                            Share the outcomes you are chasing to tailor your updates.
+                          </p>
+                        )}
+                      </div>
+                      <div className="rounded-2xl border-2 border-black bg-[#FFF5F1] p-4">
+                        <h4 className="flex items-center gap-2 text-xs font-black uppercase tracking-wide text-[#FF8A65]">
+                          <NotebookPen className="h-3.5 w-3.5" aria-hidden="true" /> Planned contributions
+                        </h4>
+                        {onboardingContributions.length > 0 ? (
+                          <ul className="mt-2 space-y-1 text-sm font-semibold text-gray-700">
+                            {onboardingContributions.map((item) => (
+                              <li key={item} className="flex items-center gap-2">
+                                <NotebookPen className="h-3.5 w-3.5 text-[#FF8A65]" aria-hidden="true" />
+                                {item}
+                              </li>
+                            ))}
+                          </ul>
+                        ) : (
+                          <p className="mt-2 text-xs font-semibold text-gray-500">
+                            Tell us how you want to contribute so we can line up opportunities.
+                          </p>
+                        )}
+                        <p className="mt-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                          Formats you love:{' '}
+                          {onboardingLearning.length > 0
+                            ? onboardingLearning.join(', ')
+                            : 'Choose at least one learning style'}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="rounded-2xl border-2 border-black bg-[#E8F8FF] p-4">
+                      <h4 className="flex items-center gap-2 text-xs font-black uppercase tracking-wide text-[#2E7D32]">
+                        <Target className="h-3.5 w-3.5" aria-hidden="true" /> Support &amp; check-ins
+                      </h4>
+                      {onboardingSupport.length > 0 ? (
+                        <ul className="mt-2 space-y-1 text-sm font-semibold text-gray-700">
+                          {onboardingSupport.map((item) => (
+                            <li key={item} className="flex items-center gap-2">
+                              <Target className="h-3.5 w-3.5 text-[#2E7D32]" aria-hidden="true" />
+                              {item}
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="mt-2 text-xs font-semibold text-gray-500">
+                          Flag the support you want so we can coordinate the right experiences.
+                        </p>
+                      )}
+                      <p className="mt-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                        Accountability style:{' '}
+                        {onboardingAccountability ?? 'Pick what keeps you motivated'}
+                      </p>
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {onboardingCommunications.length > 0 ? (
+                          onboardingCommunications.map((item) => (
+                            <span
+                              key={item}
+                              className="inline-flex items-center gap-2 rounded-full border border-black/10 bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-gray-600"
+                            >
+                              <CalendarCheck2 className="h-3.5 w-3.5 text-[#6C63FF]" aria-hidden="true" />
+                              {item}
+                            </span>
+                          ))
+                        ) : (
+                          <span className="text-xs font-semibold text-gray-500">
+                            Choose how we should keep in touch.
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="mt-4 rounded-2xl border-2 border-dashed border-gray-300 bg-gray-50 p-5 text-sm font-semibold text-gray-600">
+                    Complete onboarding to see your personalised goals, contribution plan, and support preferences here.
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              <StatCard
+                label="Published pieces"
+                value={contributions.totals.publishedPosts}
+                accent="rgba(108, 99, 255, 0.25)"
+                helper="Stories visible to the community"
+              />
+              <StatCard
+                label="Drafts in progress"
+                value={contributions.totals.draftPosts}
+                accent="rgba(255, 214, 107, 0.45)"
+                helper="Ideas waiting for the final polish"
+              />
+              <StatCard
+                label="Total reads"
+                value={contributions.totals.totalViews}
+                accent="rgba(124, 251, 255, 0.35)"
+                helper="Lifetime audience views"
+              />
+              <StatCard
+                label="Community replies"
+                value={contributions.totals.totalComments}
+                accent="rgba(255, 82, 82, 0.35)"
+                helper="Conversations you have sparked"
+              />
+            </div>
+          </section>
+
+          <section id="identity" className="scroll-mt-28 space-y-6">
+            <SectionHeader
+              eyebrow="Identity"
+              title="Manage profile identity and security"
+              description="Refresh your public details, keep your avatar current, and review how your account stays signed in."
+            />
+
+            <ProfileIdentityManager
+              profile={currentProfile}
+              onProfileChange={handleProfileChange}
+              onRefreshRequested={refreshAuthenticatedProfile}
+            />
+
+            <div className="grid gap-4 lg:grid-cols-2">
+              <div className="rounded-[28px] border-4 border-black bg-white p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.18)]">
+                <h3 className="text-xl font-black text-gray-900">Account access</h3>
+                <p className="mt-2 text-sm font-medium text-gray-600">
+                  You are signed in with a community account.
+                  {currentProfile.isAdmin ? (
+                    <span className="font-semibold text-[#6C63FF]">
+                      {' '}
+                      You also have admin permissions with newsroom oversight.
+                    </span>
+                  ) : (
+                    <span> Contribute consistently to unlock elevated privileges.</span>
+                  )}
+                </p>
+                <p className="mt-3 rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-4 text-xs font-semibold uppercase tracking-wide text-gray-600">
+                  Session stays active until you sign out. Close your browser without worry—your reading queue and drafts follow you.
+                </p>
+                {currentProfile.isAdmin ? (
+                  <Link
+                    href="/admin"
+                    className="mt-3 inline-flex items-center gap-2 text-sm font-bold text-[#6C63FF] hover:underline"
+                  >
+                    Go to admin console <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Link>
+                ) : null}
+              </div>
+              <div className="rounded-[28px] border-4 border-black bg-white p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.18)]">
+                <h3 className="text-xl font-black text-gray-900">Security log</h3>
+                <ul className="mt-3 space-y-3 text-sm font-semibold text-gray-600">
+                  <li className="flex items-center justify-between">
+                    <span>Last sign in</span>
+                    <span>{formatDate(currentProfile.lastSignInAt)}</span>
+                  </li>
+                  <li className="flex items-center justify-between">
+                    <span>Email confirmed</span>
+                    <span>{currentProfile.emailConfirmedAt ? formatDate(currentProfile.emailConfirmedAt) : 'Pending'}</span>
+                  </li>
+                  <li className="flex items-center justify-between">
+                    <span>Account created</span>
+                    <span>{formatDate(currentProfile.createdAt)}</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </section>
+
+          <section id="publishing" className="scroll-mt-28 space-y-6">
+            <SectionHeader
+              eyebrow="Publishing"
+              title="Contribution velocity"
+              description="Monitor how your stories are performing, keep drafts on track, and plan upcoming releases."
+            />
+
+            {contributions.posts.length > 0 ? (
+              <div className="grid gap-4 lg:grid-cols-2">
+                {contributions.posts.slice(0, 6).map((post) => (
+                  <ContributionCard key={post.id} post={post} />
+                ))}
+              </div>
             ) : (
-              <Link
-                href="/admin/login"
-                className="inline-flex items-center mt-3 text-sm text-purple-600 underline"
-              >
-                Admins sign in here
-              </Link>
+              <div className="rounded-2xl border-2 border-dashed border-gray-300 bg-white p-6 text-sm font-semibold text-gray-600">
+                You have not published anything yet. Spin up a draft and share your expertise with the community.
+              </div>
             )}
           </section>
 
-          <section className="border border-black p-4 bg-white">
-            <h2 className="font-semibold text-lg">Sign out</h2>
-            <p className="text-sm text-gray-600 mt-1">Finished browsing? You can sign out safely below.</p>
-            <button
-              type="button"
-              onClick={handleSignOut}
-              disabled={isSigningOut}
-              className="mt-3 neo-button px-4 py-2 font-bold"
-            >
-              {isSigningOut ? 'Signing out...' : 'Sign out'}
-            </button>
-            {error && (
-              <p className="mt-3 text-sm text-red-600" role="alert">
-                {error}
-              </p>
-            )}
+          <section id="community" className="scroll-mt-28 space-y-6">
+            <SectionHeader
+              eyebrow="Community"
+              title="Engagement timeline"
+              description="Keep tabs on discussions you have started and how moderators responded to your contributions."
+            />
+
+            <div className="grid gap-4 lg:grid-cols-2">
+              <div className="space-y-4">
+                <h3 className="text-lg font-black text-gray-900">Recent comments</h3>
+                {contributions.comments.length > 0 ? (
+                  contributions.comments.slice(0, 5).map((comment) => (
+                    <CommentCard key={comment.id} comment={comment} />
+                  ))
+                ) : (
+                  <div className="rounded-2xl border-2 border-dashed border-gray-300 bg-white p-6 text-sm font-semibold text-gray-600">
+                    Join the discussion on a post to see your contributions here.
+                  </div>
+                )}
+              </div>
+              <div className="space-y-4">
+                <h3 className="text-lg font-black text-gray-900">Activity timeline</h3>
+                {activity.length > 0 ? (
+                  <ol className="space-y-4">
+                    {activity.map((entry) => (
+                      <li
+                        key={entry.id}
+                        className="rounded-2xl border-2 border-black bg-white p-5 shadow-[6px_6px_0px_0px_rgba(0,0,0,0.15)]"
+                      >
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="space-y-1">
+                            <span
+                              className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ${
+                                entry.badgeTone === 'emerald'
+                                  ? 'border-emerald-500 bg-emerald-100 text-emerald-700'
+                                  : entry.badgeTone === 'orange'
+                                  ? 'border-orange-500 bg-orange-100 text-orange-700'
+                                  : entry.badgeTone === 'blue'
+                                  ? 'border-blue-500 bg-blue-100 text-blue-700'
+                                  : entry.badgeTone === 'red'
+                                  ? 'border-red-500 bg-red-100 text-red-700'
+                                  : 'border-purple-500 bg-purple-100 text-purple-700'
+                              }`}
+                            >
+                              {entry.type === 'post' ? (
+                                <FileText className="h-3.5 w-3.5" aria-hidden="true" />
+                              ) : (
+                                <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />
+                              )}
+                              {entry.statusLabel}
+                            </span>
+                            <p className="text-lg font-black text-gray-900">{entry.title}</p>
+                            <p className="text-sm font-semibold text-gray-600">{entry.description}</p>
+                            {entry.excerpt ? (
+                              <p className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-3 text-sm font-medium text-gray-700">
+                                {entry.excerpt}
+                              </p>
+                            ) : null}
+                          </div>
+                          <div className="text-right">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                              {formatDate(entry.timestamp)}
+                            </p>
+                            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                              {formatRelative(entry.timestamp)}
+                            </p>
+                            {entry.href ? (
+                              <Link
+                                href={entry.href}
+                                className="mt-3 inline-flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-[#6C63FF] hover:underline"
+                              >
+                                Jump to detail <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                              </Link>
+                            ) : null}
+                          </div>
+                        </div>
+                      </li>
+                    ))}
+                  </ol>
+                ) : (
+                  <div className="rounded-2xl border-2 border-dashed border-gray-300 bg-white p-6 text-sm font-semibold text-gray-600">
+                    Your activity trail will appear here once you publish articles or join discussions.
+                  </div>
+                )}
+              </div>
+            </div>
+          </section>
+
+          <section id="capabilities" className="scroll-mt-28 space-y-6">
+            <SectionHeader
+              eyebrow="Capabilities"
+              title="What you can do inside Syntax & Sips"
+              description="A quick reference of powers already unlocked and features coming soon for your membership tier."
+            />
+
+            <div className="grid gap-4 md:grid-cols-2">
+              {capabilities.map((capability) => (
+                <CapabilityCard key={capability.title} {...capability} />
+              ))}
+            </div>
+          </section>
+
+          <section id="rules" className="scroll-mt-28 space-y-6">
+            <SectionHeader
+              eyebrow="Guidelines"
+              title="House rules & benefits"
+              description="Keep these essentials, recommendations, and perks in sight to stay in good standing and maximize your membership."
+            />
+
+            <div className="grid gap-6 lg:grid-cols-4">
+              <div className="space-y-3">
+                <h3 className="flex items-center gap-2 text-lg font-black text-gray-900">
+                  <CheckCircle2 className="h-5 w-5 text-emerald-600" aria-hidden="true" />
+                  Required
+                </h3>
+                {requiredRules.map((rule) => (
+                  <RuleCard key={rule.title} {...rule} />
+                ))}
+              </div>
+
+              <div className="space-y-3">
+                <h3 className="flex items-center gap-2 text-lg font-black text-gray-900">
+                  <Sparkles className="h-5 w-5 text-[#6C63FF]" aria-hidden="true" />
+                  Recommended
+                </h3>
+                {recommendedRules.map((rule) => (
+                  <RuleCard key={rule.title} {...rule} />
+                ))}
+              </div>
+
+              <div className="space-y-3">
+                <h3 className="flex items-center gap-2 text-lg font-black text-gray-900">
+                  <Award className="h-5 w-5 text-[#FF8A65]" aria-hidden="true" />
+                  Complimentary perks
+                </h3>
+                {complimentaryBenefits.map((rule) => (
+                  <RuleCard key={rule.title} {...rule} />
+                ))}
+              </div>
+
+              <div className="space-y-3">
+                <h3 className="flex items-center gap-2 text-lg font-black text-gray-900">
+                  <AlertTriangle className="h-5 w-5 text-red-500" aria-hidden="true" />
+                  Needs attention
+                </h3>
+                {attentionItems.length > 0 ? (
+                  attentionItems.map((rule) => <RuleCard key={rule.title} {...rule} />)
+                ) : (
+                  <div className="rounded-2xl border-2 border-black bg-white p-4 text-sm font-semibold text-gray-600 shadow-[6px_6px_0px_0px_rgba(0,0,0,0.12)]">
+                    All clear! Keep up the excellent community etiquette.
+                  </div>
+                )}
+              </div>
+            </div>
+          </section>
+
+          <section id="resources" className="scroll-mt-28 space-y-6">
+            <SectionHeader
+              eyebrow="Support"
+              title="Resources & help desk"
+              description="Need a refresher on guidelines or a human to chat with? Start here to find the right channel."
+            />
+
+            <div className="grid gap-4 lg:grid-cols-3">
+              <div className="rounded-3xl border-2 border-black bg-white p-5 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.15)]">
+                <h3 className="flex items-center gap-2 text-lg font-black text-gray-900">
+                  <NotebookPen className="h-5 w-5 text-[#6C63FF]" aria-hidden="true" />
+                  Contributor playbook
+                </h3>
+                <p className="mt-2 text-sm font-medium text-gray-600">
+                  Review formatting expectations, tone guidance, and examples of exceptional submissions.
+                </p>
+                <Link
+                  href="/resources"
+                  className="mt-3 inline-flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-[#6C63FF] hover:underline"
+                >
+                  Browse resources <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                </Link>
+              </div>
+
+              <div className="rounded-3xl border-2 border-black bg-white p-5 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.15)]">
+                <h3 className="flex items-center gap-2 text-lg font-black text-gray-900">
+                  <LifeBuoy className="h-5 w-5 text-[#FF5252]" aria-hidden="true" />
+                  Contact the editors
+                </h3>
+                <p className="mt-2 text-sm font-medium text-gray-600">
+                  Need feedback on a draft or help recovering an account? Reach out and we will respond quickly.
+                </p>
+                <Link
+                  href="mailto:editors@syntaxandsips.dev"
+                  className="mt-3 inline-flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-[#FF5252] hover:underline"
+                >
+                  Email editorial desk <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                </Link>
+              </div>
+
+              <div className="rounded-3xl border-2 border-black bg-white p-5 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.15)]">
+                <h3 className="flex items-center gap-2 text-lg font-black text-gray-900">
+                  <UsersRound className="h-5 w-5 text-[#FFD66B]" aria-hidden="true" />
+                  Admin insights
+                </h3>
+                <p className="mt-2 text-sm font-medium text-gray-600">
+                  Admins can review member contributions, flag policy violations, and assign new privileges.
+                </p>
+                <Link
+                  href={currentProfile.isAdmin ? '/admin' : '#community'}
+                  className="mt-3 inline-flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-[#FFD66B] hover:underline"
+                >
+                  {currentProfile.isAdmin ? 'Open moderation tools' : 'See how you contribute'}{' '}
+                  <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                </Link>
+              </div>
+            </div>
           </section>
         </div>
       </div>
     </div>
-  );
-};
+  )
+}

--- a/src/components/auth/UserSignUpForm.tsx
+++ b/src/components/auth/UserSignUpForm.tsx
@@ -56,8 +56,10 @@ export const UserSignUpForm = () => {
 
     if (data.session) {
       await syncAuthState('SIGNED_IN', data.session);
-      setInfo('Account created! Redirecting to your account...');
-      router.replace(redirectTo ?? '/account');
+      setInfo('Account created! Let’s personalise your experience...');
+      const destination = redirectTo ?? '/account';
+      const onboardingRedirect = `/onboarding?redirect=${encodeURIComponent(destination)}`;
+      router.replace(onboardingRedirect);
       return;
     }
 

--- a/src/components/ui/NewNavbar.tsx
+++ b/src/components/ui/NewNavbar.tsx
@@ -1,14 +1,19 @@
 "use client";
 
 import React, { useState, useEffect } from 'react';
-import { Menu, X, Coffee, Code, Search } from 'lucide-react';
+import Image from 'next/image';
+import { Menu, X, Coffee, Code, Search, UserRound } from 'lucide-react';
 import Link from 'next/link';
 import { GlobalSearch } from './GlobalSearch';
 import { useClientPathname } from '@/hooks/useClientPathname';
+import { useAuthenticatedProfile } from '@/hooks/useAuthenticatedProfile';
+import type { AuthenticatedProfileSummary } from '@/utils/types';
 
 export const NewNavbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = useClientPathname();
+  const { profile, isLoading } = useAuthenticatedProfile();
+  const needsOnboarding = Boolean(profile && profile.onboarding?.status !== 'completed');
 
   // Function to check if a path is active
   const isActive = (path: string) => {
@@ -44,18 +49,26 @@ export const NewNavbar = () => {
             </NavLink>
             <GlobalSearch />
             <div className="flex items-center gap-3">
-              <Link
-                href="/signup"
-                className="inline-flex items-center justify-center rounded-md border-2 border-black bg-[#6C63FF] px-4 py-2 text-sm font-extrabold uppercase tracking-wide text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px] hover:shadow-[4px_4px_0px_0px_rgba(108,99,255,0.45)]"
-              >
-                Sign up
-              </Link>
-              <Link
-                href="/login"
-                className="inline-flex items-center justify-center rounded-md border-2 border-black bg-[#FF5252] px-4 py-2 text-sm font-extrabold uppercase tracking-wide text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px] hover:shadow-[4px_4px_0px_0px_rgba(255,82,82,0.45)]"
-              >
-                Sign in
-              </Link>
+              {isLoading ? (
+                <span className="h-10 w-10 rounded-full border-2 border-dashed border-black/40 bg-white animate-pulse" aria-hidden />
+              ) : profile ? (
+                <ProfileShortcut profile={profile} />
+              ) : (
+                <>
+                  <Link
+                    href="/signup"
+                    className="inline-flex items-center justify-center rounded-md border-2 border-black bg-[#6C63FF] px-4 py-2 text-sm font-extrabold uppercase tracking-wide text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px] hover:shadow-[4px_4px_0px_0px_rgba(108,99,255,0.45)]"
+                  >
+                    Sign up
+                  </Link>
+                  <Link
+                    href="/login"
+                    className="inline-flex items-center justify-center rounded-md border-2 border-black bg-[#FF5252] px-4 py-2 text-sm font-extrabold uppercase tracking-wide text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px] hover:shadow-[4px_4px_0px_0px_rgba(255,82,82,0.45)]"
+                  >
+                    Sign in
+                  </Link>
+                </>
+              )}
             </div>
           </nav>
           {/* Mobile actions */}
@@ -96,25 +109,104 @@ export const NewNavbar = () => {
               <MobileNavLink href="/changelog" isActive={isActive('/changelog')}>
                 Changelogs
               </MobileNavLink>
-              <div className="grid grid-cols-2 gap-3">
-                <Link
-                  href="/signup"
-                  className="inline-flex items-center justify-center rounded-md border-2 border-black bg-[#6C63FF] px-4 py-2 text-sm font-extrabold uppercase tracking-wide text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px] hover:shadow-[4px_4px_0px_0px_rgba(108,99,255,0.45)]"
-                >
-                  Sign up
-                </Link>
-                <Link
-                  href="/login"
-                  className="inline-flex items-center justify-center rounded-md border-2 border-black bg-[#FF5252] px-4 py-2 text-sm font-extrabold uppercase tracking-wide text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px] hover:shadow-[4px_4px_0px_0px_rgba(255,82,82,0.45)]"
-                >
-                  Sign in
-                </Link>
-              </div>
+              {isLoading ? (
+                <div className="grid grid-cols-1">
+                  <span className="h-10 rounded-lg border-2 border-dashed border-black/40 bg-white animate-pulse" aria-hidden />
+                </div>
+              ) : profile ? (
+                <div className="flex flex-col space-y-3">
+                  <Link
+                    href="/account"
+                    className="inline-flex items-center justify-center gap-2 rounded-md border-2 border-black bg-[#FFD66B] px-4 py-2 text-sm font-extrabold uppercase tracking-wide text-black shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,0.25)]"
+                  >
+                    <UserRound className="h-4 w-4" aria-hidden="true" />
+                    My profile
+                  </Link>
+                  {needsOnboarding ? (
+                    <Link
+                      href="/onboarding?redirect=/account"
+                      className="inline-flex items-center justify-center rounded-md border-2 border-black bg-[#FF5252] px-4 py-2 text-xs font-extrabold uppercase tracking-wide text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] hover:-translate-y-[1px] hover:shadow-[4px_4px_0px_0px_rgba(255,82,82,0.35)]"
+                    >
+                      Finish onboarding
+                    </Link>
+                  ) : null}
+                  <Link
+                    href="/account#contributions"
+                    className="inline-flex items-center justify-center rounded-md border-2 border-dashed border-black/50 bg-white px-4 py-2 text-xs font-bold uppercase tracking-wide text-black/70"
+                  >
+                    View contributions
+                  </Link>
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 gap-3">
+                  <Link
+                    href="/signup"
+                    className="inline-flex items-center justify-center rounded-md border-2 border-black bg-[#6C63FF] px-4 py-2 text-sm font-extrabold uppercase tracking-wide text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px] hover:shadow-[4px_4px_0px_0px_rgba(108,99,255,0.45)]"
+                  >
+                    Sign up
+                  </Link>
+                  <Link
+                    href="/login"
+                    className="inline-flex items-center justify-center rounded-md border-2 border-black bg-[#FF5252] px-4 py-2 text-sm font-extrabold uppercase tracking-wide text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px] hover:shadow-[4px_4px_0px_0px_rgba(255,82,82,0.45)]"
+                  >
+                    Sign in
+                  </Link>
+                </div>
+              )}
             </div>
           </div>
         )}
       </div>
     </header>
+  );
+};
+
+interface ProfileShortcutProps {
+  profile: AuthenticatedProfileSummary;
+}
+
+const ProfileShortcut = ({ profile }: ProfileShortcutProps) => {
+  const onboardingStatus = profile.onboarding?.status ?? 'pending';
+  const helperLabel = onboardingStatus === 'completed' ? 'Open dashboard' : 'Finish onboarding';
+  const helperTone = onboardingStatus === 'completed' ? 'text-[#6C63FF]' : 'text-[#FF5252]';
+  const hoverBadgeLabel = onboardingStatus === 'completed' ? 'View' : 'Resume';
+
+  return (
+    <Link
+      href="/account"
+      className="group relative inline-flex items-center gap-3 rounded-full border-2 border-black bg-white px-2 py-1 pr-4 shadow-[3px_3px_0px_0px_rgba(0,0,0,0.15)] transition hover:-translate-y-[1px] hover:shadow-[5px_5px_0px_0px_rgba(0,0,0,0.2)]"
+    >
+      <span className="relative inline-flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border-2 border-black bg-[#F6EDE3] text-sm font-black uppercase text-black">
+        {profile.avatarUrl ? (
+          <Image
+            src={profile.avatarUrl}
+            alt={`${profile.displayName}'s avatar`}
+            fill
+            sizes="40px"
+            className="object-cover"
+          />
+        ) : (
+          <UserRound className="h-5 w-5" aria-hidden="true" />
+        )}
+        {onboardingStatus !== 'completed' ? (
+          <span className="absolute -top-1 -right-1 inline-flex h-4 w-4 items-center justify-center rounded-full border border-black bg-[#FF5252] text-[10px] font-black text-white">
+            !
+          </span>
+        ) : null}
+      </span>
+      <span className="hidden flex-col text-left xl:flex">
+        <span className="text-sm font-extrabold leading-tight text-black">
+          {profile.displayName}
+        </span>
+        <span className={`text-xs font-semibold uppercase tracking-wide ${helperTone}`}>
+          {helperLabel}
+        </span>
+      </span>
+      <span className="absolute -bottom-2 right-3 hidden rounded-full bg-[#6C63FF] px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-white shadow-[2px_2px_0px_0px_rgba(0,0,0,0.15)] group-hover:block">
+        {hoverBadgeLabel}
+      </span>
+      <span className="sr-only">Go to your profile</span>
+    </Link>
   );
 };
 

--- a/src/hooks/useAuthenticatedProfile.ts
+++ b/src/hooks/useAuthenticatedProfile.ts
@@ -1,0 +1,88 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { AuthenticatedProfileSummary } from '@/utils/types'
+import { createBrowserClient } from '@/lib/supabase/client'
+
+interface UseAuthenticatedProfileResult {
+  profile: AuthenticatedProfileSummary | null
+  isLoading: boolean
+  refresh: () => Promise<void>
+}
+
+export const useAuthenticatedProfile = (): UseAuthenticatedProfileResult => {
+  const supabase = useMemo(() => createBrowserClient(), [])
+  const mountedRef = useRef(true)
+  const [profile, setProfile] = useState<AuthenticatedProfileSummary | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => () => {
+    mountedRef.current = false
+  }, [])
+
+  const loadProfile = useCallback(async () => {
+    setIsLoading(true)
+
+    try {
+      const response = await fetch('/api/auth/me', {
+        method: 'GET',
+        cache: 'no-store',
+        credentials: 'include',
+      })
+
+      if (!mountedRef.current) {
+        return
+      }
+
+      if (!response.ok) {
+        if (response.status === 401 || response.status === 404) {
+          setProfile(null)
+          setIsLoading(false)
+          return
+        }
+
+        console.error('Failed to resolve authenticated profile', await response.text())
+        setProfile(null)
+        setIsLoading(false)
+        return
+      }
+
+      const { profile: payload } = (await response.json()) as {
+        profile: AuthenticatedProfileSummary
+      }
+
+      setProfile(payload)
+    } catch (error) {
+      if (mountedRef.current) {
+        console.error('Failed to resolve authenticated profile', error)
+        setProfile(null)
+      }
+    } finally {
+      if (mountedRef.current) {
+        setIsLoading(false)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadProfile()
+  }, [loadProfile])
+
+  useEffect(() => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(() => {
+      void loadProfile()
+    })
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [loadProfile, supabase])
+
+  const refresh = useCallback(async () => {
+    await loadProfile()
+  }, [loadProfile])
+
+  return { profile, isLoading, refresh }
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -12,4 +12,10 @@ if (!supabaseAnonKey) {
 }
 
 export const createBrowserClient = () =>
-  createSupabaseBrowserClient(supabaseUrl, supabaseAnonKey)
+  createSupabaseBrowserClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      autoRefreshToken: true,
+      persistSession: true,
+      detectSessionInUrl: true,
+    },
+  })

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -74,6 +74,82 @@ export interface AdminUserRole {
   priority: number
 }
 
+export type OnboardingStatus = 'pending' | 'in_progress' | 'completed'
+
+export type OnboardingPersona =
+  | 'learning-explorer'
+  | 'hands-on-builder'
+  | 'community-connector'
+  | 'career-switcher'
+  | 'team-enabler'
+
+export type OnboardingExperienceLevel =
+  | 'early-career'
+  | 'mid-level'
+  | 'senior-practitioner'
+  | 'strategic-leader'
+
+export type OnboardingGoal =
+  | 'publish-signature-series'
+  | 'grow-technical-voice'
+  | 'level-up-ai-skills'
+  | 'ship-side-projects'
+  | 'find-peers'
+  | 'transition-role'
+
+export type OnboardingContribution =
+  | 'write-articles'
+  | 'host-events'
+  | 'share-code-snippets'
+  | 'produce-videos'
+  | 'mentor-community'
+
+export type OnboardingLearningFormat =
+  | 'deep-dives'
+  | 'quick-tips'
+  | 'live-builds'
+  | 'case-studies'
+  | 'audio-notes'
+
+export type OnboardingSupportPreference =
+  | 'editorial-reviews'
+  | 'pair-programming'
+  | 'career-coaching'
+  | 'community-challenges'
+  | 'office-hours'
+
+export type OnboardingAccountability =
+  | 'progress-updates'
+  | 'quiet-focus'
+  | 'public-goals'
+  | 'one-on-one'
+
+export type OnboardingCommunication =
+  | 'weekly-digest'
+  | 'event-reminders'
+  | 'opportunity-alerts'
+  | 'product-updates'
+
+export interface ProfileOnboardingResponses {
+  persona: OnboardingPersona | null
+  experienceLevel: OnboardingExperienceLevel | null
+  motivations: OnboardingGoal[]
+  focusAreas: OnboardingContribution[]
+  preferredLearningFormats: OnboardingLearningFormat[]
+  supportPreferences: OnboardingSupportPreference[]
+  accountabilityStyle: OnboardingAccountability | null
+  communicationPreferences: OnboardingCommunication[]
+}
+
+export interface ProfileOnboardingJourney {
+  status: OnboardingStatus
+  currentStep: string | null
+  completedAt: string | null
+  updatedAt?: string | null
+  version: string | null
+  responses: ProfileOnboardingResponses | null
+}
+
 export interface AdminUserSummary {
   profileId: string
   userId: string
@@ -116,4 +192,55 @@ export interface AdminCommentSummary {
   postSlug: string
   authorDisplayName: string | null
   authorProfileId: string | null
+}
+
+export interface AuthenticatedProfileSummary {
+  userId: string
+  email: string
+  displayName: string
+  avatarUrl: string | null
+  isAdmin: boolean
+  createdAt: string
+  lastSignInAt: string | null
+  emailConfirmedAt: string | null
+  primaryRoleId: string | null
+  roles: AdminUserRole[]
+  onboarding: ProfileOnboardingJourney | null
+}
+
+export interface UserPostSummary {
+  id: string
+  title: string
+  slug: string | null
+  status: PostStatus
+  views: number
+  createdAt: string
+  publishedAt: string | null
+}
+
+export interface UserCommentSummary {
+  id: string
+  content: string
+  status: CommentStatus
+  createdAt: string
+  postTitle: string | null
+  postSlug: string | null
+}
+
+export interface UserContributionTotals {
+  totalPosts: number
+  publishedPosts: number
+  draftPosts: number
+  scheduledPosts: number
+  totalViews: number
+  totalComments: number
+  approvedComments: number
+  pendingComments: number
+  rejectedComments: number
+}
+
+export interface UserContributionSnapshot {
+  posts: UserPostSummary[]
+  comments: UserCommentSummary[]
+  totals: UserContributionTotals
 }

--- a/supabase/migrations/0010_create_profile_photos_bucket.sql
+++ b/supabase/migrations/0010_create_profile_photos_bucket.sql
@@ -1,0 +1,97 @@
+-- Create a public bucket for user profile photos and lock it down per-user for writes
+insert into storage.buckets (id, name, public)
+select 'profile-photos', 'profile-photos', true
+where not exists (
+  select 1
+  from storage.buckets
+  where id = 'profile-photos'
+);
+
+-- Ensure bucket stays public if it already existed
+update storage.buckets
+set public = true
+where id = 'profile-photos';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'Avatar images are publicly accessible'
+  ) THEN
+    CREATE POLICY "Avatar images are publicly accessible"
+      ON storage.objects
+      FOR SELECT
+      USING (bucket_id = 'profile-photos');
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'Users can upload their avatar'
+  ) THEN
+    CREATE POLICY "Users can upload their avatar"
+      ON storage.objects
+      FOR INSERT
+      TO authenticated
+      WITH CHECK (
+        bucket_id = 'profile-photos'
+        AND auth.uid()::text = split_part(name, '/', 1)
+      );
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'Users can update their avatar'
+  ) THEN
+    CREATE POLICY "Users can update their avatar"
+      ON storage.objects
+      FOR UPDATE
+      TO authenticated
+      USING (
+        bucket_id = 'profile-photos'
+        AND auth.uid()::text = split_part(name, '/', 1)
+      )
+      WITH CHECK (
+        bucket_id = 'profile-photos'
+        AND auth.uid()::text = split_part(name, '/', 1)
+      );
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'Users can delete their avatar'
+  ) THEN
+    CREATE POLICY "Users can delete their avatar"
+      ON storage.objects
+      FOR DELETE
+      TO authenticated
+      USING (
+        bucket_id = 'profile-photos'
+        AND auth.uid()::text = split_part(name, '/', 1)
+      );
+  END IF;
+END
+$$;

--- a/supabase/migrations/0011_add_onboarding_flow.sql
+++ b/supabase/migrations/0011_add_onboarding_flow.sql
@@ -1,0 +1,88 @@
+-- Create onboarding status enum if it does not already exist
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'onboarding_status') THEN
+    CREATE TYPE onboarding_status AS ENUM ('pending', 'in_progress', 'completed');
+  END IF;
+END;
+$$;
+
+-- Create table to store personalized onboarding journeys
+CREATE TABLE IF NOT EXISTS public.profile_onboarding_journeys (
+  profile_id uuid PRIMARY KEY REFERENCES public.profiles(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  status onboarding_status NOT NULL DEFAULT 'pending',
+  current_step text,
+  responses jsonb NOT NULL DEFAULT '{}'::jsonb,
+  version text NOT NULL DEFAULT '2025.02',
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  completed_at timestamptz
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS profile_onboarding_journeys_user_id_key
+  ON public.profile_onboarding_journeys(user_id);
+
+-- Ensure updated_at stays fresh
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'profile_onboarding_journeys_set_updated_at'
+  ) THEN
+    CREATE TRIGGER profile_onboarding_journeys_set_updated_at
+      BEFORE UPDATE ON public.profile_onboarding_journeys
+      FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+  END IF;
+END;
+$$;
+
+-- Automatically seed onboarding journeys for every profile
+CREATE OR REPLACE FUNCTION public.create_onboarding_journey_for_profile()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.profile_onboarding_journeys (profile_id, user_id)
+  VALUES (NEW.id, NEW.user_id)
+  ON CONFLICT (profile_id) DO UPDATE
+    SET user_id = EXCLUDED.user_id;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS create_onboarding_journey_for_profile ON public.profiles;
+
+CREATE TRIGGER create_onboarding_journey_for_profile
+  AFTER INSERT ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION public.create_onboarding_journey_for_profile();
+
+-- Backfill for existing profiles
+INSERT INTO public.profile_onboarding_journeys (profile_id, user_id)
+SELECT p.id, p.user_id
+FROM public.profiles p
+ON CONFLICT (profile_id) DO UPDATE
+  SET user_id = EXCLUDED.user_id;
+
+-- Enable and configure RLS
+ALTER TABLE public.profile_onboarding_journeys ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their onboarding"
+  ON public.profile_onboarding_journeys
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can record onboarding progress"
+  ON public.profile_onboarding_journeys
+  FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can start their onboarding"
+  ON public.profile_onboarding_journeys
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add a multi-step onboarding flow that captures persona, goals, enablement needs, and support preferences while persisting progress in Supabase
- surface onboarding journey status and insights across the account dashboard, navbar shortcut, and auth flows so new or incomplete users resume orientation
- extend the data model with onboarding journey types, API exposure, and a Supabase migration that seeds, backfills, and protects the new table

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e54df4a9c4832d895cc3fedb67e0b1