### PR TITLE
Fix build errors from avatar upload and onboarding redirect

### DIFF
--- a/src/app/api/profile/avatar/route.ts
+++ b/src/app/api/profile/avatar/route.ts
@@ -124,16 +124,23 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Unable to process upload.' }, { status: 400 })
   }
 
-  const file = formData.get('file')
+  const fileEntry = formData.get('file')
+  const candidateFile = fileEntry instanceof File ? fileEntry : null
 
   try {
-    validateFile(file instanceof File ? file : null)
+    validateFile(candidateFile)
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Invalid upload.' },
       { status: 400 },
     )
   }
+
+  if (!candidateFile) {
+    return NextResponse.json({ error: 'No file provided.' }, { status: 400 })
+  }
+
+  const file = candidateFile
 
   let serviceClient
   try {

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -64,7 +64,7 @@ export default async function OnboardingPage({ searchParams }: OnboardingPagePro
         responses: null,
       };
 
-  const redirectPath = sanitizeRedirect(resolvedSearchParams?.redirect);
+  const redirectPath = sanitizeRedirect(resolvedSearchParams?.redirect) ?? '/account';
 
   return (
     <OnboardingFlow


### PR DESCRIPTION
## Summary
- guard the avatar upload API against missing files so the type checker recognizes the validated File instance
- ensure the onboarding page always passes a string redirect path to the onboarding flow component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5751ee0e0832d8a032fbcfe6d49e1