### PR TITLE
Sanitize redirect parameters in auth flows

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { createServerComponentClient } from '@/lib/supabase/server-client';
 import { OnboardingFlow } from '@/components/auth/OnboardingFlow';
+import { sanitizeRedirect } from '@/utils/sanitizeRedirect';
 import type { ProfileOnboardingJourney } from '@/utils/types';
 
 export const dynamic = 'force-dynamic';
@@ -8,21 +9,6 @@ export const dynamic = 'force-dynamic';
 interface OnboardingPageProps {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }
-
-const sanitizeRedirect = (value: string | string[] | null | undefined) => {
-  const candidate = Array.isArray(value) ? value[0] : value;
-
-  if (!candidate || typeof candidate !== 'string') {
-    return '/account';
-  }
-
-  try {
-    const url = new URL(candidate, 'http://localhost');
-    return url.pathname.startsWith('/') ? url.pathname + url.search + url.hash : '/account';
-  } catch {
-    return candidate.startsWith('/') ? candidate : '/account';
-  }
-};
 
 export default async function OnboardingPage({ searchParams }: OnboardingPageProps) {
   const resolvedSearchParams = searchParams ? await searchParams : undefined;

--- a/src/components/auth/UserSignInForm.tsx
+++ b/src/components/auth/UserSignInForm.tsx
@@ -9,6 +9,7 @@ import { syncAuthState } from '@/lib/supabase/sync-auth-state';
 import { useSupabaseAuthSync } from '@/hooks/useSupabaseAuthSync';
 import '@/styles/neo-brutalism.css';
 import type { AuthenticatedProfileSummary } from '@/utils/types';
+import { sanitizeRedirect } from '@/utils/sanitizeRedirect';
 
 export const UserSignInForm = () => {
   const router = useRouter();
@@ -21,7 +22,7 @@ export const UserSignInForm = () => {
   const [info, setInfo] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
-  const redirectTo = searchParams.get('redirect_to');
+  const redirectTo = sanitizeRedirect(searchParams.get('redirect_to'), { defaultValue: null });
 
   const emailConfirmed = searchParams.get('email_confirmed');
   const authError = searchParams.get('error_description') ?? searchParams.get('error');

--- a/src/components/auth/UserSignUpForm.tsx
+++ b/src/components/auth/UserSignUpForm.tsx
@@ -9,6 +9,7 @@ import { syncAuthState } from '@/lib/supabase/sync-auth-state';
 import { useSupabaseAuthSync } from '@/hooks/useSupabaseAuthSync';
 import '@/styles/neo-brutalism.css';
 import { getSiteUrl } from '@/lib/site-url';
+import { sanitizeRedirect } from '@/utils/sanitizeRedirect';
 
 export const UserSignUpForm = () => {
   const router = useRouter();
@@ -23,7 +24,7 @@ export const UserSignUpForm = () => {
   const [info, setInfo] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
-  const redirectTo = searchParams.get('redirect_to');
+  const redirectTo = sanitizeRedirect(searchParams.get('redirect_to'), { defaultValue: null });
 
   useSupabaseAuthSync(supabase);
 

--- a/src/utils/sanitizeRedirect.ts
+++ b/src/utils/sanitizeRedirect.ts
@@ -1,0 +1,45 @@
+export interface SanitizeRedirectOptions {
+  defaultValue?: string | null;
+}
+
+const DEFAULT_BASE_URL = 'http://localhost';
+
+const hasProtocol = (value: string) => /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value);
+
+export const sanitizeRedirect = (
+  value: string | string[] | null | undefined,
+  options: SanitizeRedirectOptions = {},
+): string | null => {
+  const { defaultValue = '/account' } = options;
+  const candidate = Array.isArray(value) ? value[0] : value;
+
+  if (!candidate || typeof candidate !== 'string') {
+    return defaultValue;
+  }
+
+  const trimmed = candidate.trim();
+
+  if (!trimmed) {
+    return defaultValue;
+  }
+
+  if (trimmed.startsWith('//') || hasProtocol(trimmed)) {
+    return defaultValue;
+  }
+
+  if (trimmed.startsWith('/')) {
+    return trimmed;
+  }
+
+  try {
+    const url = new URL(trimmed, DEFAULT_BASE_URL);
+
+    if (url.origin !== DEFAULT_BASE_URL) {
+      return defaultValue;
+    }
+
+    return url.pathname + url.search + url.hash;
+  } catch {
+    return defaultValue;
+  }
+};


### PR DESCRIPTION
## Summary
- add a shared sanitizeRedirect helper that filters redirect targets to internal routes
- use the helper in the sign-up form to guard confirmation redirect URLs and follow-up onboarding routing
- apply the same sanitization to sign-in navigation and reuse it in the onboarding page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e57256304c832da460961ff68d5e76