### PR TITLE
Fix duplicate profile creation when adding admin users

### DIFF
--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -160,11 +160,14 @@ export async function POST(request: Request) {
 
     const { data: profileData, error: profileError } = await serviceClient
       .from('profiles')
-      .insert({
-        user_id: authUser.id,
-        display_name: displayName,
-        is_admin: isAdmin,
-      })
+      .upsert(
+        {
+          user_id: authUser.id,
+          display_name: displayName,
+          is_admin: isAdmin,
+        },
+        { onConflict: 'user_id' },
+      )
       .select(
         `id, user_id, display_name, is_admin, created_at, primary_role_id,
          profile_roles(role:roles(id, slug, name, description, priority))`,


### PR DESCRIPTION
## Summary
- replace the manual profile insert in the admin user API with an upsert keyed on `user_id`
- prevent duplicate key errors triggered by the automatic profile provisioning trigger

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e68da01788832d9d5e82b15189f3e4