### PR TITLE
Add Vercel Analytics tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@react-three/postprocessing": "^3.0.4",
         "@supabase/ssr": "^0.5.0",
         "@supabase/supabase-js": "^2.48.0",
+        "@vercel/analytics": "^1.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.8.0",
@@ -4397,6 +4398,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@webgpu/types": {
       "version": "0.1.65",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@react-three/postprocessing": "^3.0.4",
     "@supabase/ssr": "^0.5.0",
     "@supabase/supabase-js": "^2.48.0",
+    "@vercel/analytics": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.8.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 import "@/styles/neo-brutalism.css";
 import ConditionalNavbar from "@/components/ConditionalNavbar";
@@ -61,6 +62,7 @@ export default async function RootLayout({
           <Loader />
           <ConditionalNavbar initialPathname={initialPathname} />
           {children}
+          <Analytics />
         </LoaderProvider>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- add the @vercel/analytics dependency
- render the Analytics component from @vercel/analytics/next in the app layout to enable tracking

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e67704d4f0832da497299a2e4d462a