### PR TITLE
feat: introduce gamification data layer and UI

### DIFF
--- a/docs/gamification-compliance.md
+++ b/docs/gamification-compliance.md
@@ -1,0 +1,46 @@
+# Gamification DPIA & Compliance Checklist
+
+This document summarises the foundational governance work completed for the Syntax & Sips gamification rollout.
+
+## Data Protection Impact Assessment Summary
+
+- **Purpose & scope:** The gamification system processes engagement signals (post views, comment approvals, onboarding completion, challenge participation) to award XP, badges, streaks, and roles. Personal data processed remains limited to existing `profiles` records plus opt-in preferences stored in `gamification_profiles.settings`.
+- **Legal basis:** Community participation is governed by the Syntax & Sips Terms of Use; gamification is considered legitimate interest with an explicit opt-in toggle stored per profile (`gamification_profiles.opted_in`). Users can withdraw consent at any time via profile settings.
+- **Data flows:** Events are written to `gamification_actions` with metadata, aggregated into `gamification_profiles`, and surfaced through Next.js API routes. Admin operations are logged to `gamification_audit` ensuring traceability.
+- **Risk mitigation:**
+  - Row level security policies restrict access to owners and admins for all gamification tables.
+  - Audit triggers capture XP/level changes for incident investigation.
+  - Consent toggle is enforced in the points engine before any XP is awarded.
+  - Age gating reuses existing onboarding checks; under-13 profiles remain opted-out by default.
+
+## Privacy Policy & Retention Notes
+
+- **Privacy policy update:** Add a new section describing storage of progression data (XP totals, challenge history, badge ownership) and purpose of motivational feedback.
+- **Retention:** Gamification actions are retained for 24 months for analytics before archival. Audit logs are retained for 36 months for compliance.
+- **User controls:**
+  - Opt-in/opt-out managed via `gamification_profiles.opted_in`.
+  - Manual XP adjustments require admin justification recorded in `gamification_audit`.
+  - Export requests can leverage the `leaderboard_snapshots` payload for quick fulfilment.
+
+## Security Posture
+
+- RLS policies implemented for every gamification table (see `supabase/migrations/0012_create_gamification_schema.sql`).
+- Service role policies isolate write access for background jobs (`auth.role() = 'service_role'`).
+- Cached leaderboard payloads respect TTL controls to prevent stale exposure.
+- Admin APIs enforce authentication via `requireAdmin` helper to avoid privilege escalation.
+
+## Monitoring & Alerting
+
+- Badge/Challenge admin endpoints surface success messages and persist audit entries for manual adjustments.
+- Leaderboard and analytics queries are cached (Upstash-ready) with hit/miss logging to `console` for early diagnostics.
+- Future work: integrate with the existing observability stack to emit metrics for XP throughput, badge unlock rates, and challenge completion velocity.
+
+## Accessibility & UX Guardrails
+
+- All gamification UI components follow neobrutalist styling with large tap targets and WCAG-compliant contrast.
+- Progress visuals expose textual summaries for assistive technologies.
+- Admin workflows provide validation feedback and loading indicators to communicate long-running operations.
+
+---
+
+_Last updated: 2025-02-14_

--- a/env.d.ts
+++ b/env.d.ts
@@ -12,5 +12,7 @@ declare namespace NodeJS {
     MAILTRAP_PASS?: string
     MAILTRAP_FROM_EMAIL?: string
     MAILTRAP_FROM_NAME?: string
+    UPSTASH_REDIS_REST_URL?: string
+    UPSTASH_REDIS_REST_TOKEN?: string
   }
 }

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -158,6 +158,7 @@ export default async function AccountPage() {
       : user.email ?? 'Community friend';
 
   const profileSummary: AuthenticatedProfileSummary = {
+    profileId: profileRecord.id as string,
     userId: user.id,
     email: user.email ?? '',
     displayName: resolvedDisplayName,

--- a/src/app/api/admin/gamification/analytics/route.ts
+++ b/src/app/api/admin/gamification/analytics/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server'
+import { createServiceRoleClient } from '@/lib/supabase/server-client'
+import { requireAdmin } from '../shared'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const result = await requireAdmin()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const supabase = createServiceRoleClient()
+
+  const [profilesQuery, badgesQuery, challengesQuery] = await Promise.all([
+    supabase
+      .from('gamification_profiles')
+      .select('profile_id, xp_total, level, current_streak', { count: 'exact' }),
+    supabase
+      .from('profile_badges')
+      .select('badge_id, badges:badge_id (slug)', { count: 'exact' }),
+    supabase
+      .from('profile_challenge_progress')
+      .select('status', { count: 'exact' }),
+  ])
+
+  if (profilesQuery.error) {
+    return NextResponse.json({ error: profilesQuery.error.message }, { status: 500 })
+  }
+
+  const profiles = profilesQuery.data ?? []
+  const totalProfiles = profilesQuery.count ?? profiles.length
+  const totalXp = profiles.reduce((sum, profile) => sum + Number(profile.xp_total ?? 0), 0)
+  const averageLevel = totalProfiles > 0
+    ? profiles.reduce((sum, profile) => sum + Number(profile.level ?? 1), 0) / totalProfiles
+    : 0
+
+  const streakLeaders = [...profiles]
+    .sort((a, b) => Number(b.current_streak ?? 0) - Number(a.current_streak ?? 0))
+    .slice(0, 5)
+    .map((entry) => ({
+      profileId: entry.profile_id,
+      streak: Number(entry.current_streak ?? 0),
+      level: Number(entry.level ?? 1),
+      xp: Number(entry.xp_total ?? 0),
+    }))
+
+  const badgeCounts: Record<string, number> = {}
+
+  if (!badgesQuery.error) {
+    for (const entry of badgesQuery.data ?? []) {
+      const slug = Array.isArray(entry.badges) ? entry.badges[0]?.slug : (entry as any)?.badges?.slug
+      if (typeof slug === 'string') {
+        badgeCounts[slug] = (badgeCounts[slug] ?? 0) + 1
+      }
+    }
+  }
+
+  const challengeStatusCounts: Record<string, number> = {}
+  if (!challengesQuery.error) {
+    for (const entry of challengesQuery.data ?? []) {
+      const status = typeof entry.status === 'string' ? entry.status : 'unknown'
+      challengeStatusCounts[status] = (challengeStatusCounts[status] ?? 0) + 1
+    }
+  }
+
+  return NextResponse.json({
+    profiles: {
+      total: totalProfiles,
+      totalXp,
+      averageLevel: Number(averageLevel.toFixed(2)),
+      streakLeaders,
+    },
+    badges: badgeCounts,
+    challenges: challengeStatusCounts,
+  })
+}

--- a/src/app/api/admin/gamification/badges/route.ts
+++ b/src/app/api/admin/gamification/badges/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from 'next/server'
+import { createServiceRoleClient } from '@/lib/supabase/server-client'
+import { requireAdmin } from '../shared'
+
+export const dynamic = 'force-dynamic'
+
+const sanitizeString = (value: unknown) => (typeof value === 'string' ? value.trim() : '')
+const sanitizeBoolean = (value: unknown, fallback = false) =>
+  typeof value === 'boolean' ? value : fallback
+
+export async function GET() {
+  const result = await requireAdmin()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const supabase = createServiceRoleClient()
+
+  const { data, error } = await supabase
+    .from('gamification_badges')
+    .select('*, profile_badges(count)')
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  const badges = (data ?? []).map((badge) => ({
+    id: badge.id,
+    slug: badge.slug,
+    name: badge.name,
+    description: badge.description,
+    category: badge.category,
+    rarity: badge.rarity,
+    icon: badge.icon,
+    theme: badge.theme,
+    rewardPoints: badge.reward_points,
+    requirements: badge.requirements,
+    isTimeLimited: badge.is_time_limited,
+    availableFrom: badge.available_from,
+    availableTo: badge.available_to,
+    totalAwarded: Array.isArray(badge.profile_badges)
+      ? (badge.profile_badges[0]?.count as number | null) ?? 0
+      : 0,
+  }))
+
+  return NextResponse.json({ badges })
+}
+
+export async function POST(request: Request) {
+  const result = await requireAdmin()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const payload = (await request.json().catch(() => ({}))) as Record<string, unknown>
+
+  const id = sanitizeString(payload.id)
+  const slug = sanitizeString(payload.slug)
+  const name = sanitizeString(payload.name)
+  const category = sanitizeString(payload.category)
+  const rarity = sanitizeString(payload.rarity || 'common') || 'common'
+  const description = sanitizeString(payload.description) || null
+  const icon = sanitizeString(payload.icon) || null
+  const theme = sanitizeString(payload.theme) || null
+  const rewardPoints = Number(payload.rewardPoints ?? 0)
+  const requirements = (payload.requirements as Record<string, unknown> | undefined) ?? {}
+  const isTimeLimited = sanitizeBoolean(payload.isTimeLimited, false)
+  const availableFrom = sanitizeString(payload.availableFrom) || null
+  const availableTo = sanitizeString(payload.availableTo) || null
+
+  if (!slug || !name || !category) {
+    return NextResponse.json(
+      { error: 'Slug, name, and category are required.' },
+      { status: 422 },
+    )
+  }
+
+  const supabase = createServiceRoleClient()
+
+  const { data, error } = await supabase
+    .from('gamification_badges')
+    .upsert(
+      {
+        id: id || undefined,
+        slug,
+        name,
+        category,
+        rarity,
+        description,
+        icon,
+        theme,
+        reward_points: rewardPoints,
+        requirements,
+        is_time_limited: isTimeLimited,
+        available_from: availableFrom,
+        available_to: availableTo,
+      },
+      { onConflict: 'slug' },
+    )
+    .select('*')
+    .maybeSingle()
+
+  if (error || !data) {
+    return NextResponse.json(
+      { error: error?.message ?? 'Unable to save badge.' },
+      { status: 500 },
+    )
+  }
+
+  await supabase.from('gamification_audit').insert({
+    action: 'badge_catalog_update',
+    delta: null,
+    metadata: { badgeSlug: slug },
+    reason: 'Badge catalog updated via admin API',
+  })
+
+  return NextResponse.json({ badge: data })
+}

--- a/src/app/api/admin/gamification/challenges/route.ts
+++ b/src/app/api/admin/gamification/challenges/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from 'next/server'
+import { createServiceRoleClient } from '@/lib/supabase/server-client'
+import { requireAdmin } from '../shared'
+
+export const dynamic = 'force-dynamic'
+
+const sanitizeString = (value: unknown) => (typeof value === 'string' ? value.trim() : '')
+const sanitizeNumber = (value: unknown, fallback = 0) => {
+  const num = Number(value)
+  return Number.isFinite(num) ? num : fallback
+}
+
+export async function GET() {
+  const result = await requireAdmin()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const supabase = createServiceRoleClient()
+  const { data, error } = await supabase
+    .from('gamification_challenges')
+    .select('*, profile_challenge_progress(count)')
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  const challenges = (data ?? []).map((challenge) => ({
+    id: challenge.id,
+    slug: challenge.slug,
+    title: challenge.title,
+    description: challenge.description,
+    cadence: challenge.cadence,
+    requirements: challenge.requirements,
+    rewardPoints: challenge.reward_points,
+    rewardBadgeId: challenge.reward_badge_id,
+    startsAt: challenge.starts_at,
+    endsAt: challenge.ends_at,
+    isActive: challenge.is_active,
+    participantCount: Array.isArray(challenge.profile_challenge_progress)
+      ? (challenge.profile_challenge_progress[0]?.count as number | null) ?? 0
+      : 0,
+  }))
+
+  return NextResponse.json({ challenges })
+}
+
+export async function POST(request: Request) {
+  const result = await requireAdmin()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const payload = (await request.json().catch(() => ({}))) as Record<string, unknown>
+
+  const id = sanitizeString(payload.id)
+  const slug = sanitizeString(payload.slug)
+  const title = sanitizeString(payload.title)
+  const description = sanitizeString(payload.description) || null
+  const cadence = sanitizeString(payload.cadence) as
+    | 'daily'
+    | 'weekly'
+    | 'monthly'
+    | 'seasonal'
+    | 'event'
+  const rewardPoints = sanitizeNumber(payload.rewardPoints, 0)
+  const rewardBadgeId = sanitizeString(payload.rewardBadgeId) || null
+  const startsAt = sanitizeString(payload.startsAt) || null
+  const endsAt = sanitizeString(payload.endsAt) || null
+  const isActive = typeof payload.isActive === 'boolean' ? payload.isActive : true
+  const requirements = (payload.requirements as Record<string, unknown> | undefined) ?? {}
+
+  if (!slug || !title || !cadence) {
+    return NextResponse.json(
+      { error: 'Slug, title, and cadence are required.' },
+      { status: 422 },
+    )
+  }
+
+  const supabase = createServiceRoleClient()
+  const { data, error } = await supabase
+    .from('gamification_challenges')
+    .upsert(
+      {
+        id: id || undefined,
+        slug,
+        title,
+        description,
+        cadence,
+        reward_points: rewardPoints,
+        reward_badge_id: rewardBadgeId,
+        starts_at: startsAt,
+        ends_at: endsAt,
+        is_active: isActive,
+        requirements,
+      },
+      { onConflict: 'slug' },
+    )
+    .select('*')
+    .maybeSingle()
+
+  if (error || !data) {
+    return NextResponse.json({ error: error?.message ?? 'Unable to save challenge.' }, { status: 500 })
+  }
+
+  await supabase.from('gamification_audit').insert({
+    action: 'challenge_catalog_update',
+    delta: null,
+    metadata: { challengeSlug: slug },
+    reason: 'Challenge catalog updated via admin API',
+  })
+
+  return NextResponse.json({ challenge: data })
+}

--- a/src/app/api/admin/gamification/shared.ts
+++ b/src/app/api/admin/gamification/shared.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server'
+import { createServerComponentClient } from '@/lib/supabase/server-client'
+
+export const requireAdmin = async (): Promise<
+  | { response: NextResponse }
+  | { profile: { id: string } }
+> => {
+  const supabase = createServerComponentClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, is_admin')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (error) {
+    return {
+      response: NextResponse.json({ error: `Unable to load profile: ${error.message}` }, { status: 500 }),
+    }
+  }
+
+  if (!profile || !profile.is_admin) {
+    return {
+      response: NextResponse.json(
+        { error: 'Forbidden: admin access required.' },
+        { status: 403 },
+      ),
+    }
+  }
+
+  return { profile: { id: profile.id } }
+}

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -145,6 +145,7 @@ export async function GET() {
         : user.email ?? ''
 
     const payload: AuthenticatedProfileSummary = {
+      profileId: profile.id,
       userId: user.id,
       email: user.email ?? '',
       displayName: preferredDisplayName,

--- a/src/app/api/gamification/actions/route.ts
+++ b/src/app/api/gamification/actions/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from 'next/server'
+import { createServerComponentClient, createServiceRoleClient } from '@/lib/supabase/server-client'
+import type { GamificationActionType } from '@/lib/gamification/types'
+import { recordAction } from '@/lib/gamification/points-engine'
+
+export const dynamic = 'force-dynamic'
+
+interface RequestPayload {
+  profileId?: string
+  actionType?: GamificationActionType
+  metadata?: Record<string, unknown>
+  actionSource?: string
+  requestId?: string
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json().catch(() => ({}))) as RequestPayload
+
+  const supabaseAuth = createServerComponentClient()
+  const {
+    data: { user },
+  } = await supabaseAuth.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Authentication required.' }, { status: 401 })
+  }
+
+  const supabase = createServiceRoleClient()
+
+  const { data: profileRecord, error: profileError } = await supabase
+    .from('profiles')
+    .select('id, user_id, is_admin')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    return NextResponse.json({ error: profileError.message }, { status: 500 })
+  }
+
+  if (!profileRecord) {
+    return NextResponse.json({ error: 'Profile not found.' }, { status: 404 })
+  }
+
+  const profileId = typeof body.profileId === 'string' ? body.profileId : profileRecord.id
+
+  const { data: targetProfile, error: targetProfileError } = await supabase
+    .from('profiles')
+    .select('id, user_id')
+    .eq('id', profileId)
+    .maybeSingle()
+
+  if (targetProfileError) {
+    return NextResponse.json({ error: targetProfileError.message }, { status: 500 })
+  }
+
+  if (!targetProfile) {
+    return NextResponse.json({ error: 'Target profile not found.' }, { status: 404 })
+  }
+
+  if (targetProfile.user_id !== user.id && !profileRecord.is_admin) {
+    return NextResponse.json({ error: 'You are not allowed to record actions for this profile.' }, { status: 403 })
+  }
+
+  const actionType = body.actionType ?? 'custom.manual_adjustment'
+
+  try {
+    const result = await recordAction(
+      {
+        profileId,
+        actionType,
+        metadata: body.metadata ?? {},
+        actionSource: body.actionSource,
+        requestId: body.requestId,
+      },
+      supabase,
+    )
+
+    return NextResponse.json({ result })
+  } catch (error) {
+    console.error('Failed to record gamification action', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unable to record action.' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/gamification/challenges/route.ts
+++ b/src/app/api/gamification/challenges/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server'
+import { createServerComponentClient, createServiceRoleClient } from '@/lib/supabase/server-client'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const supabaseAuth = createServerComponentClient()
+  const {
+    data: { user },
+  } = await supabaseAuth.auth.getUser()
+
+  const supabase = createServiceRoleClient()
+
+  let profileId: string | null = null
+
+  if (user) {
+    const { data: profileRecord } = await supabase
+      .from('profiles')
+      .select('id')
+      .eq('user_id', user.id)
+      .maybeSingle()
+
+    profileId = profileRecord?.id ?? null
+  }
+
+  const { data, error } = await supabase
+    .from('gamification_challenges')
+    .select(
+      `id, slug, title, description, cadence, reward_points, reward_badge_id, starts_at, ends_at, requirements, is_active,
+       progress:profile_challenge_progress(profile_id, status, progress, completed_at, started_at, streak_count)`
+    )
+    .eq('is_active', true)
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  const challenges = (data ?? []).map((challenge) => {
+    const progressEntries = Array.isArray(challenge.progress) ? challenge.progress : []
+    const progressForProfile = progressEntries.find((entry) => entry.profile_id === profileId)
+
+    return {
+      id: challenge.id,
+      slug: challenge.slug,
+      title: challenge.title,
+      description: challenge.description,
+      cadence: challenge.cadence,
+      rewardPoints: challenge.reward_points,
+      rewardBadgeId: challenge.reward_badge_id,
+      startsAt: challenge.starts_at,
+      endsAt: challenge.ends_at,
+      requirements: challenge.requirements,
+      status: progressForProfile?.status ?? 'active',
+      progress: progressForProfile?.progress ?? {},
+      streakCount: progressForProfile?.streak_count ?? 0,
+      completedAt: progressForProfile?.completed_at ?? null,
+    }
+  })
+
+  return NextResponse.json({ challenges })
+}

--- a/src/app/api/gamification/leaderboards/route.ts
+++ b/src/app/api/gamification/leaderboards/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { fetchLeaderboard } from '@/lib/gamification/profile-service'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const scope = (url.searchParams.get('scope') ?? 'global') as 'global' | 'seasonal' | 'category'
+  const category = url.searchParams.get('category') ?? undefined
+  const limit = Number(url.searchParams.get('limit') ?? 10)
+
+  try {
+    const payload = await fetchLeaderboard({ scope, category, limit })
+    return NextResponse.json(payload)
+  } catch (error) {
+    console.error('Failed to load leaderboard', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unable to load leaderboard.' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/gamification/profile/route.ts
+++ b/src/app/api/gamification/profile/route.ts
@@ -13,31 +13,41 @@ export async function GET(request: Request) {
     data: { user },
   } = await supabaseAuth.auth.getUser()
 
-  if (!user && !profileIdParam) {
+  if (!user) {
     return NextResponse.json({ error: 'Authentication required.' }, { status: 401 })
   }
 
-  const supabase = createServiceRoleClient()
+  const {
+    data: requesterProfile,
+    error: requesterError,
+  } = await supabaseAuth
+    .from('profiles')
+    .select('id, is_admin')
+    .eq('user_id', user.id)
+    .maybeSingle()
 
-  let profileId = profileIdParam
-
-  if (!profileId) {
-    const { data: profileRecord, error: profileError } = await supabase
-      .from('profiles')
-      .select('id')
-      .eq('user_id', user?.id ?? '')
-      .maybeSingle()
-
-    if (profileError) {
-      return NextResponse.json({ error: profileError.message }, { status: 500 })
-    }
-
-    if (!profileRecord) {
-      return NextResponse.json({ error: 'Profile not found.' }, { status: 404 })
-    }
-
-    profileId = profileRecord.id
+  if (requesterError) {
+    return NextResponse.json({ error: requesterError.message }, { status: 500 })
   }
+
+  if (!requesterProfile) {
+    return NextResponse.json({ error: 'Profile not found.' }, { status: 404 })
+  }
+
+  let profileId = requesterProfile.id
+
+  if (profileIdParam) {
+    if (profileIdParam !== requesterProfile.id && !requesterProfile.is_admin) {
+      return NextResponse.json(
+        { error: 'Forbidden: insufficient permissions to view this profile.' },
+        { status: 403 },
+      )
+    }
+
+    profileId = profileIdParam
+  }
+
+  const supabase = createServiceRoleClient()
 
   try {
     const payload = await fetchGamificationProfile(profileId, supabase)

--- a/src/app/api/gamification/profile/route.ts
+++ b/src/app/api/gamification/profile/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server'
+import { createServerComponentClient, createServiceRoleClient } from '@/lib/supabase/server-client'
+import { fetchGamificationProfile } from '@/lib/gamification/profile-service'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const profileIdParam = url.searchParams.get('profileId')
+
+  const supabaseAuth = createServerComponentClient()
+  const {
+    data: { user },
+  } = await supabaseAuth.auth.getUser()
+
+  if (!user && !profileIdParam) {
+    return NextResponse.json({ error: 'Authentication required.' }, { status: 401 })
+  }
+
+  const supabase = createServiceRoleClient()
+
+  let profileId = profileIdParam
+
+  if (!profileId) {
+    const { data: profileRecord, error: profileError } = await supabase
+      .from('profiles')
+      .select('id')
+      .eq('user_id', user?.id ?? '')
+      .maybeSingle()
+
+    if (profileError) {
+      return NextResponse.json({ error: profileError.message }, { status: 500 })
+    }
+
+    if (!profileRecord) {
+      return NextResponse.json({ error: 'Profile not found.' }, { status: 404 })
+    }
+
+    profileId = profileRecord.id
+  }
+
+  try {
+    const payload = await fetchGamificationProfile(profileId, supabase)
+    return NextResponse.json(payload)
+  } catch (error) {
+    console.error('Failed to load gamification profile', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unable to load profile.' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -16,6 +16,7 @@ import { TaxonomyManager } from './TaxonomyManager'
 import { DashboardOverview } from './DashboardOverview'
 import { AnalyticsPanel } from './AnalyticsPanel'
 import { SettingsPanel } from './SettingsPanel'
+import { GamificationPanel } from './GamificationPanel'
 import { createBrowserClient } from '@/lib/supabase/client'
 import { Menu } from 'lucide-react'
 import {
@@ -931,6 +932,8 @@ const AdminDashboard = ({
             onDelete={handleDeleteComment}
           />
         )
+      case 'gamification':
+        return <GamificationPanel />
       case 'analytics':
         return <AnalyticsPanel posts={posts} recentComments={recentComments} />
       case 'settings':

--- a/src/components/admin/GamificationPanel.tsx
+++ b/src/components/admin/GamificationPanel.tsx
@@ -1,0 +1,496 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Loader2, RefreshCcw, Save, Star, Flame, Target } from 'lucide-react'
+import { NeobrutalCard } from '@/components/neobrutal/card'
+import { NeobrutalProgressBar } from '@/components/neobrutal/progress-bar'
+import { cn } from '@/lib/utils'
+
+interface BadgeFormState {
+  id?: string
+  slug: string
+  name: string
+  category: string
+  rarity: string
+  rewardPoints: number
+  description: string
+}
+
+interface ChallengeFormState {
+  id?: string
+  slug: string
+  title: string
+  cadence: 'daily' | 'weekly' | 'monthly' | 'seasonal' | 'event'
+  rewardPoints: number
+  description: string
+}
+
+interface AnalyticsState {
+  profiles: {
+    total: number
+    totalXp: number
+    averageLevel: number
+    streakLeaders: Array<{ profileId: string; streak: number; level: number; xp: number }>
+  }
+  badges: Record<string, number>
+  challenges: Record<string, number>
+}
+
+const defaultBadge: BadgeFormState = {
+  slug: '',
+  name: '',
+  category: '',
+  rarity: 'common',
+  rewardPoints: 0,
+  description: '',
+}
+
+const defaultChallenge: ChallengeFormState = {
+  slug: '',
+  title: '',
+  cadence: 'weekly',
+  rewardPoints: 0,
+  description: '',
+}
+
+export const GamificationPanel = () => {
+  const [analytics, setAnalytics] = useState<AnalyticsState | null>(null)
+  const [badges, setBadges] = useState<BadgeFormState[]>([])
+  const [challenges, setChallenges] = useState<ChallengeFormState[]>([])
+  const [badgeForm, setBadgeForm] = useState<BadgeFormState>(defaultBadge)
+  const [challengeForm, setChallengeForm] = useState<ChallengeFormState>(defaultChallenge)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSavingBadge, setIsSavingBadge] = useState(false)
+  const [isSavingChallenge, setIsSavingChallenge] = useState(false)
+  const [feedback, setFeedback] = useState<string | null>(null)
+
+  const fetchAll = useCallback(async () => {
+    setIsLoading(true)
+    setFeedback(null)
+
+    try {
+      const [analyticsResponse, badgesResponse, challengesResponse] = await Promise.all([
+        fetch('/api/admin/gamification/analytics', { cache: 'no-store' }),
+        fetch('/api/admin/gamification/badges', { cache: 'no-store' }),
+        fetch('/api/admin/gamification/challenges', { cache: 'no-store' }),
+      ])
+
+      const [analyticsPayload, badgesPayload, challengesPayload] = await Promise.all([
+        analyticsResponse.json(),
+        badgesResponse.json(),
+        challengesResponse.json(),
+      ])
+
+      if (!analyticsResponse.ok) {
+        throw new Error(analyticsPayload.error ?? 'Unable to load analytics.')
+      }
+
+      if (!badgesResponse.ok) {
+        throw new Error(badgesPayload.error ?? 'Unable to load badges.')
+      }
+
+      if (!challengesResponse.ok) {
+        throw new Error(challengesPayload.error ?? 'Unable to load challenges.')
+      }
+
+      setAnalytics(analyticsPayload)
+      setBadges((badgesPayload.badges ?? []).map((badge: any) => ({
+        id: badge.id,
+        slug: badge.slug,
+        name: badge.name,
+        category: badge.category,
+        rarity: badge.rarity,
+        rewardPoints: Number(badge.rewardPoints ?? badge.reward_points ?? 0),
+        description: badge.description ?? '',
+      })))
+      setChallenges((challengesPayload.challenges ?? []).map((challenge: any) => ({
+        id: challenge.id,
+        slug: challenge.slug,
+        title: challenge.title,
+        cadence: challenge.cadence,
+        rewardPoints: Number(challenge.rewardPoints ?? challenge.reward_points ?? 0),
+        description: challenge.description ?? '',
+      })))
+    } catch (error) {
+      console.error('Failed to load gamification admin data', error)
+      setFeedback(error instanceof Error ? error.message : 'Unable to load gamification data.')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchAll()
+  }, [fetchAll])
+
+  const handleBadgeSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setIsSavingBadge(true)
+    setFeedback(null)
+
+    try {
+      const response = await fetch('/api/admin/gamification/badges', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: badgeForm.id,
+          slug: badgeForm.slug,
+          name: badgeForm.name,
+          category: badgeForm.category,
+          rarity: badgeForm.rarity,
+          rewardPoints: badgeForm.rewardPoints,
+          description: badgeForm.description,
+        }),
+      })
+
+      const payload = await response.json()
+
+      if (!response.ok) {
+        throw new Error(payload.error ?? 'Unable to save badge.')
+      }
+
+      setBadgeForm(defaultBadge)
+      setFeedback('Badge saved successfully.')
+      await fetchAll()
+    } catch (error) {
+      console.error('Failed to save badge', error)
+      setFeedback(error instanceof Error ? error.message : 'Unable to save badge.')
+    } finally {
+      setIsSavingBadge(false)
+    }
+  }
+
+  const handleChallengeSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setIsSavingChallenge(true)
+    setFeedback(null)
+
+    try {
+      const response = await fetch('/api/admin/gamification/challenges', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: challengeForm.id,
+          slug: challengeForm.slug,
+          title: challengeForm.title,
+          cadence: challengeForm.cadence,
+          rewardPoints: challengeForm.rewardPoints,
+          description: challengeForm.description,
+        }),
+      })
+
+      const payload = await response.json()
+
+      if (!response.ok) {
+        throw new Error(payload.error ?? 'Unable to save challenge.')
+      }
+
+      setChallengeForm(defaultChallenge)
+      setFeedback('Challenge saved successfully.')
+      await fetchAll()
+    } catch (error) {
+      console.error('Failed to save challenge', error)
+      setFeedback(error instanceof Error ? error.message : 'Unable to save challenge.')
+    } finally {
+      setIsSavingChallenge(false)
+    }
+  }
+
+  const streakLeaders = analytics?.profiles.streakLeaders ?? []
+
+  const badgeDistribution = useMemo(() => {
+    if (!analytics?.badges) return []
+    return Object.entries(analytics.badges).map(([slug, total]) => ({ slug, total }))
+  }, [analytics?.badges])
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <h2 className="text-2xl font-black uppercase tracking-[0.4em] text-gray-900">Gamification Control Center</h2>
+        <button
+          type="button"
+          onClick={() => void fetchAll()}
+          className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-white px-4 py-2 text-sm font-bold uppercase tracking-wide text-black shadow-[6px_6px_0px_rgba(0,0,0,0.12)] hover:-translate-y-[1px]"
+          disabled={isLoading}
+        >
+          <RefreshCcw className="h-4 w-4" /> Refresh
+        </button>
+      </div>
+
+      {feedback ? (
+        <div className="rounded-xl border-2 border-black bg-[#FFF1D6] p-4 text-sm font-semibold text-black shadow-[6px_6px_0px_rgba(0,0,0,0.12)]">
+          {feedback}
+        </div>
+      ) : null}
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <NeobrutalCard className="bg-white">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-black uppercase tracking-widest text-gray-800">Total Profiles</h3>
+            <Star className="h-5 w-5 text-[#FFAF00]" />
+          </div>
+          <p className="mt-4 text-3xl font-black text-gray-900">{analytics?.profiles.total ?? '—'}</p>
+          <p className="mt-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+            XP awarded {analytics ? analytics.profiles.totalXp.toLocaleString('en-US') : '—'}
+          </p>
+          <NeobrutalProgressBar
+            className="mt-4"
+            value={analytics?.profiles.averageLevel ?? 0}
+            max={10}
+            label={`Average level ${analytics?.profiles.averageLevel?.toFixed(2) ?? '—'}`}
+          />
+        </NeobrutalCard>
+        <NeobrutalCard className="bg-[#FFF0F5]">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-black uppercase tracking-widest text-gray-800">Badge Distribution</h3>
+            <Flame className="h-5 w-5 text-[#FF5252]" />
+          </div>
+          <div className="mt-4 space-y-2 text-xs font-semibold uppercase tracking-wide text-gray-700">
+            {badgeDistribution.length > 0 ? (
+              badgeDistribution.map((item) => (
+                <div key={item.slug} className="flex items-center justify-between">
+                  <span>{item.slug}</span>
+                  <span>{item.total}</span>
+                </div>
+              ))
+            ) : (
+              <p>No badges awarded yet.</p>
+            )}
+          </div>
+        </NeobrutalCard>
+        <NeobrutalCard className="bg-[#E9F5FF]">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-black uppercase tracking-widest text-gray-800">Challenge Status</h3>
+            <Target className="h-5 w-5 text-[#1B9AAA]" />
+          </div>
+          <div className="mt-4 space-y-2 text-xs font-semibold uppercase tracking-wide text-gray-700">
+            {analytics?.challenges ? (
+              Object.entries(analytics.challenges).map(([status, count]) => (
+                <div key={status} className="flex items-center justify-between">
+                  <span>{status}</span>
+                  <span>{count}</span>
+                </div>
+              ))
+            ) : (
+              <p>Challenge telemetry is warming up.</p>
+            )}
+          </div>
+        </NeobrutalCard>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <NeobrutalCard className="bg-white">
+          <h3 className="text-lg font-black uppercase tracking-[0.3em] text-gray-900">Badge catalog</h3>
+          <p className="mt-2 text-sm font-medium text-gray-600">
+            Create and update badges. Existing badges will be updated when slugs match.
+          </p>
+          <form onSubmit={handleBadgeSubmit} className="mt-4 space-y-3">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                Slug
+                <input
+                  className="mt-1 w-full rounded-lg border-2 border-black bg-white px-3 py-2 text-sm font-semibold shadow-[4px_4px_0px_rgba(0,0,0,0.12)]"
+                  value={badgeForm.slug}
+                  onChange={(event) => setBadgeForm((prev) => ({ ...prev, slug: event.target.value }))}
+                  required
+                />
+              </label>
+              <label className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                Name
+                <input
+                  className="mt-1 w-full rounded-lg border-2 border-black bg-white px-3 py-2 text-sm font-semibold shadow-[4px_4px_0px_rgba(0,0,0,0.12)]"
+                  value={badgeForm.name}
+                  onChange={(event) => setBadgeForm((prev) => ({ ...prev, name: event.target.value }))}
+                  required
+                />
+              </label>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <label className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                Category
+                <input
+                  className="mt-1 w-full rounded-lg border-2 border-black bg-white px-3 py-2 text-sm font-semibold shadow-[4px_4px_0px_rgba(0,0,0,0.12)]"
+                  value={badgeForm.category}
+                  onChange={(event) => setBadgeForm((prev) => ({ ...prev, category: event.target.value }))}
+                  required
+                />
+              </label>
+              <label className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                Rarity
+                <select
+                  className="mt-1 w-full rounded-lg border-2 border-black bg-white px-3 py-2 text-sm font-semibold shadow-[4px_4px_0px_rgba(0,0,0,0.12)]"
+                  value={badgeForm.rarity}
+                  onChange={(event) => setBadgeForm((prev) => ({ ...prev, rarity: event.target.value }))}
+                >
+                  <option value="common">Common</option>
+                  <option value="uncommon">Uncommon</option>
+                  <option value="rare">Rare</option>
+                  <option value="legendary">Legendary</option>
+                </select>
+              </label>
+              <label className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                Reward points
+                <input
+                  type="number"
+                  className="mt-1 w-full rounded-lg border-2 border-black bg-white px-3 py-2 text-sm font-semibold shadow-[4px_4px_0px_rgba(0,0,0,0.12)]"
+                  value={badgeForm.rewardPoints}
+                  onChange={(event) => setBadgeForm((prev) => ({ ...prev, rewardPoints: Number(event.target.value) }))}
+                  min={0}
+                />
+              </label>
+            </div>
+            <label className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+              Description
+              <textarea
+                className="mt-1 w-full rounded-lg border-2 border-black bg-white px-3 py-2 text-sm font-semibold shadow-[4px_4px_0px_rgba(0,0,0,0.12)]"
+                rows={3}
+                value={badgeForm.description}
+                onChange={(event) => setBadgeForm((prev) => ({ ...prev, description: event.target.value }))}
+              />
+            </label>
+            <div className="flex items-center justify-between">
+              <button
+                type="submit"
+                className={cn(
+                  'inline-flex items-center gap-2 rounded-full border-2 border-black bg-[#6C63FF] px-4 py-2 text-sm font-black uppercase tracking-wide text-white shadow-[6px_6px_0px_rgba(0,0,0,0.18)] hover:-translate-y-[1px]',
+                  isSavingBadge && 'opacity-70',
+                )}
+                disabled={isSavingBadge}
+              >
+                {isSavingBadge ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                Save badge
+              </button>
+            </div>
+          </form>
+          <div className="mt-6 space-y-2 text-xs font-semibold uppercase tracking-wide text-gray-600">
+            {badges.map((badge) => (
+              <button
+                key={badge.slug}
+                type="button"
+                onClick={() => setBadgeForm(badge)}
+                className="flex w-full items-center justify-between rounded-xl border-2 border-black bg-white px-3 py-2 text-left shadow-[4px_4px_0px_rgba(0,0,0,0.12)] hover:-translate-y-[1px]"
+              >
+                <span>{badge.name}</span>
+                <span>{badge.rarity}</span>
+              </button>
+            ))}
+          </div>
+        </NeobrutalCard>
+
+        <NeobrutalCard className="bg-white">
+          <h3 className="text-lg font-black uppercase tracking-[0.3em] text-gray-900">Challenge catalog</h3>
+          <p className="mt-2 text-sm font-medium text-gray-600">
+            Keep programming fresh with rotating challenges.
+          </p>
+          <form onSubmit={handleChallengeSubmit} className="mt-4 space-y-3">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                Slug
+                <input
+                  className="mt-1 w-full rounded-lg border-2 border-black bg-white px-3 py-2 text-sm font-semibold shadow-[4px_4px_0px_rgba(0,0,0,0.12)]"
+                  value={challengeForm.slug}
+                  onChange={(event) => setChallengeForm((prev) => ({ ...prev, slug: event.target.value }))}
+                  required
+                />
+              </label>
+              <label className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                Title
+                <input
+                  className="mt-1 w-full rounded-lg border-2 border-black bg-white px-3 py-2 text-sm font-semibold shadow-[4px_4px_0px_rgba(0,0,0,0.12)]"
+                  value={challengeForm.title}
+                  onChange={(event) => setChallengeForm((prev) => ({ ...prev, title: event.target.value }))}
+                  required
+                />
+              </label>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <label className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                Cadence
+                <select
+                  className="mt-1 w-full rounded-lg border-2 border-black bg-white px-3 py-2 text-sm font-semibold shadow-[4px_4px_0px_rgba(0,0,0,0.12)]"
+                  value={challengeForm.cadence}
+                  onChange={(event) =>
+                    setChallengeForm((prev) => ({ ...prev, cadence: event.target.value as ChallengeFormState['cadence'] }))
+                  }
+                >
+                  <option value="daily">Daily</option>
+                  <option value="weekly">Weekly</option>
+                  <option value="monthly">Monthly</option>
+                  <option value="seasonal">Seasonal</option>
+                  <option value="event">Event</option>
+                </select>
+              </label>
+              <label className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                Reward points
+                <input
+                  type="number"
+                  className="mt-1 w-full rounded-lg border-2 border-black bg-white px-3 py-2 text-sm font-semibold shadow-[4px_4px_0px_rgba(0,0,0,0.12)]"
+                  value={challengeForm.rewardPoints}
+                  onChange={(event) => setChallengeForm((prev) => ({ ...prev, rewardPoints: Number(event.target.value) }))}
+                />
+              </label>
+            </div>
+            <label className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+              Description
+              <textarea
+                className="mt-1 w-full rounded-lg border-2 border-black bg-white px-3 py-2 text-sm font-semibold shadow-[4px_4px_0px_rgba(0,0,0,0.12)]"
+                rows={3}
+                value={challengeForm.description}
+                onChange={(event) => setChallengeForm((prev) => ({ ...prev, description: event.target.value }))}
+              />
+            </label>
+            <div className="flex items-center justify-between">
+              <button
+                type="submit"
+                className={cn(
+                  'inline-flex items-center gap-2 rounded-full border-2 border-black bg-[#06D6A0] px-4 py-2 text-sm font-black uppercase tracking-wide text-black shadow-[6px_6px_0px_rgba(0,0,0,0.18)] hover:-translate-y-[1px]',
+                  isSavingChallenge && 'opacity-70',
+                )}
+                disabled={isSavingChallenge}
+              >
+                {isSavingChallenge ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                Save challenge
+              </button>
+            </div>
+          </form>
+          <div className="mt-6 space-y-2 text-xs font-semibold uppercase tracking-wide text-gray-600">
+            {challenges.map((challenge) => (
+              <button
+                key={challenge.slug}
+                type="button"
+                onClick={() => setChallengeForm(challenge)}
+                className="flex w-full items-center justify-between rounded-xl border-2 border-black bg-white px-3 py-2 text-left shadow-[4px_4px_0px_rgba(0,0,0,0.12)] hover:-translate-y-[1px]"
+              >
+                <span>{challenge.title}</span>
+                <span>{challenge.cadence}</span>
+              </button>
+            ))}
+          </div>
+        </NeobrutalCard>
+      </div>
+
+      <NeobrutalCard className="bg-white">
+        <h3 className="text-lg font-black uppercase tracking-[0.3em] text-gray-900">Top streak leaders</h3>
+        <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {streakLeaders.length > 0 ? (
+            streakLeaders.map((leader) => (
+              <div
+                key={leader.profileId}
+                className="rounded-xl border-2 border-black bg-white px-4 py-3 text-sm font-semibold uppercase tracking-wide text-gray-700 shadow-[4px_4px_0px_rgba(0,0,0,0.12)]"
+              >
+                <p className="text-xs font-bold text-gray-500">Profile</p>
+                <p className="text-sm font-black text-gray-900">{leader.profileId.slice(0, 8)}…</p>
+                <p className="mt-2 text-xs font-bold text-gray-500">Streak</p>
+                <p className="text-lg font-black text-gray-900">{leader.streak} days</p>
+                <p className="mt-2 text-xs font-bold text-gray-500">Level</p>
+                <p className="text-lg font-black text-gray-900">{leader.level}</p>
+              </div>
+            ))
+          ) : (
+            <p className="text-sm font-semibold text-gray-600">No streak data yet. Encourage daily engagement!</p>
+          )}
+        </div>
+      </NeobrutalCard>
+    </div>
+  )
+}

--- a/src/components/admin/Sidebar.tsx
+++ b/src/components/admin/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   LogOut,
   Settings,
   ShieldCheck,
+  Sparkles,
   Tag,
   Users,
   X,
@@ -114,6 +115,14 @@ export const Sidebar = ({
                 label="Taxonomy"
                 isActive={currentView === 'taxonomy'}
                 onClick={() => onNavigate('taxonomy')}
+              />
+            )}
+            {isAdmin && (
+              <SidebarLink
+                icon={<Sparkles />}
+                label="Gamification"
+                isActive={currentView === 'gamification'}
+                onClick={() => onNavigate('gamification')}
               />
             )}
             <SidebarLink

--- a/src/components/auth/UserAccountPanel.tsx
+++ b/src/components/auth/UserAccountPanel.tsx
@@ -56,6 +56,7 @@ import {
 } from '@/lib/storage/profile-photos'
 import { useAuthenticatedProfile } from '@/hooks/useAuthenticatedProfile'
 import '@/styles/neo-brutalism.css'
+import { GamificationOverview } from '@/components/gamification/GamificationOverview'
 
 interface UserAccountPanelProps {
   profile: AuthenticatedProfileSummary
@@ -1362,6 +1363,10 @@ export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelPro
             </div>
 
             <div className="mt-8 grid gap-6 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+              <div className="xl:col-span-2">
+                <GamificationOverview profileId={currentProfile.profileId} />
+              </div>
+
               <div className="flex h-full flex-col gap-4 rounded-3xl border-2 border-black bg-white p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.15)]">
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>

--- a/src/components/gamification/GamificationOverview.tsx
+++ b/src/components/gamification/GamificationOverview.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { useMemo } from 'react'
+import { Trophy, Flame, Sparkles, Target, Award, TrendingUp } from 'lucide-react'
+import { NeobrutalCard } from '@/components/neobrutal/card'
+import { NeobrutalProgressBar } from '@/components/neobrutal/progress-bar'
+import { useGamificationProfile } from '@/hooks/useGamificationProfile'
+import { useLeaderboard } from '@/hooks/useLeaderboard'
+import { useChallenges } from '@/hooks/useChallenges'
+import type { OwnedBadge } from '@/lib/gamification/types'
+import { cn } from '@/lib/utils'
+
+interface GamificationOverviewProps {
+  profileId?: string
+}
+
+const rarityColorMap: Record<string, string> = {
+  common: 'bg-white text-black',
+  uncommon: 'bg-[#06D6A0]/90 text-black',
+  rare: 'bg-[#6C63FF]/90 text-white',
+  legendary: 'bg-[#FF5252]/90 text-white',
+}
+
+const formatNumber = (value: number) => value.toLocaleString('en-US')
+
+const BadgeCard = ({ badge }: { badge: OwnedBadge }) => {
+  const tone = rarityColorMap[badge.rarity] ?? rarityColorMap.common
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-2 rounded-xl border-3 border-black p-4 text-sm shadow-[4px_4px_0px_rgba(0,0,0,0.12)]',
+        tone,
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border-2 border-black bg-black/10 text-lg">
+            {badge.icon ? badge.icon.slice(0, 2).toUpperCase() : '★'}
+          </span>
+          <div>
+            <p className="text-base font-black uppercase tracking-wide">{badge.name}</p>
+            <p className="text-xs font-semibold uppercase tracking-wider text-black/70">{badge.category}</p>
+          </div>
+        </div>
+        <span className="rounded-full border-2 border-black bg-black/10 px-3 py-1 text-xs font-bold uppercase tracking-widest">
+          {badge.rarity}
+        </span>
+      </div>
+      {badge.description ? <p className="text-sm leading-relaxed">{badge.description}</p> : null}
+      <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-black/70">
+        <span>Reward</span>
+        <span>{formatNumber(badge.rewardPoints)} pts</span>
+      </div>
+    </div>
+  )
+}
+
+export function GamificationOverview({ profileId }: GamificationOverviewProps) {
+  const { profile, badges, recentActions, isLoading, error } = useGamificationProfile(profileId)
+  const { entries: leaderboardEntries } = useLeaderboard('global')
+  const { challenges } = useChallenges()
+
+  const topBadges = useMemo(() => badges.slice(0, 6), [badges])
+  const xpProgress = profile ? Math.min((profile.xpTotal / (profile.nextLevelXp || 1)) * 100, 100) : 0
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-6 lg:grid lg:grid-cols-3">
+        <NeobrutalCard className="col-span-2 h-full bg-gradient-to-br from-white to-[#F7F1FF]">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className="text-xs font-black uppercase tracking-widest text-black/60">Level</p>
+                <h2 className="text-3xl font-black leading-tight text-black">
+                  {isLoading ? 'Loading…' : `Level ${profile?.level ?? 1}`}
+                </h2>
+              </div>
+              <div className="flex items-center gap-2 rounded-full border-3 border-black bg-white px-3 py-1">
+                <Flame className="h-5 w-5 text-[#FF5252]" />
+                <span className="text-sm font-bold uppercase tracking-wide text-black">
+                  {formatNumber(profile?.currentStreak ?? 0)} day streak
+                </span>
+              </div>
+            </div>
+            <NeobrutalProgressBar
+              value={xpProgress}
+              max={100}
+              label={`XP ${formatNumber(profile?.xpTotal ?? 0)} / ${formatNumber(profile?.nextLevelXp ?? 0)}`}
+            />
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="flex items-center gap-3 rounded-xl border-3 border-black bg-white/70 p-4 shadow-[4px_4px_0px_rgba(0,0,0,0.12)]">
+                <Trophy className="h-10 w-10 text-[#6C63FF]" />
+                <div>
+                  <p className="text-xs font-black uppercase tracking-wide text-black/60">Prestige</p>
+                  <p className="text-lg font-black">{profile?.prestigeLevel ?? 0}</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 rounded-xl border-3 border-black bg-white/70 p-4 shadow-[4px_4px_0px_rgba(0,0,0,0.12)]">
+                <Sparkles className="h-10 w-10 text-[#FFAF00]" />
+                <div>
+                  <p className="text-xs font-black uppercase tracking-wide text-black/60">Badges</p>
+                  <p className="text-lg font-black">{badges.length}</p>
+                </div>
+              </div>
+            </div>
+            <div className="rounded-xl border-3 border-black bg-white/70 p-4 shadow-[4px_4px_0px_rgba(0,0,0,0.12)]">
+              <p className="text-xs font-black uppercase tracking-widest text-black/60">Recent Activity</p>
+              <div className="mt-3 space-y-2 text-sm">
+                {recentActions.slice(0, 5).map((action) => (
+                  <div key={`${action.actionType}-${action.awardedAt}`} className="flex items-center justify-between">
+                    <span className="font-semibold uppercase tracking-wide text-black/70">
+                      {action.actionType.replace('.', ' › ')}
+                    </span>
+                    <span className="font-bold text-black">
+                      +{formatNumber(action.xp)} XP · {new Date(action.awardedAt).toLocaleDateString('en-US')}
+                    </span>
+                  </div>
+                ))}
+                {recentActions.length === 0 ? (
+                  <p className="text-sm font-medium text-black/60">Complete an action to start filling your activity feed.</p>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </NeobrutalCard>
+        <NeobrutalCard className="flex h-full flex-col gap-4 bg-[#FFFBEB]">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-black uppercase tracking-widest text-black">Leaderboard</h3>
+            <TrendingUp className="h-6 w-6 text-[#FF5252]" />
+          </div>
+          <div className="space-y-3">
+            {leaderboardEntries.slice(0, 5).map((entry) => (
+              <div
+                key={entry.profileId}
+                className="flex items-center justify-between rounded-xl border-3 border-black bg-white px-3 py-2 shadow-[3px_3px_0px_rgba(0,0,0,0.12)]"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border-2 border-black bg-[#6C63FF]/90 text-white font-black">
+                    {entry.rank}
+                  </span>
+                  <div>
+                    <p className="text-sm font-black leading-tight">{entry.displayName}</p>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-black/60">
+                      Lv {entry.level} · {formatNumber(entry.xp)} XP
+                    </p>
+                  </div>
+                </div>
+                <span className="text-xs font-bold uppercase tracking-widest text-[#FF5252]">
+                  {formatNumber(entry.streak)} streak
+                </span>
+              </div>
+            ))}
+            {leaderboardEntries.length === 0 ? (
+              <p className="text-sm font-medium text-black/60">Leaderboard data is being generated. Check back soon!</p>
+            ) : null}
+          </div>
+        </NeobrutalCard>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <NeobrutalCard className="col-span-2 bg-white">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-black uppercase tracking-widest text-black">Badge Showcase</h3>
+            <Award className="h-6 w-6 text-[#6C63FF]" />
+          </div>
+          <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {topBadges.length > 0 ? (
+              topBadges.map((badge) => <BadgeCard key={badge.id} badge={badge} />)
+            ) : (
+              <p className="text-sm font-medium text-black/60">Earn badges by joining challenges and sharing your work.</p>
+            )}
+          </div>
+        </NeobrutalCard>
+        <NeobrutalCard className="bg-[#E9F5FF]">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-black uppercase tracking-widest text-black">Active Challenges</h3>
+            <Target className="h-6 w-6 text-[#1B9AAA]" />
+          </div>
+          <div className="mt-4 space-y-3">
+            {challenges.slice(0, 3).map((challenge) => (
+              <div
+                key={challenge.id}
+                className="rounded-xl border-3 border-black bg-white/80 p-3 shadow-[3px_3px_0px_rgba(0,0,0,0.12)]"
+              >
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-black uppercase tracking-wide text-black">{challenge.title}</p>
+                  <span className="text-xs font-semibold uppercase tracking-widest text-black/60">
+                    {challenge.cadence}
+                  </span>
+                </div>
+                {challenge.description ? (
+                  <p className="mt-1 text-xs text-black/70">{challenge.description}</p>
+                ) : null}
+                <div className="mt-2 flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-black/70">
+                  <span>Status: {challenge.status}</span>
+                  <span>{formatNumber(challenge.rewardPoints)} pts</span>
+                </div>
+              </div>
+            ))}
+            {challenges.length === 0 ? (
+              <p className="text-sm font-medium text-black/60">
+                Challenges rotate weekly. Subscribe to notifications to be first in line.
+              </p>
+            ) : null}
+          </div>
+        </NeobrutalCard>
+      </div>
+
+      {error ? (
+        <NeobrutalCard tone="warning" className="bg-[#FFD166] text-black">
+          <p className="font-bold">{error}</p>
+        </NeobrutalCard>
+      ) : null}
+    </section>
+  )
+}

--- a/src/hooks/useBadges.ts
+++ b/src/hooks/useBadges.ts
@@ -1,0 +1,17 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useGamificationProfile } from './useGamificationProfile'
+
+export const useBadges = (profileId?: string) => {
+  const { badges, isLoading, error } = useGamificationProfile(profileId)
+
+  return useMemo(
+    () => ({
+      badges,
+      isLoading,
+      error,
+    }),
+    [badges, isLoading, error],
+  )
+}

--- a/src/hooks/useChallenges.ts
+++ b/src/hooks/useChallenges.ts
@@ -1,0 +1,74 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface ChallengeState {
+  id: string
+  slug: string
+  title: string
+  description: string | null
+  cadence: string
+  rewardPoints: number
+  rewardBadgeId: string | null
+  startsAt: string | null
+  endsAt: string | null
+  requirements: Record<string, unknown>
+  status: string
+  progress: Record<string, unknown>
+  streakCount: number
+  completedAt: string | null
+}
+
+interface UseChallengesState {
+  challenges: ChallengeState[]
+  isLoading: boolean
+  error: string | null
+}
+
+export const useChallenges = () => {
+  const [state, setState] = useState<UseChallengesState>({
+    challenges: [],
+    isLoading: true,
+    error: null,
+  })
+
+  useEffect(() => {
+    let isMounted = true
+
+    const load = async () => {
+      setState((prev) => ({ ...prev, isLoading: true, error: null }))
+
+      const response = await fetch('/api/gamification/challenges', {
+        method: 'GET',
+        cache: 'no-store',
+      })
+
+      const payload = await response.json()
+
+      if (!isMounted) return
+
+      if (!response.ok) {
+        setState((prev) => ({
+          ...prev,
+          isLoading: false,
+          error: typeof payload.error === 'string' ? payload.error : 'Unable to load challenges.',
+        }))
+        return
+      }
+
+      setState({
+        challenges: Array.isArray(payload.challenges) ? payload.challenges : [],
+        isLoading: false,
+        error: null,
+      })
+    }
+
+    void load()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  return state
+}

--- a/src/hooks/useGamificationProfile.ts
+++ b/src/hooks/useGamificationProfile.ts
@@ -1,0 +1,74 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { GamificationProfileSummary, OwnedBadge } from '@/lib/gamification/types'
+
+interface GamificationProfileState {
+  profile: GamificationProfileSummary | null
+  badges: OwnedBadge[]
+  streakHistory: Array<{ date: string; xp: number }>
+  recentActions: Array<{ actionType: string; awardedAt: string; xp: number; points: number }>
+  isLoading: boolean
+  error: string | null
+}
+
+export const useGamificationProfile = (profileId?: string) => {
+  const [state, setState] = useState<GamificationProfileState>({
+    profile: null,
+    badges: [],
+    streakHistory: [],
+    recentActions: [],
+    isLoading: true,
+    error: null,
+  })
+
+  useEffect(() => {
+    let isMounted = true
+
+    const load = async () => {
+      setState((prev) => ({ ...prev, isLoading: true, error: null }))
+
+      const params = new URLSearchParams()
+      if (profileId) {
+        params.set('profileId', profileId)
+      }
+
+      const response = await fetch(`/api/gamification/profile?${params.toString()}`, {
+        method: 'GET',
+        cache: 'no-store',
+      })
+
+      const payload = await response.json()
+
+      if (!isMounted) {
+        return
+      }
+
+      if (!response.ok) {
+        setState((prev) => ({
+          ...prev,
+          isLoading: false,
+          error: typeof payload.error === 'string' ? payload.error : 'Unable to load gamification profile.',
+        }))
+        return
+      }
+
+      setState({
+        profile: payload.profile ?? null,
+        badges: Array.isArray(payload.badges) ? payload.badges : [],
+        streakHistory: Array.isArray(payload.streakHistory) ? payload.streakHistory : [],
+        recentActions: Array.isArray(payload.recentActions) ? payload.recentActions : [],
+        isLoading: false,
+        error: null,
+      })
+    }
+
+    void load()
+
+    return () => {
+      isMounted = false
+    }
+  }, [profileId])
+
+  return state
+}

--- a/src/hooks/useLeaderboard.ts
+++ b/src/hooks/useLeaderboard.ts
@@ -1,0 +1,66 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { LeaderboardEntry } from '@/lib/gamification/types'
+
+interface LeaderboardState {
+  entries: LeaderboardEntry[]
+  capturedAt: string | null
+  isLoading: boolean
+  error: string | null
+}
+
+export const useLeaderboard = (scope: 'global' | 'seasonal' | 'category' = 'global', category?: string) => {
+  const [state, setState] = useState<LeaderboardState>({
+    entries: [],
+    capturedAt: null,
+    isLoading: true,
+    error: null,
+  })
+
+  useEffect(() => {
+    let isMounted = true
+
+    const load = async () => {
+      setState((prev) => ({ ...prev, isLoading: true, error: null }))
+
+      const params = new URLSearchParams({ scope })
+      if (category) {
+        params.set('category', category)
+      }
+
+      const response = await fetch(`/api/gamification/leaderboards?${params.toString()}`, {
+        method: 'GET',
+        cache: 'no-store',
+      })
+
+      const payload = await response.json()
+
+      if (!isMounted) return
+
+      if (!response.ok) {
+        setState((prev) => ({
+          ...prev,
+          isLoading: false,
+          error: typeof payload.error === 'string' ? payload.error : 'Unable to load leaderboard.',
+        }))
+        return
+      }
+
+      setState({
+        entries: Array.isArray(payload.entries) ? payload.entries : [],
+        capturedAt: typeof payload.capturedAt === 'string' ? payload.capturedAt : null,
+        isLoading: false,
+        error: null,
+      })
+    }
+
+    void load()
+
+    return () => {
+      isMounted = false
+    }
+  }, [scope, category])
+
+  return state
+}

--- a/src/lib/gamification/badge-evaluator.ts
+++ b/src/lib/gamification/badge-evaluator.ts
@@ -1,10 +1,17 @@
-import type { Database } from '@/lib/supabase/types'
 import type {
   BadgeDefinition,
   BadgeEvaluationContext,
   OwnedBadge,
   SupabaseClient,
 } from './types'
+import type { Database } from '@/lib/supabase/types'
+import {
+  extractRelationSlug,
+  ensureJsonRecord,
+  isRecordLike,
+  toNumber,
+  toNullableString,
+} from './utils'
 
 interface BadgeEvaluationResult {
   newBadges: OwnedBadge[]
@@ -19,10 +26,10 @@ const meetsBadgeCriteria = (
     return false
   }
 
-  const requirements = (badge.requirements ?? {}) as Record<string, unknown>
+  const requirements = ensureJsonRecord(badge.requirements ?? {})
 
   if (requirements.requires && Array.isArray(requirements.requires)) {
-    const required = requirements.requires as string[]
+    const required = requirements.requires.filter((value): value is string => typeof value === 'string')
     if (required.includes('onboarding_completed') && context.action.actionType !== 'onboarding.completed') {
       return false
     }
@@ -41,7 +48,10 @@ const meetsBadgeCriteria = (
   }
 
   if (requirements.actions_required && Array.isArray(requirements.actions_required)) {
-    const actions = requirements.actions_required as Array<{ action: string; count?: number }>
+    const actions = requirements.actions_required.filter(
+      (entry): entry is { action: string; count?: number } =>
+        isRecordLike(entry) && typeof entry.action === 'string',
+    )
     const requiredAction = actions.find((entry) => entry.action === context.action.actionType)
     if (!requiredAction) {
       return false
@@ -51,26 +61,51 @@ const meetsBadgeCriteria = (
   return true
 }
 
-const mapBadgeRow = (
-  badge: Database['public']['Tables']['gamification_badges']['Row'],
-  awardedAt: string,
-): OwnedBadge => ({
-  id: badge.id,
-  slug: badge.slug,
-  name: badge.name,
-  description: badge.description,
-  category: badge.category,
-  rarity: badge.rarity,
-  icon: badge.icon,
-  theme: badge.theme,
-  requirements: badge.requirements,
-  rewardPoints: badge.reward_points,
-  availableFrom: badge.available_from,
-  availableTo: badge.available_to,
+const mapBadgeToOwned = (badge: BadgeDefinition, awardedAt: string): OwnedBadge => ({
+  ...badge,
   awardedAt,
   state: 'awarded',
   notifiedAt: null,
 })
+
+const normalizeBadgeDefinition = (value: unknown): BadgeDefinition | null => {
+  if (!isRecordLike(value)) {
+    return null
+  }
+
+  const id = typeof value.id === 'string' ? value.id : null
+  const slug = typeof value.slug === 'string' ? value.slug : null
+  const name = typeof value.name === 'string' ? value.name : null
+  const category = typeof value.category === 'string' ? value.category : null
+  const rarity = typeof value.rarity === 'string' ? value.rarity : null
+
+  if (!id || !slug || !name || !category || !rarity) {
+    return null
+  }
+
+  const description = typeof value.description === 'string' ? value.description : null
+  const icon = toNullableString(value.icon)
+  const theme = toNullableString(value.theme)
+  const requirements = ensureJsonRecord(value.requirements ?? {})
+  const rewardPoints = toNumber(value.reward_points, 0)
+  const availableFrom = toNullableString(value.available_from)
+  const availableTo = toNullableString(value.available_to)
+
+  return {
+    id,
+    slug,
+    name,
+    description,
+    category,
+    rarity,
+    icon,
+    theme,
+    requirements,
+    rewardPoints,
+    availableFrom,
+    availableTo,
+  }
+}
 
 export const evaluateBadgesForAction = async (
   context: BadgeEvaluationContext,
@@ -90,9 +125,15 @@ export const evaluateBadgesForAction = async (
 
   const ownedSlugs = new Set<string>()
 
-  for (const entry of ownedBadgesData ?? []) {
-    const slugValue = Array.isArray(entry.badges) ? entry.badges[0]?.slug : (entry as any)?.badges?.slug
-    if (typeof slugValue === 'string') {
+  const ownedBadgeEntries: unknown[] = ownedBadgesData ?? []
+
+  for (const entry of ownedBadgeEntries) {
+    if (!isRecordLike(entry)) {
+      continue
+    }
+
+    const slugValue = extractRelationSlug(entry.badges)
+    if (slugValue) {
       ownedSlugs.add(slugValue)
     }
   }
@@ -108,44 +149,38 @@ export const evaluateBadgesForAction = async (
 
   const earnedBadges: OwnedBadge[] = []
 
-  for (const badge of badgeCatalog ?? []) {
-    const badgeDef: BadgeDefinition = {
-      id: badge.id,
-      slug: badge.slug,
-      name: badge.name,
-      description: badge.description,
-      category: badge.category,
-      rarity: badge.rarity,
-      icon: badge.icon,
-      theme: badge.theme,
-      requirements: badge.requirements,
-      rewardPoints: badge.reward_points,
-      availableFrom: badge.available_from,
-      availableTo: badge.available_to,
+  const badgeEntries: unknown[] = badgeCatalog ?? []
+
+  for (const badge of badgeEntries) {
+    const badgeDef = normalizeBadgeDefinition(badge)
+    if (!badgeDef) {
+      continue
     }
 
     if (!meetsBadgeCriteria(badgeDef, context, ownedSlugs)) {
       continue
     }
 
-    const { error: insertError } = await supabase.from('profile_badges').upsert(
-      {
-        profile_id: context.profile.profileId,
-        badge_id: badge.id,
-        state: 'awarded',
-        awarded_at: nowIso,
-        notified_at: null,
-        progress: {},
-      },
-      { onConflict: 'profile_id,badge_id' },
-    )
+    const { error: insertError } = await supabase
+      .from('profile_badges')
+      .upsert<Database['public']['Tables']['profile_badges']['Insert']>(
+        {
+          profile_id: context.profile.profileId,
+          badge_id: badgeDef.id,
+          state: 'awarded',
+          awarded_at: nowIso,
+          notified_at: null,
+          progress: {},
+        },
+        { onConflict: 'profile_id,badge_id' },
+      )
 
     if (insertError) {
-      console.error(`Unable to award badge ${badge.slug}`, insertError)
+      console.error(`Unable to award badge ${badgeDef.slug}`, insertError)
       continue
     }
 
-    earnedBadges.push(mapBadgeRow(badge, nowIso))
+    earnedBadges.push(mapBadgeToOwned(badgeDef, nowIso))
   }
 
   return { newBadges: earnedBadges }

--- a/src/lib/gamification/badge-evaluator.ts
+++ b/src/lib/gamification/badge-evaluator.ts
@@ -1,0 +1,152 @@
+import type { Database } from '@/lib/supabase/types'
+import type {
+  BadgeDefinition,
+  BadgeEvaluationContext,
+  OwnedBadge,
+  SupabaseClient,
+} from './types'
+
+interface BadgeEvaluationResult {
+  newBadges: OwnedBadge[]
+}
+
+const meetsBadgeCriteria = (
+  badge: BadgeDefinition,
+  context: BadgeEvaluationContext,
+  ownedBadgeSlugs: Set<string>,
+) => {
+  if (ownedBadgeSlugs.has(badge.slug)) {
+    return false
+  }
+
+  const requirements = (badge.requirements ?? {}) as Record<string, unknown>
+
+  if (requirements.requires && Array.isArray(requirements.requires)) {
+    const required = requirements.requires as string[]
+    if (required.includes('onboarding_completed') && context.action.actionType !== 'onboarding.completed') {
+      return false
+    }
+  }
+
+  if (typeof requirements.streak_days === 'number') {
+    if (context.profile.currentStreak < Number(requirements.streak_days)) {
+      return false
+    }
+  }
+
+  if (typeof requirements.total_xp === 'number') {
+    if (context.profile.xpTotal < Number(requirements.total_xp)) {
+      return false
+    }
+  }
+
+  if (requirements.actions_required && Array.isArray(requirements.actions_required)) {
+    const actions = requirements.actions_required as Array<{ action: string; count?: number }>
+    const requiredAction = actions.find((entry) => entry.action === context.action.actionType)
+    if (!requiredAction) {
+      return false
+    }
+  }
+
+  return true
+}
+
+const mapBadgeRow = (
+  badge: Database['public']['Tables']['gamification_badges']['Row'],
+  awardedAt: string,
+): OwnedBadge => ({
+  id: badge.id,
+  slug: badge.slug,
+  name: badge.name,
+  description: badge.description,
+  category: badge.category,
+  rarity: badge.rarity,
+  icon: badge.icon,
+  theme: badge.theme,
+  requirements: badge.requirements,
+  rewardPoints: badge.reward_points,
+  availableFrom: badge.available_from,
+  availableTo: badge.available_to,
+  awardedAt,
+  state: 'awarded',
+  notifiedAt: null,
+})
+
+export const evaluateBadgesForAction = async (
+  context: BadgeEvaluationContext,
+  supabase: SupabaseClient,
+): Promise<BadgeEvaluationResult> => {
+  const nowIso = new Date().toISOString()
+
+  const { data: ownedBadgesData, error: ownedError } = await supabase
+    .from('profile_badges')
+    .select('badge_id, badges:badge_id (slug)')
+    .eq('profile_id', context.profile.profileId)
+
+  if (ownedError) {
+    console.error('Unable to load owned badges for evaluation', ownedError)
+    return { newBadges: [] }
+  }
+
+  const ownedSlugs = new Set<string>()
+
+  for (const entry of ownedBadgesData ?? []) {
+    const slugValue = Array.isArray(entry.badges) ? entry.badges[0]?.slug : (entry as any)?.badges?.slug
+    if (typeof slugValue === 'string') {
+      ownedSlugs.add(slugValue)
+    }
+  }
+
+  const { data: badgeCatalog, error: badgeError } = await supabase
+    .from('gamification_badges')
+    .select('*')
+
+  if (badgeError) {
+    console.error('Unable to load badge catalog', badgeError)
+    return { newBadges: [] }
+  }
+
+  const earnedBadges: OwnedBadge[] = []
+
+  for (const badge of badgeCatalog ?? []) {
+    const badgeDef: BadgeDefinition = {
+      id: badge.id,
+      slug: badge.slug,
+      name: badge.name,
+      description: badge.description,
+      category: badge.category,
+      rarity: badge.rarity,
+      icon: badge.icon,
+      theme: badge.theme,
+      requirements: badge.requirements,
+      rewardPoints: badge.reward_points,
+      availableFrom: badge.available_from,
+      availableTo: badge.available_to,
+    }
+
+    if (!meetsBadgeCriteria(badgeDef, context, ownedSlugs)) {
+      continue
+    }
+
+    const { error: insertError } = await supabase.from('profile_badges').upsert(
+      {
+        profile_id: context.profile.profileId,
+        badge_id: badge.id,
+        state: 'awarded',
+        awarded_at: nowIso,
+        notified_at: null,
+        progress: {},
+      },
+      { onConflict: 'profile_id,badge_id' },
+    )
+
+    if (insertError) {
+      console.error(`Unable to award badge ${badge.slug}`, insertError)
+      continue
+    }
+
+    earnedBadges.push(mapBadgeRow(badge, nowIso))
+  }
+
+  return { newBadges: earnedBadges }
+}

--- a/src/lib/gamification/cache.ts
+++ b/src/lib/gamification/cache.ts
@@ -1,0 +1,110 @@
+import type { Database } from '@/lib/supabase/types'
+import type { SupabaseClient } from './types'
+
+type CacheValue<T> = {
+  value: T
+  expiresAt: number
+}
+
+const inMemoryCache = new Map<string, CacheValue<unknown>>()
+
+const upstashUrl = process.env.UPSTASH_REDIS_REST_URL
+const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN
+
+const hasUpstash = Boolean(upstashUrl && upstashToken)
+
+const serialize = (value: unknown) => JSON.stringify(value)
+const deserialize = <T>(raw: string | null): T | null => (raw ? (JSON.parse(raw) as T) : null)
+
+export const buildCacheKey = (...parts: Array<string | number | undefined>) =>
+  parts
+    .filter((part) => part !== undefined && part !== null)
+    .map((part) => String(part))
+    .join(':')
+
+export async function cacheGet<T>(key: string): Promise<T | null> {
+  if (hasUpstash) {
+    try {
+      const response = await fetch(`${upstashUrl}/get/${encodeURIComponent(key)}`, {
+        headers: {
+          Authorization: `Bearer ${upstashToken}`,
+        },
+        cache: 'no-store',
+      })
+
+      if (!response.ok) {
+        return null
+      }
+
+      const payload = (await response.json()) as { result: string | null }
+      return deserialize<T>(payload.result)
+    } catch (error) {
+      console.error('Failed to fetch from Upstash cache', error)
+    }
+  }
+
+  const cached = inMemoryCache.get(key)
+
+  if (!cached) {
+    return null
+  }
+
+  if (Date.now() > cached.expiresAt) {
+    inMemoryCache.delete(key)
+    return null
+  }
+
+  return cached.value as T
+}
+
+export async function cacheSet<T>(key: string, value: T, ttlSeconds: number) {
+  const expiresAt = Date.now() + ttlSeconds * 1000
+
+  if (hasUpstash) {
+    try {
+      await fetch(`${upstashUrl}/set/${encodeURIComponent(key)}/${encodeURIComponent(serialize(value))}`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${upstashToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ ex: ttlSeconds }),
+      })
+    } catch (error) {
+      console.error('Failed to write to Upstash cache', error)
+    }
+  }
+
+  inMemoryCache.set(key, { value, expiresAt })
+}
+
+export async function cacheInvalidate(prefix: string) {
+  if (hasUpstash) {
+    try {
+      await fetch(`${upstashUrl}/del/${encodeURIComponent(prefix)}:*`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${upstashToken}`,
+        },
+      })
+    } catch (error) {
+      console.error('Failed to invalidate Upstash cache', error)
+    }
+  }
+
+  for (const key of inMemoryCache.keys()) {
+    if (key.startsWith(prefix)) {
+      inMemoryCache.delete(key)
+    }
+  }
+}
+
+export const upsertGamificationProfile = async (
+  supabase: SupabaseClient,
+  profileId: string,
+  payload: Partial<Database['public']['Tables']['gamification_profiles']['Insert']>,
+) => {
+  await supabase
+    .from('gamification_profiles')
+    .upsert({ profile_id: profileId, ...payload }, { onConflict: 'profile_id' })
+}

--- a/src/lib/gamification/challenge-service.ts
+++ b/src/lib/gamification/challenge-service.ts
@@ -1,0 +1,162 @@
+import type { Database } from '@/lib/supabase/types'
+import type {
+  ChallengeDefinition,
+  ChallengeProgress,
+  RecordActionInput,
+  SupabaseClient,
+} from './types'
+
+interface ProcessChallengesInput {
+  profile: {
+    profileId: string
+  }
+  action: RecordActionInput
+  metadata: Record<string, unknown>
+  xpAwarded: number
+}
+
+interface ProcessChallengesResult {
+  completed: ChallengeProgress[]
+}
+
+const mapChallenge = (
+  challenge: Database['public']['Tables']['gamification_challenges']['Row'],
+): ChallengeDefinition => ({
+  id: challenge.id,
+  slug: challenge.slug,
+  title: challenge.title,
+  description: challenge.description,
+  cadence: challenge.cadence,
+  rewardPoints: challenge.reward_points,
+  rewardBadgeId: challenge.reward_badge_id,
+  startsAt: challenge.starts_at,
+  endsAt: challenge.ends_at,
+  requirements: challenge.requirements,
+})
+
+const buildProgressPayload = (
+  previous: Record<string, unknown> | null,
+  actionType: string,
+) => {
+  const progress = typeof previous === 'object' && previous !== null ? { ...previous } : {}
+  const actionCounts = typeof progress.action_counts === 'object' && progress.action_counts !== null
+    ? { ...(progress.action_counts as Record<string, number>) }
+    : {}
+
+  actionCounts[actionType] = (actionCounts[actionType] ?? 0) + 1
+
+  return {
+    ...progress,
+    action_counts: actionCounts,
+  }
+}
+
+const meetsCompletion = (
+  challenge: ChallengeDefinition,
+  progress: Record<string, unknown>,
+) => {
+  const requirements = (challenge.requirements ?? {}) as Record<string, unknown>
+  const actionRequirements = Array.isArray(requirements.actions_required)
+    ? (requirements.actions_required as Array<{ action: string; count?: number }>)
+    : []
+  const actionCounts = (progress.action_counts as Record<string, number> | undefined) ?? {}
+
+  return actionRequirements.every((req) => {
+    const requiredCount = Number(req.count ?? 1)
+    return (actionCounts[req.action] ?? 0) >= requiredCount
+  })
+}
+
+export const processChallengesForAction = async (
+  input: ProcessChallengesInput,
+  supabase: SupabaseClient,
+): Promise<ProcessChallengesResult> => {
+  const { data: activeChallenges, error: challengeError } = await supabase
+    .from('gamification_challenges')
+    .select('*')
+    .eq('is_active', true)
+
+  if (challengeError) {
+    console.error('Unable to fetch active challenges', challengeError)
+    return { completed: [] }
+  }
+
+  const completed: ChallengeProgress[] = []
+
+  for (const challenge of activeChallenges ?? []) {
+    const definition = mapChallenge(challenge)
+
+    const { data: progressRow, error: progressError } = await supabase
+      .from('profile_challenge_progress')
+      .select('*')
+      .eq('profile_id', input.profile.profileId)
+      .eq('challenge_id', challenge.id)
+      .maybeSingle()
+
+    if (progressError) {
+      console.error('Unable to load challenge progress', progressError)
+      continue
+    }
+
+    const progressPayload = buildProgressPayload(progressRow?.progress ?? {}, input.action.actionType)
+
+    if (!progressRow) {
+      const { error: insertError } = await supabase.from('profile_challenge_progress').insert({
+        profile_id: input.profile.profileId,
+        challenge_id: challenge.id,
+        progress: progressPayload,
+      })
+
+      if (insertError) {
+        console.error('Unable to start challenge progress', insertError)
+        continue
+      }
+    } else {
+      const { error: updateError } = await supabase
+        .from('profile_challenge_progress')
+        .update({
+          progress: progressPayload,
+          status: 'active',
+        })
+        .eq('id', progressRow.id)
+
+      if (updateError) {
+        console.error('Unable to update challenge progress', updateError)
+        continue
+      }
+    }
+
+    if (meetsCompletion(definition, progressPayload)) {
+      const completionTime = new Date().toISOString()
+      const { data: completedRow, error: completionError } = await supabase
+        .from('profile_challenge_progress')
+        .update({
+          status: 'completed',
+          completed_at: completionTime,
+          progress: progressPayload,
+        })
+        .eq('profile_id', input.profile.profileId)
+        .eq('challenge_id', challenge.id)
+        .select('*')
+        .maybeSingle()
+
+      if (completionError || !completedRow) {
+        console.error('Unable to finalize challenge completion', completionError)
+        continue
+      }
+
+      completed.push({
+        id: completedRow.id,
+        profileId: completedRow.profile_id,
+        challengeId: completedRow.challenge_id,
+        progress: completedRow.progress,
+        status: completedRow.status,
+        streakCount: completedRow.streak_count,
+        startedAt: completedRow.started_at,
+        completedAt: completedRow.completed_at,
+      })
+    }
+  }
+
+  return { completed }
+}

--- a/src/lib/gamification/points-engine.ts
+++ b/src/lib/gamification/points-engine.ts
@@ -106,7 +106,6 @@ const mapProfileRowToSummary = (
 ): GamificationProfileSummary => {
   const xpTotal = Number(row.xp_total ?? 0)
   const currentLevel = Number(row.level ?? 1)
-  const xpToNext = Math.max(nextLevelXp - xpTotal, 0)
   const levelProgress = nextLevelXp > 0 ? Math.min((xpTotal / nextLevelXp) * 100, 100) : 0
 
   return {

--- a/src/lib/gamification/points-engine.ts
+++ b/src/lib/gamification/points-engine.ts
@@ -1,0 +1,396 @@
+import { createServiceRoleClient } from '@/lib/supabase/server-client'
+import type { Database } from '@/lib/supabase/types'
+import {
+  cacheGet,
+  cacheInvalidate,
+  cacheSet,
+  buildCacheKey,
+} from './cache'
+import type {
+  ActionDefinition,
+  GamificationProfileSummary,
+  GamificationActionType,
+  RecordActionInput,
+  RecordActionResult,
+  SupabaseClient,
+} from './types'
+import { evaluateBadgesForAction } from './badge-evaluator'
+import { applyStreakProgress } from './streak-manager'
+import { processChallengesForAction } from './challenge-service'
+import { syncRolesForProfile } from './role-service'
+
+const ACTION_DEFINITIONS: Record<GamificationActionType, ActionDefinition> = {
+  'post.published': {
+    type: 'post.published',
+    baseXp: 120,
+    basePoints: 100,
+    description: 'Published a new article',
+    cooldownMs: 1000 * 60 * 30,
+  },
+  'post.updated': {
+    type: 'post.updated',
+    baseXp: 40,
+    basePoints: 30,
+    description: 'Updated an existing article',
+    cooldownMs: 1000 * 60 * 10,
+    maxDailyOccurrences: 5,
+  },
+  'comment.approved': {
+    type: 'comment.approved',
+    baseXp: 25,
+    basePoints: 15,
+    description: 'Had a comment approved',
+    cooldownMs: 1000 * 60 * 5,
+  },
+  'comment.submitted': {
+    type: 'comment.submitted',
+    baseXp: 10,
+    basePoints: 5,
+    description: 'Submitted a comment pending review',
+    cooldownMs: 1000 * 60,
+    maxDailyOccurrences: 10,
+  },
+  'comment.received_upvote': {
+    type: 'comment.received_upvote',
+    baseXp: 15,
+    basePoints: 10,
+    description: 'Received a community upvote',
+    cooldownMs: 1000 * 60,
+    maxDailyOccurrences: 20,
+  },
+  'onboarding.completed': {
+    type: 'onboarding.completed',
+    baseXp: 150,
+    basePoints: 200,
+    description: 'Completed onboarding journey',
+  },
+  'account.login_streak': {
+    type: 'account.login_streak',
+    baseXp: 35,
+    basePoints: 25,
+    description: 'Maintained a login streak',
+    cooldownMs: 1000 * 60 * 60 * 12,
+  },
+  'challenge.completed': {
+    type: 'challenge.completed',
+    baseXp: 200,
+    basePoints: 160,
+    description: 'Completed an active challenge',
+  },
+  'badge.awarded': {
+    type: 'badge.awarded',
+    baseXp: 80,
+    basePoints: 60,
+    description: 'Badge unlocked bonus',
+  },
+  'custom.manual_adjustment': {
+    type: 'custom.manual_adjustment',
+    baseXp: 0,
+    basePoints: 0,
+    description: 'Manual admin adjustment',
+  },
+}
+
+const LEVEL_CACHE_KEY = 'gamification:levels:v1'
+const LEVEL_CACHE_TTL_SECONDS = 60 * 15
+
+interface LevelDefinition {
+  level: number
+  min_xp: number
+  title: string
+}
+
+const mapProfileRowToSummary = (
+  row: Database['public']['Tables']['gamification_profiles']['Row'],
+  nextLevelXp: number,
+): GamificationProfileSummary => {
+  const xpTotal = Number(row.xp_total ?? 0)
+  const currentLevel = Number(row.level ?? 1)
+  const xpToNext = Math.max(nextLevelXp - xpTotal, 0)
+  const levelProgress = nextLevelXp > 0 ? Math.min((xpTotal / nextLevelXp) * 100, 100) : 0
+
+  return {
+    profileId: row.profile_id,
+    xpTotal,
+    level: currentLevel,
+    prestigeLevel: Number(row.prestige_level ?? 0),
+    currentStreak: Number(row.current_streak ?? 0),
+    longestStreak: Number(row.longest_streak ?? 0),
+    nextLevelXp,
+    progressPercentage: Math.round(levelProgress * 100) / 100,
+    optedIn: Boolean(row.opted_in),
+    lastActionAt: row.last_action_at,
+    streakFrozenUntil: row.streak_frozen_until,
+    settings: row.settings ?? {},
+  }
+}
+
+const loadLevelDefinitions = async (supabase: SupabaseClient): Promise<LevelDefinition[]> => {
+  const cached = await cacheGet<LevelDefinition[]>(LEVEL_CACHE_KEY)
+
+  if (cached) {
+    return cached
+  }
+
+  const { data, error } = await supabase
+    .from('gamification_levels')
+    .select('level, min_xp, title')
+    .order('min_xp', { ascending: true })
+
+  if (error) {
+    throw new Error(`Unable to load gamification levels: ${error.message}`)
+  }
+
+  const mapped: LevelDefinition[] = (data ?? []).map((entry) => ({
+    level: Number(entry.level),
+    min_xp: Number(entry.min_xp),
+    title: String(entry.title ?? `Level ${entry.level}`),
+  }))
+
+  await cacheSet(LEVEL_CACHE_KEY, mapped, LEVEL_CACHE_TTL_SECONDS)
+
+  return mapped
+}
+
+const resolveLevel = (levels: LevelDefinition[], xpTotal: number) => {
+  let currentLevel = 1
+  let nextLevelXp = xpTotal
+
+  for (const levelDef of levels) {
+    if (xpTotal >= levelDef.min_xp) {
+      currentLevel = levelDef.level
+    } else {
+      nextLevelXp = levelDef.min_xp
+      break
+    }
+  }
+
+  const lastLevel = levels[levels.length - 1]
+
+  if (!levels.some((level) => level.level === currentLevel)) {
+    currentLevel = lastLevel ? lastLevel.level : 1
+  }
+
+  if (xpTotal >= (lastLevel?.min_xp ?? 0)) {
+    nextLevelXp = (lastLevel?.min_xp ?? xpTotal) + Math.pow(1.5, currentLevel) * 500
+  }
+
+  return { currentLevel, nextLevelXp }
+}
+
+const hasExceededDailyCap = async (
+  supabase: SupabaseClient,
+  profileId: string,
+  actionType: GamificationActionType,
+  maxDailyOccurrences?: number,
+) => {
+  if (!maxDailyOccurrences) {
+    return false
+  }
+
+  const startOfDay = new Date()
+  startOfDay.setUTCHours(0, 0, 0, 0)
+
+  const { count, error } = await supabase
+    .from('gamification_actions')
+    .select('id', { head: true, count: 'exact' })
+    .eq('profile_id', profileId)
+    .eq('action_type', actionType)
+    .gte('awarded_at', startOfDay.toISOString())
+
+  if (error) {
+    console.error('Unable to check action daily cap', error)
+    return false
+  }
+
+  return typeof count === 'number' && count >= maxDailyOccurrences
+}
+
+const shouldApplyCooldown = async (
+  profileId: string,
+  action: ActionDefinition,
+): Promise<boolean> => {
+  if (!action.cooldownMs) {
+    return false
+  }
+
+  const cacheKey = buildCacheKey('gamification', 'cooldown', profileId, action.type)
+  const expiresAt = await cacheGet<number>(cacheKey)
+
+  if (expiresAt && expiresAt > Date.now()) {
+    return true
+  }
+
+  await cacheSet(cacheKey, Date.now() + action.cooldownMs, Math.ceil(action.cooldownMs / 1000))
+  return false
+}
+
+const coerceNumber = (value: unknown, fallback = 0) => {
+  const num = Number(value)
+  return Number.isFinite(num) ? num : fallback
+}
+
+const ensureProfileRecord = async (supabase: SupabaseClient, profileId: string) => {
+  const { data, error } = await supabase
+    .from('gamification_profiles')
+    .select('*')
+    .eq('profile_id', profileId)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Unable to load gamification profile: ${error.message}`)
+  }
+
+  if (data) {
+    return data
+  }
+
+  const insertPayload: Database['public']['Tables']['gamification_profiles']['Insert'] = {
+    profile_id: profileId,
+    xp_total: 0,
+    level: 1,
+    current_streak: 0,
+    longest_streak: 0,
+    level_progress: {},
+    settings: {},
+  }
+
+  const { data: inserted, error: insertError } = await supabase
+    .from('gamification_profiles')
+    .insert(insertPayload)
+    .select('*')
+    .maybeSingle()
+
+  if (insertError) {
+    throw new Error(`Unable to create gamification profile: ${insertError.message}`)
+  }
+
+  return inserted!
+}
+
+export const recordAction = async (
+  input: RecordActionInput,
+  client: SupabaseClient = createServiceRoleClient(),
+): Promise<RecordActionResult> => {
+  const definition = ACTION_DEFINITIONS[input.actionType] ?? ACTION_DEFINITIONS['custom.manual_adjustment']
+  const supabase = client
+
+  const existingProfileRow = await ensureProfileRecord(supabase, input.profileId)
+
+  if (!existingProfileRow.opted_in && input.actionType !== 'custom.manual_adjustment') {
+    return {
+      applied: false,
+      xpAwarded: 0,
+      pointsAwarded: 0,
+      profile: mapProfileRowToSummary(existingProfileRow, 0),
+      newlyEarnedBadges: [],
+      completedChallenges: [],
+    }
+  }
+
+  if (await shouldApplyCooldown(input.profileId, definition)) {
+    return {
+      applied: false,
+      xpAwarded: 0,
+      pointsAwarded: 0,
+      profile: mapProfileRowToSummary(existingProfileRow, 0),
+      newlyEarnedBadges: [],
+      completedChallenges: [],
+    }
+  }
+
+  if (await hasExceededDailyCap(supabase, input.profileId, definition.type, definition.maxDailyOccurrences)) {
+    return {
+      applied: false,
+      xpAwarded: 0,
+      pointsAwarded: 0,
+      profile: mapProfileRowToSummary(existingProfileRow, 0),
+      newlyEarnedBadges: [],
+      completedChallenges: [],
+    }
+  }
+
+  const metadata = input.metadata ?? {}
+  const xpAwarded = coerceNumber(metadata.xp ?? definition.baseXp, definition.baseXp)
+  const pointsAwarded = coerceNumber(metadata.points ?? definition.basePoints, definition.basePoints)
+
+  const nowIso = new Date().toISOString()
+
+  const { error: insertError } = await supabase.from('gamification_actions').insert({
+    profile_id: input.profileId,
+    action_type: definition.type,
+    action_source: input.actionSource ?? null,
+    metadata,
+    xp_awarded: xpAwarded,
+    points_awarded: pointsAwarded,
+    awarded_at: nowIso,
+    request_id: input.requestId ?? null,
+  })
+
+  if (insertError) {
+    throw new Error(`Unable to record gamification action: ${insertError.message}`)
+  }
+
+  const levels = await loadLevelDefinitions(supabase)
+
+  const newXpTotal = coerceNumber(existingProfileRow.xp_total) + xpAwarded
+  const streakResult = applyStreakProgress(existingProfileRow, nowIso)
+  const { currentLevel, nextLevelXp } = resolveLevel(levels, newXpTotal)
+
+  const updatedPayload: Database['public']['Tables']['gamification_profiles']['Update'] = {
+    xp_total: newXpTotal,
+    level: currentLevel,
+    current_streak: streakResult.currentStreak,
+    longest_streak: Math.max(streakResult.currentStreak, coerceNumber(existingProfileRow.longest_streak)),
+    last_action_at: nowIso,
+    level_progress: {
+      nextLevelXp,
+      xpAwarded,
+      pointsAwarded,
+      actionType: definition.type,
+    },
+  }
+
+  if (streakResult.streakFrozenUntil) {
+    updatedPayload.streak_frozen_until = streakResult.streakFrozenUntil
+  }
+
+  const { data: updatedRow, error: updateError } = await supabase
+    .from('gamification_profiles')
+    .update(updatedPayload)
+    .eq('profile_id', input.profileId)
+    .select('*')
+    .maybeSingle()
+
+  if (updateError || !updatedRow) {
+    throw new Error(`Unable to update gamification profile: ${updateError?.message ?? 'unknown error'}`)
+  }
+
+  await cacheInvalidate(buildCacheKey('gamification', 'leaderboard'))
+
+  const profileSummary = mapProfileRowToSummary(updatedRow, nextLevelXp)
+
+  const badgeResults = await evaluateBadgesForAction({
+    profile: profileSummary,
+    action: input,
+    metadata,
+  }, supabase)
+
+  const challengeResults = await processChallengesForAction({
+    profile: profileSummary,
+    action: input,
+    xpAwarded,
+    metadata,
+  }, supabase)
+
+  await syncRolesForProfile(profileSummary, supabase)
+
+  return {
+    applied: true,
+    xpAwarded,
+    pointsAwarded,
+    profile: profileSummary,
+    newlyEarnedBadges: badgeResults.newBadges,
+    completedChallenges: challengeResults.completed,
+  }
+}

--- a/src/lib/gamification/profile-service.ts
+++ b/src/lib/gamification/profile-service.ts
@@ -1,0 +1,193 @@
+import { createServiceRoleClient } from '@/lib/supabase/server-client'
+import type { Database } from '@/lib/supabase/types'
+import {
+  cacheGet,
+  cacheSet,
+  buildCacheKey,
+} from './cache'
+import type {
+  GamificationProfileSummary,
+  LeaderboardEntry,
+  LeaderboardFilters,
+  OwnedBadge,
+  SupabaseClient,
+} from './types'
+
+const PROFILE_CACHE_TTL_SECONDS = 60
+const LEADERBOARD_CACHE_TTL_SECONDS = 30
+
+const mapProfileRow = (
+  row: Database['public']['Tables']['gamification_profiles']['Row'],
+): GamificationProfileSummary => {
+  const xpTotal = Number(row.xp_total ?? 0)
+  const nextLevelXp = Number((row.level_progress as any)?.nextLevelXp ?? 0)
+  const progressPercentage = nextLevelXp > 0 ? Math.min((xpTotal / nextLevelXp) * 100, 100) : 0
+
+  return {
+    profileId: row.profile_id,
+    xpTotal,
+    level: Number(row.level ?? 1),
+    prestigeLevel: Number(row.prestige_level ?? 0),
+    currentStreak: Number(row.current_streak ?? 0),
+    longestStreak: Number(row.longest_streak ?? 0),
+    nextLevelXp,
+    progressPercentage,
+    optedIn: Boolean(row.opted_in),
+    lastActionAt: row.last_action_at,
+    streakFrozenUntil: row.streak_frozen_until,
+    settings: row.settings ?? {},
+  }
+}
+
+const mapOwnedBadge = (
+  badge: {
+    badges: { id: string; slug: string; name: string; description: string | null; category: string; rarity: string; icon: string | null; theme: string | null; requirements: Record<string, unknown>; reward_points: number; available_from: string | null; available_to: string | null } | null
+    awarded_at: string
+    state: 'awarded' | 'revoked' | 'suspended'
+    notified_at: string | null
+  },
+): OwnedBadge | null => {
+  if (!badge.badges) return null
+  return {
+    id: badge.badges.id,
+    slug: badge.badges.slug,
+    name: badge.badges.name,
+    description: badge.badges.description,
+    category: badge.badges.category,
+    rarity: badge.badges.rarity,
+    icon: badge.badges.icon,
+    theme: badge.badges.theme,
+    requirements: badge.badges.requirements,
+    rewardPoints: badge.badges.reward_points,
+    availableFrom: badge.badges.available_from,
+    availableTo: badge.badges.available_to,
+    awardedAt: badge.awarded_at,
+    state: badge.state,
+    notifiedAt: badge.notified_at,
+  }
+}
+
+export interface GamificationProfilePayload {
+  profile: GamificationProfileSummary | null
+  badges: OwnedBadge[]
+  streakHistory: Array<{ date: string; xp: number }>
+  recentActions: Array<{ actionType: string; awardedAt: string; xp: number; points: number }>
+}
+
+export const fetchGamificationProfile = async (
+  profileId: string,
+  client: SupabaseClient = createServiceRoleClient(),
+): Promise<GamificationProfilePayload> => {
+  const cacheKey = buildCacheKey('gamification', 'profile', profileId)
+  const cached = await cacheGet<GamificationProfilePayload>(cacheKey)
+  if (cached) {
+    return cached
+  }
+
+  const supabase = client
+
+  const [{ data: profileRow }, { data: badgesData }, { data: actionsData }] = await Promise.all([
+    supabase
+      .from('gamification_profiles')
+      .select('*')
+      .eq('profile_id', profileId)
+      .maybeSingle(),
+    supabase
+      .from('profile_badges')
+      .select('awarded_at, state, notified_at, badges:badge_id (id, slug, name, description, category, rarity, icon, theme, requirements, reward_points, available_from, available_to)')
+      .eq('profile_id', profileId)
+      .order('awarded_at', { ascending: false }),
+    supabase
+      .from('gamification_actions')
+      .select('action_type, awarded_at, xp_awarded, points_awarded')
+      .eq('profile_id', profileId)
+      .order('awarded_at', { ascending: false })
+      .limit(20),
+  ])
+
+  const profile = profileRow ? mapProfileRow(profileRow) : null
+  const badges = (badgesData ?? [])
+    .map((badge) => mapOwnedBadge(badge as any))
+    .filter((value): value is OwnedBadge => Boolean(value))
+
+  const recentActions = (actionsData ?? []).map((action) => ({
+    actionType: action.action_type,
+    awardedAt: action.awarded_at,
+    xp: Number(action.xp_awarded ?? 0),
+    points: Number(action.points_awarded ?? 0),
+  }))
+
+  const streakHistory = recentActions.map((entry) => ({
+    date: entry.awardedAt,
+    xp: entry.xp,
+  }))
+
+  const payload: GamificationProfilePayload = {
+    profile,
+    badges,
+    streakHistory,
+    recentActions,
+  }
+
+  await cacheSet(cacheKey, payload, PROFILE_CACHE_TTL_SECONDS)
+
+  return payload
+}
+
+interface LeaderboardPayload {
+  entries: LeaderboardEntry[]
+  capturedAt: string
+}
+
+const mapLeaderboardEntries = (
+  rows: Array<{
+    profile_id: string
+    xp_total: number
+    level: number
+    current_streak: number
+    profiles: { display_name: string | null; avatar_url: string | null } | null
+    badges: { slug: string }[] | null
+  }>,
+): LeaderboardEntry[] =>
+  rows.map((row, index) => ({
+    profileId: row.profile_id,
+    xp: Number(row.xp_total ?? 0),
+    level: Number(row.level ?? 1),
+    streak: Number(row.current_streak ?? 0),
+    displayName: row.profiles?.display_name ?? 'Community member',
+    avatarUrl: row.profiles?.avatar_url ?? null,
+    badges: (row.badges ?? []).map((badge) => badge.slug),
+    rank: index + 1,
+  }))
+
+export const fetchLeaderboard = async (
+  filters: LeaderboardFilters,
+  client: SupabaseClient = createServiceRoleClient(),
+): Promise<LeaderboardPayload> => {
+  const cacheKey = buildCacheKey('gamification', 'leaderboard', filters.scope, filters.category ?? 'all')
+  const cached = await cacheGet<LeaderboardPayload>(cacheKey)
+
+  if (cached) {
+    return cached
+  }
+
+  const supabase = client
+  const { data, error } = await supabase
+    .from('gamification_profiles')
+    .select('profile_id, xp_total, level, current_streak, profiles:profile_id (display_name, avatar_url), badges:profile_badges!left (slug)')
+    .order('xp_total', { ascending: false })
+    .limit(filters.limit ?? 10)
+
+  if (error) {
+    throw new Error(`Unable to load leaderboard: ${error.message}`)
+  }
+
+  const payload: LeaderboardPayload = {
+    entries: mapLeaderboardEntries(data ?? []),
+    capturedAt: new Date().toISOString(),
+  }
+
+  await cacheSet(cacheKey, payload, LEADERBOARD_CACHE_TTL_SECONDS)
+
+  return payload
+}

--- a/src/lib/gamification/role-service.ts
+++ b/src/lib/gamification/role-service.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from './types'
+import { extractRelationSlug, isRecordLike } from './utils'
 
 const LEVEL_ROLE_THRESHOLDS: Array<{ level: number; roleSlug: string }> = [
   { level: 2, roleSlug: 'community-member' },
@@ -47,8 +48,12 @@ const fetchOwnedBadges = async (supabase: SupabaseClient, profileId: string) => 
 
   const slugs = new Set<string>()
   for (const entry of data ?? []) {
-    const slug = Array.isArray(entry.badges) ? entry.badges[0]?.slug : (entry as any)?.badges?.slug
-    if (typeof slug === 'string') {
+    if (!isRecordLike(entry)) {
+      continue
+    }
+
+    const slug = extractRelationSlug(entry.badges)
+    if (slug) {
       slugs.add(slug)
     }
   }
@@ -95,8 +100,12 @@ export const syncRolesForProfile = async (
   const roleIdBySlug = new Map<string, string>()
 
   for (const entry of existingRoles ?? []) {
-    const slug = Array.isArray(entry.roles) ? entry.roles[0]?.slug : (entry as any)?.roles?.slug
-    if (typeof slug === 'string') {
+    if (!isRecordLike(entry)) {
+      continue
+    }
+
+    const slug = extractRelationSlug(entry.roles)
+    if (slug) {
       ownedRoleSlugs.add(slug)
       if (typeof entry.role_id === 'string') {
         roleIdBySlug.set(slug, entry.role_id)

--- a/src/lib/gamification/role-service.ts
+++ b/src/lib/gamification/role-service.ts
@@ -1,0 +1,140 @@
+import type { SupabaseClient } from './types'
+
+const LEVEL_ROLE_THRESHOLDS: Array<{ level: number; roleSlug: string }> = [
+  { level: 2, roleSlug: 'community-member' },
+  { level: 3, roleSlug: 'trusted-voice' },
+  { level: 4, roleSlug: 'community-moderator' },
+  { level: 5, roleSlug: 'syntax-sage' },
+]
+
+const BADGE_ROLE_MAPPINGS: Array<{ badgeSlug: string; roleSlug: string }> = [
+  { badgeSlug: 'community-barista', roleSlug: 'community-moderator' },
+  { badgeSlug: 'seasonal-taster', roleSlug: 'event-host' },
+]
+
+const fetchRoleIds = async (supabase: SupabaseClient, slugs: string[]) => {
+  if (!slugs.length) return new Map<string, string>()
+
+  const { data, error } = await supabase
+    .from('roles')
+    .select('id, slug')
+    .in('slug', slugs)
+
+  if (error) {
+    console.error('Unable to fetch role ids for gamification', error)
+    return new Map<string, string>()
+  }
+
+  const map = new Map<string, string>()
+  for (const role of data ?? []) {
+    if (role && typeof role.slug === 'string' && typeof role.id === 'string') {
+      map.set(role.slug, role.id)
+    }
+  }
+  return map
+}
+
+const fetchOwnedBadges = async (supabase: SupabaseClient, profileId: string) => {
+  const { data, error } = await supabase
+    .from('profile_badges')
+    .select('badges:badge_id (slug)')
+    .eq('profile_id', profileId)
+
+  if (error) {
+    console.error('Unable to fetch owned badges for role mapping', error)
+    return new Set<string>()
+  }
+
+  const slugs = new Set<string>()
+  for (const entry of data ?? []) {
+    const slug = Array.isArray(entry.badges) ? entry.badges[0]?.slug : (entry as any)?.badges?.slug
+    if (typeof slug === 'string') {
+      slugs.add(slug)
+    }
+  }
+  return slugs
+}
+
+export const syncRolesForProfile = async (
+  profile: { profileId: string; level: number },
+  supabase: SupabaseClient,
+) => {
+  const eligibleRoleSlugs = new Set<string>()
+
+  for (const mapping of LEVEL_ROLE_THRESHOLDS) {
+    if (profile.level >= mapping.level) {
+      eligibleRoleSlugs.add(mapping.roleSlug)
+    }
+  }
+
+  const ownedBadges = await fetchOwnedBadges(supabase, profile.profileId)
+
+  for (const mapping of BADGE_ROLE_MAPPINGS) {
+    if (ownedBadges.has(mapping.badgeSlug)) {
+      eligibleRoleSlugs.add(mapping.roleSlug)
+    }
+  }
+
+  if (!eligibleRoleSlugs.size) {
+    return
+  }
+
+  const roleIdMap = await fetchRoleIds(supabase, Array.from(eligibleRoleSlugs))
+
+  const { data: existingRoles, error: profileRolesError } = await supabase
+    .from('profile_roles')
+    .select('id, role_id, roles:role_id (slug)')
+    .eq('profile_id', profile.profileId)
+
+  if (profileRolesError) {
+    console.error('Unable to fetch existing profile roles', profileRolesError)
+    return
+  }
+
+  const ownedRoleSlugs = new Set<string>()
+  const roleIdBySlug = new Map<string, string>()
+
+  for (const entry of existingRoles ?? []) {
+    const slug = Array.isArray(entry.roles) ? entry.roles[0]?.slug : (entry as any)?.roles?.slug
+    if (typeof slug === 'string') {
+      ownedRoleSlugs.add(slug)
+      if (typeof entry.role_id === 'string') {
+        roleIdBySlug.set(slug, entry.role_id)
+      }
+    }
+  }
+
+  const rolesToAssign: Array<{ profile_id: string; role_id: string }> = []
+
+  for (const slug of eligibleRoleSlugs) {
+    if (ownedRoleSlugs.has(slug)) {
+      continue
+    }
+    const roleId = roleIdMap.get(slug)
+    if (roleId) {
+      rolesToAssign.push({ profile_id: profile.profileId, role_id: roleId })
+    }
+  }
+
+  if (rolesToAssign.length) {
+    const { error: insertError } = await supabase.from('profile_roles').insert(rolesToAssign)
+    if (insertError) {
+      console.error('Unable to assign gamification roles', insertError)
+    }
+  }
+
+  for (const ownedSlug of ownedRoleSlugs) {
+    if (!eligibleRoleSlugs.has(ownedSlug)) {
+      const roleId = roleIdBySlug.get(ownedSlug)
+      if (!roleId) continue
+      const { error: deleteError } = await supabase
+        .from('profile_roles')
+        .delete()
+        .eq('profile_id', profile.profileId)
+        .eq('role_id', roleId)
+      if (deleteError) {
+        console.error('Unable to remove outdated gamification role', deleteError)
+      }
+    }
+  }
+}

--- a/src/lib/gamification/streak-manager.ts
+++ b/src/lib/gamification/streak-manager.ts
@@ -1,0 +1,63 @@
+import type { Database } from '@/lib/supabase/types'
+
+interface StreakResult {
+  currentStreak: number
+  streakFrozenUntil: string | null
+}
+
+const STREAK_GRACE_PERIOD_HOURS = 36
+
+const parseDate = (value: string | null) => {
+  if (!value) return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+export const applyStreakProgress = (
+  profile: Database['public']['Tables']['gamification_profiles']['Row'],
+  nowIso: string,
+): StreakResult => {
+  const now = parseDate(nowIso) ?? new Date()
+  const lastAction = parseDate(profile.last_action_at)
+  const frozenUntil = parseDate(profile.streak_frozen_until)
+
+  if (frozenUntil && frozenUntil > now) {
+    return {
+      currentStreak: profile.current_streak ?? 0,
+      streakFrozenUntil: profile.streak_frozen_until,
+    }
+  }
+
+  if (!lastAction) {
+    return {
+      currentStreak: 1,
+      streakFrozenUntil: null,
+    }
+  }
+
+  const diffHours = Math.abs(now.getTime() - lastAction.getTime()) / (1000 * 60 * 60)
+
+  if (diffHours <= STREAK_GRACE_PERIOD_HOURS) {
+    return {
+      currentStreak: Number(profile.current_streak ?? 0) + 1,
+      streakFrozenUntil: null,
+    }
+  }
+
+  return {
+    currentStreak: 1,
+    streakFrozenUntil: null,
+  }
+}
+
+export const applyStreakFreeze = (
+  profileId: string,
+  supabase: import('./types').SupabaseClient,
+  hours: number,
+) => {
+  const freezeUntil = new Date(Date.now() + hours * 60 * 60 * 1000).toISOString()
+  return supabase
+    .from('gamification_profiles')
+    .update({ streak_frozen_until: freezeUntil })
+    .eq('profile_id', profileId)
+}

--- a/src/lib/gamification/types.ts
+++ b/src/lib/gamification/types.ts
@@ -1,0 +1,148 @@
+import type { Database } from '@/lib/supabase/types'
+
+type Json = Database['public']['Tables']['gamification_profiles']['Row']['settings']
+
+type Maybe<T> = T | null
+
+export type GamificationActionType =
+  | 'post.published'
+  | 'post.updated'
+  | 'comment.approved'
+  | 'comment.submitted'
+  | 'comment.received_upvote'
+  | 'onboarding.completed'
+  | 'account.login_streak'
+  | 'challenge.completed'
+  | 'badge.awarded'
+  | 'custom.manual_adjustment'
+
+export interface ActionDefinition {
+  type: GamificationActionType
+  baseXp: number
+  basePoints: number
+  description: string
+  cooldownMs?: number
+  maxDailyOccurrences?: number
+  metadataKeys?: string[]
+}
+
+export interface GamificationProfileSummary {
+  profileId: string
+  xpTotal: number
+  level: number
+  prestigeLevel: number
+  currentStreak: number
+  longestStreak: number
+  nextLevelXp: number
+  progressPercentage: number
+  optedIn: boolean
+  lastActionAt: Maybe<string>
+  streakFrozenUntil: Maybe<string>
+  settings: Json
+}
+
+export interface LeaderboardEntry {
+  profileId: string
+  displayName: string
+  avatarUrl: Maybe<string>
+  level: number
+  xp: number
+  rank: number
+  badges: string[]
+  streak: number
+}
+
+export interface BadgeDefinition {
+  id: string
+  slug: string
+  name: string
+  description: Maybe<string>
+  category: string
+  rarity: string
+  icon: Maybe<string>
+  theme: Maybe<string>
+  requirements: Json
+  rewardPoints: number
+  availableFrom: Maybe<string>
+  availableTo: Maybe<string>
+}
+
+export interface OwnedBadge extends BadgeDefinition {
+  awardedAt: string
+  state: 'awarded' | 'revoked' | 'suspended'
+  notifiedAt: Maybe<string>
+}
+
+export interface ChallengeDefinition {
+  id: string
+  slug: string
+  title: string
+  description: Maybe<string>
+  cadence: 'daily' | 'weekly' | 'monthly' | 'seasonal' | 'event'
+  rewardPoints: number
+  rewardBadgeId: Maybe<string>
+  startsAt: Maybe<string>
+  endsAt: Maybe<string>
+  requirements: Json
+}
+
+export interface ChallengeProgress {
+  id: string
+  challengeId: string
+  profileId: string
+  progress: Json
+  status: 'active' | 'completed' | 'expired' | 'abandoned'
+  streakCount: number
+  startedAt: string
+  completedAt: Maybe<string>
+}
+
+export interface GamificationAnalyticsSnapshot {
+  totalProfiles: number
+  totalXpAwarded: number
+  averageLevel: number
+  streakLeaders: LeaderboardEntry[]
+  badgeCounts: Array<{ badgeSlug: string; total: number }>
+  activeChallenges: ChallengeDefinition[]
+}
+
+export interface RecordActionInput {
+  profileId: string
+  actionType: GamificationActionType
+  metadata?: Record<string, unknown>
+  actionSource?: string
+  requestId?: string
+}
+
+export interface RecordActionResult {
+  applied: boolean
+  xpAwarded: number
+  pointsAwarded: number
+  profile: GamificationProfileSummary
+  newlyEarnedBadges: OwnedBadge[]
+  completedChallenges: ChallengeProgress[]
+}
+
+export interface BadgeEvaluationContext {
+  profile: GamificationProfileSummary
+  action: RecordActionInput
+  metadata: Record<string, unknown>
+}
+
+export interface LeaderboardFilters {
+  scope: 'global' | 'seasonal' | 'category'
+  category?: string
+  limit?: number
+  cursor?: string
+}
+
+export interface ConsentToggleInput {
+  profileId: string
+  optedIn: boolean
+}
+
+export type SupabaseClient = ReturnType<typeof import('@supabase/supabase-js')['createClient']<
+  Database,
+  'public',
+  any
+>>

--- a/src/lib/gamification/types.ts
+++ b/src/lib/gamification/types.ts
@@ -1,3 +1,4 @@
+import type { SupabaseClient as SupabaseClientBase } from '@supabase/supabase-js'
 import type { Database } from '@/lib/supabase/types'
 
 type Json = Database['public']['Tables']['gamification_profiles']['Row']['settings']
@@ -141,8 +142,4 @@ export interface ConsentToggleInput {
   optedIn: boolean
 }
 
-export type SupabaseClient = ReturnType<typeof import('@supabase/supabase-js')['createClient']<
-  Database,
-  'public',
-  any
->>
+export type SupabaseClient = SupabaseClientBase

--- a/src/lib/gamification/utils.ts
+++ b/src/lib/gamification/utils.ts
@@ -1,0 +1,82 @@
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  isObject(value) && !Array.isArray(value)
+
+export const extractRelationSlug = (relation: unknown): string | null => {
+  if (Array.isArray(relation)) {
+    for (const entry of relation) {
+      const slug = extractRelationSlug(entry)
+      if (slug) {
+        return slug
+      }
+    }
+    return null
+  }
+
+  if (isRecord(relation)) {
+    const slugValue = relation.slug
+    if (typeof slugValue === 'string' && slugValue.trim().length > 0) {
+      return slugValue
+    }
+  }
+
+  return null
+}
+
+export const extractNumericField = (value: unknown, key: string): number | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const candidate = value[key]
+  if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+    return candidate
+  }
+
+  if (typeof candidate === 'string') {
+    const parsed = Number(candidate)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  return null
+}
+
+export const ensureJsonRecord = (value: unknown): Record<string, unknown> => {
+  if (isRecord(value)) {
+    return value
+  }
+
+  return {}
+}
+
+export type BadgeState = 'awarded' | 'revoked' | 'suspended'
+
+export const isBadgeState = (value: unknown): value is BadgeState =>
+  value === 'awarded' || value === 'revoked' || value === 'suspended'
+
+export const toNumber = (value: unknown, defaultValue = 0): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return defaultValue
+}
+
+export const toNullableString = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  return null
+}
+
+export const isRecordLike = isRecord

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1,0 +1,255 @@
+export interface Database {
+  public: {
+    Tables: {
+      profiles: {
+        Row: {
+          id: string
+          user_id: string | null
+          display_name: string | null
+          avatar_url: string | null
+          is_admin: boolean | null
+        }
+        Insert: {
+          id: string
+          user_id?: string | null
+          display_name?: string | null
+          avatar_url?: string | null
+          is_admin?: boolean | null
+        }
+        Update: Partial<Database['public']['Tables']['profiles']['Insert']>
+      }
+      gamification_profiles: {
+        Row: {
+          profile_id: string
+          xp_total: number
+          level: number
+          prestige_level: number
+          level_progress: Record<string, unknown>
+          current_streak: number
+          longest_streak: number
+          last_action_at: string | null
+          streak_frozen_until: string | null
+          opted_in: boolean
+          settings: Record<string, unknown>
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          profile_id: string
+          xp_total?: number
+          level?: number
+          prestige_level?: number
+          level_progress?: Record<string, unknown>
+          current_streak?: number
+          longest_streak?: number
+          last_action_at?: string | null
+          streak_frozen_until?: string | null
+          opted_in?: boolean
+          settings?: Record<string, unknown>
+        }
+        Update: Partial<Database['public']['Tables']['gamification_profiles']['Insert']>
+      }
+      gamification_actions: {
+        Row: {
+          id: string
+          profile_id: string
+          action_type: string
+          action_source: string | null
+          points_awarded: number
+          xp_awarded: number
+          metadata: Record<string, unknown>
+          awarded_at: string
+          request_id: string | null
+        }
+        Insert: {
+          id?: string
+          profile_id: string
+          action_type: string
+          action_source?: string | null
+          points_awarded?: number
+          xp_awarded?: number
+          metadata?: Record<string, unknown>
+          awarded_at?: string
+          request_id?: string | null
+        }
+        Update: Partial<Database['public']['Tables']['gamification_actions']['Insert']>
+      }
+      gamification_badges: {
+        Row: {
+          id: string
+          slug: string
+          name: string
+          description: string | null
+          category: string
+          rarity: string
+          parent_badge_id: string | null
+          icon: string | null
+          theme: string | null
+          requirements: Record<string, unknown>
+          reward_points: number
+          is_time_limited: boolean
+          available_from: string | null
+          available_to: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          slug: string
+          name: string
+          description?: string | null
+          category: string
+          rarity?: string
+          parent_badge_id?: string | null
+          icon?: string | null
+          theme?: string | null
+          requirements?: Record<string, unknown>
+          reward_points?: number
+          is_time_limited?: boolean
+          available_from?: string | null
+          available_to?: string | null
+        }
+        Update: Partial<Database['public']['Tables']['gamification_badges']['Insert']>
+      }
+      profile_badges: {
+        Row: {
+          profile_id: string
+          badge_id: string
+          state: 'awarded' | 'revoked' | 'suspended'
+          awarded_at: string
+          evidence: Record<string, unknown> | null
+          progress: Record<string, unknown>
+          notified_at: string | null
+        }
+        Insert: {
+          profile_id: string
+          badge_id: string
+          state?: 'awarded' | 'revoked' | 'suspended'
+          awarded_at?: string
+          evidence?: Record<string, unknown> | null
+          progress?: Record<string, unknown>
+          notified_at?: string | null
+        }
+        Update: Partial<Database['public']['Tables']['profile_badges']['Insert']>
+      }
+      gamification_levels: {
+        Row: {
+          level: number
+          title: string
+          min_xp: number
+          perks: Record<string, unknown>
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          level: number
+          title: string
+          min_xp: number
+          perks?: Record<string, unknown>
+        }
+        Update: Partial<Database['public']['Tables']['gamification_levels']['Insert']>
+      }
+      gamification_challenges: {
+        Row: {
+          id: string
+          slug: string
+          title: string
+          description: string | null
+          cadence: 'daily' | 'weekly' | 'monthly' | 'seasonal' | 'event'
+          requirements: Record<string, unknown>
+          reward_points: number
+          reward_badge_id: string | null
+          starts_at: string | null
+          ends_at: string | null
+          is_active: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          slug: string
+          title: string
+          description?: string | null
+          cadence: 'daily' | 'weekly' | 'monthly' | 'seasonal' | 'event'
+          requirements?: Record<string, unknown>
+          reward_points?: number
+          reward_badge_id?: string | null
+          starts_at?: string | null
+          ends_at?: string | null
+          is_active?: boolean
+        }
+        Update: Partial<Database['public']['Tables']['gamification_challenges']['Insert']>
+      }
+      profile_challenge_progress: {
+        Row: {
+          id: string
+          profile_id: string
+          challenge_id: string
+          progress: Record<string, unknown>
+          status: 'active' | 'completed' | 'expired' | 'abandoned'
+          streak_count: number
+          started_at: string
+          completed_at: string | null
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          profile_id: string
+          challenge_id: string
+          progress?: Record<string, unknown>
+          status?: 'active' | 'completed' | 'expired' | 'abandoned'
+          streak_count?: number
+          started_at?: string
+          completed_at?: string | null
+        }
+        Update: Partial<Database['public']['Tables']['profile_challenge_progress']['Insert']>
+      }
+      leaderboard_snapshots: {
+        Row: {
+          id: string
+          scope: string
+          captured_at: string
+          expires_at: string | null
+          payload: Record<string, unknown>
+        }
+        Insert: {
+          id?: string
+          scope: string
+          captured_at?: string
+          expires_at?: string | null
+          payload?: Record<string, unknown>
+        }
+        Update: Partial<Database['public']['Tables']['leaderboard_snapshots']['Insert']>
+      }
+      gamification_audit: {
+        Row: {
+          id: string
+          profile_id: string | null
+          action: string
+          delta: number | null
+          reason: string | null
+          performed_by: string | null
+          metadata: Record<string, unknown>
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          profile_id?: string | null
+          action: string
+          delta?: number | null
+          reason?: string | null
+          performed_by?: string | null
+          metadata?: Record<string, unknown>
+          created_at?: string
+        }
+        Update: Partial<Database['public']['Tables']['gamification_audit']['Insert']>
+      }
+    }
+    Functions: {
+      is_admin: {
+        Args: Record<string, never>
+        Returns: boolean
+      }
+    }
+  }
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -195,6 +195,7 @@ export interface AdminCommentSummary {
 }
 
 export interface AuthenticatedProfileSummary {
+  profileId: string
   userId: string
   email: string
   displayName: string

--- a/supabase/migrations/0012_create_gamification_schema.sql
+++ b/supabase/migrations/0012_create_gamification_schema.sql
@@ -1,0 +1,741 @@
+-- Create gamification tables, indexes, policies, and helper routines.
+-- This migration follows the architecture described in docs/gamification-roadmap.md
+-- and provides the foundational persistence layer for the Syntax & Sips gamification system.
+
+-- Ensure custom enums exist for challenge cadence and progress status to keep data constrained.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type t
+    WHERE t.typname = 'challenge_cadence'
+      AND t.typnamespace = 'public'::regnamespace
+  ) THEN
+    CREATE TYPE public.challenge_cadence AS ENUM ('daily', 'weekly', 'monthly', 'seasonal', 'event');
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type t
+    WHERE t.typname = 'challenge_progress_status'
+      AND t.typnamespace = 'public'::regnamespace
+  ) THEN
+    CREATE TYPE public.challenge_progress_status AS ENUM ('active', 'completed', 'expired', 'abandoned');
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type t
+    WHERE t.typname = 'badge_state'
+      AND t.typnamespace = 'public'::regnamespace
+  ) THEN
+    CREATE TYPE public.badge_state AS ENUM ('awarded', 'revoked', 'suspended');
+  END IF;
+END;
+$$;
+
+-- Primary profile summary table for gamification metrics.
+CREATE TABLE IF NOT EXISTS public.gamification_profiles (
+  profile_id uuid PRIMARY KEY REFERENCES public.profiles (id) ON DELETE CASCADE,
+  xp_total bigint NOT NULL DEFAULT 0,
+  level integer NOT NULL DEFAULT 1,
+  prestige_level integer NOT NULL DEFAULT 0,
+  level_progress jsonb NOT NULL DEFAULT '{}'::jsonb,
+  current_streak integer NOT NULL DEFAULT 0,
+  longest_streak integer NOT NULL DEFAULT 0,
+  last_action_at timestamptz,
+  streak_frozen_until timestamptz,
+  opted_in boolean NOT NULL DEFAULT true,
+  settings jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS gamification_profiles_level_idx
+  ON public.gamification_profiles (level DESC, xp_total DESC);
+
+-- Ledger of every action that resulted in XP or points being awarded.
+CREATE TABLE IF NOT EXISTS public.gamification_actions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles (id) ON DELETE CASCADE,
+  action_type text NOT NULL,
+  action_source text,
+  points_awarded integer NOT NULL DEFAULT 0,
+  xp_awarded integer NOT NULL DEFAULT 0,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  awarded_at timestamptz NOT NULL DEFAULT now(),
+  request_id uuid,
+  UNIQUE (profile_id, action_type, awarded_at)
+);
+
+CREATE INDEX IF NOT EXISTS gamification_actions_profile_idx
+  ON public.gamification_actions (profile_id, awarded_at DESC);
+
+CREATE INDEX IF NOT EXISTS gamification_actions_type_idx
+  ON public.gamification_actions (action_type, awarded_at DESC);
+
+-- Badge catalog
+CREATE TABLE IF NOT EXISTS public.gamification_badges (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug text NOT NULL UNIQUE,
+  name text NOT NULL,
+  description text,
+  category text NOT NULL,
+  rarity text NOT NULL DEFAULT 'common',
+  parent_badge_id uuid REFERENCES public.gamification_badges (id) ON DELETE SET NULL,
+  icon text,
+  theme text,
+  requirements jsonb NOT NULL DEFAULT '{}'::jsonb,
+  reward_points integer NOT NULL DEFAULT 0,
+  is_time_limited boolean NOT NULL DEFAULT false,
+  available_from timestamptz,
+  available_to timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS gamification_badges_category_idx
+  ON public.gamification_badges (category);
+
+CREATE INDEX IF NOT EXISTS gamification_badges_rarity_idx
+  ON public.gamification_badges (rarity);
+
+-- Mapping between profiles and badges they own.
+CREATE TABLE IF NOT EXISTS public.profile_badges (
+  profile_id uuid NOT NULL REFERENCES public.profiles (id) ON DELETE CASCADE,
+  badge_id uuid NOT NULL REFERENCES public.gamification_badges (id) ON DELETE CASCADE,
+  state public.badge_state NOT NULL DEFAULT 'awarded',
+  awarded_at timestamptz NOT NULL DEFAULT now(),
+  evidence jsonb,
+  progress jsonb NOT NULL DEFAULT '{}'::jsonb,
+  notified_at timestamptz,
+  PRIMARY KEY (profile_id, badge_id)
+);
+
+CREATE INDEX IF NOT EXISTS profile_badges_badge_idx
+  ON public.profile_badges (badge_id);
+
+-- Level definitions with XP thresholds and perks metadata.
+CREATE TABLE IF NOT EXISTS public.gamification_levels (
+  level integer PRIMARY KEY,
+  title text NOT NULL,
+  min_xp bigint NOT NULL,
+  perks jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS gamification_levels_min_xp_idx
+  ON public.gamification_levels (min_xp);
+
+-- Challenge catalog
+CREATE TABLE IF NOT EXISTS public.gamification_challenges (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug text NOT NULL UNIQUE,
+  title text NOT NULL,
+  description text,
+  cadence public.challenge_cadence NOT NULL,
+  requirements jsonb NOT NULL DEFAULT '{}'::jsonb,
+  reward_points integer NOT NULL DEFAULT 0,
+  reward_badge_id uuid REFERENCES public.gamification_badges (id) ON DELETE SET NULL,
+  starts_at timestamptz,
+  ends_at timestamptz,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS gamification_challenges_cadence_idx
+  ON public.gamification_challenges (cadence, is_active);
+
+-- Profile challenge progress tracker
+CREATE TABLE IF NOT EXISTS public.profile_challenge_progress (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles (id) ON DELETE CASCADE,
+  challenge_id uuid NOT NULL REFERENCES public.gamification_challenges (id) ON DELETE CASCADE,
+  progress jsonb NOT NULL DEFAULT '{}'::jsonb,
+  status public.challenge_progress_status NOT NULL DEFAULT 'active',
+  streak_count integer NOT NULL DEFAULT 0,
+  started_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (profile_id, challenge_id)
+);
+
+CREATE INDEX IF NOT EXISTS profile_challenge_progress_profile_idx
+  ON public.profile_challenge_progress (profile_id);
+
+CREATE INDEX IF NOT EXISTS profile_challenge_progress_status_idx
+  ON public.profile_challenge_progress (status);
+
+-- Leaderboard snapshots for cached ranking payloads.
+CREATE TABLE IF NOT EXISTS public.leaderboard_snapshots (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope text NOT NULL,
+  captured_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS leaderboard_snapshots_scope_idx
+  ON public.leaderboard_snapshots (scope, captured_at DESC);
+
+-- Audit log for manual adjustments and privileged actions.
+CREATE TABLE IF NOT EXISTS public.gamification_audit (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid REFERENCES public.profiles (id) ON DELETE SET NULL,
+  action text NOT NULL,
+  delta bigint,
+  reason text,
+  performed_by uuid REFERENCES public.profiles (id) ON DELETE SET NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS gamification_audit_profile_idx
+  ON public.gamification_audit (profile_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS gamification_audit_action_idx
+  ON public.gamification_audit (action, created_at DESC);
+
+-- Trigger helpers for updated_at maintenance.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'gamification_profiles_set_updated_at'
+      AND tgrelid = 'public.gamification_profiles'::regclass
+  ) THEN
+    CREATE TRIGGER gamification_profiles_set_updated_at
+      BEFORE UPDATE ON public.gamification_profiles
+      FOR EACH ROW
+      EXECUTE FUNCTION public.set_updated_at();
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'gamification_badges_set_updated_at'
+      AND tgrelid = 'public.gamification_badges'::regclass
+  ) THEN
+    CREATE TRIGGER gamification_badges_set_updated_at
+      BEFORE UPDATE ON public.gamification_badges
+      FOR EACH ROW
+      EXECUTE FUNCTION public.set_updated_at();
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'gamification_levels_set_updated_at'
+      AND tgrelid = 'public.gamification_levels'::regclass
+  ) THEN
+    CREATE TRIGGER gamification_levels_set_updated_at
+      BEFORE UPDATE ON public.gamification_levels
+      FOR EACH ROW
+      EXECUTE FUNCTION public.set_updated_at();
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'gamification_challenges_set_updated_at'
+      AND tgrelid = 'public.gamification_challenges'::regclass
+  ) THEN
+    CREATE TRIGGER gamification_challenges_set_updated_at
+      BEFORE UPDATE ON public.gamification_challenges
+      FOR EACH ROW
+      EXECUTE FUNCTION public.set_updated_at();
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'profile_challenge_progress_set_updated_at'
+      AND tgrelid = 'public.profile_challenge_progress'::regclass
+  ) THEN
+    CREATE TRIGGER profile_challenge_progress_set_updated_at
+      BEFORE UPDATE ON public.profile_challenge_progress
+      FOR EACH ROW
+      EXECUTE FUNCTION public.set_updated_at();
+  END IF;
+END;
+$$;
+
+-- Audit logging trigger to capture xp total changes.
+CREATE OR REPLACE FUNCTION public.log_gamification_profile_audit()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  xp_delta bigint;
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.xp_total IS DISTINCT FROM OLD.xp_total THEN
+      xp_delta := COALESCE(NEW.xp_total, 0) - COALESCE(OLD.xp_total, 0);
+      INSERT INTO public.gamification_audit (profile_id, action, delta, reason, metadata)
+      VALUES (
+        NEW.profile_id,
+        'xp_total_changed',
+        xp_delta,
+        'Automatic XP ledger update',
+        jsonb_build_object('previous', OLD.xp_total, 'next', NEW.xp_total, 'level', NEW.level)
+      );
+    END IF;
+    IF NEW.level IS DISTINCT FROM OLD.level THEN
+      INSERT INTO public.gamification_audit (profile_id, action, delta, reason, metadata)
+      VALUES (
+        NEW.profile_id,
+        'level_changed',
+        NULL,
+        'Level recalculated based on XP thresholds',
+        jsonb_build_object('previous', OLD.level, 'next', NEW.level, 'prestige', NEW.prestige_level)
+      );
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'gamification_profiles_audit_trigger'
+      AND tgrelid = 'public.gamification_profiles'::regclass
+  ) THEN
+    CREATE TRIGGER gamification_profiles_audit_trigger
+      AFTER UPDATE ON public.gamification_profiles
+      FOR EACH ROW
+      EXECUTE FUNCTION public.log_gamification_profile_audit();
+  END IF;
+END;
+$$;
+
+-- Row Level Security policies
+ALTER TABLE public.gamification_profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gamification_actions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gamification_badges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.profile_badges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gamification_levels ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gamification_challenges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.profile_challenge_progress ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.leaderboard_snapshots ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gamification_audit ENABLE ROW LEVEL SECURITY;
+
+-- Helper predicate to determine whether the requesting user is an administrator.
+CREATE OR REPLACE FUNCTION public.is_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    WHERE p.user_id = auth.uid()
+      AND p.is_admin = TRUE
+  );
+$$;
+
+-- Policies for gamification_profiles
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'gamification_profiles'
+      AND policyname = 'Gamification profile owner access'
+  ) THEN
+    CREATE POLICY "Gamification profile owner access"
+      ON public.gamification_profiles
+      FOR SELECT
+      USING (
+        EXISTS (
+          SELECT 1
+          FROM public.profiles p
+          WHERE p.id = public.gamification_profiles.profile_id
+            AND p.user_id = auth.uid()
+        )
+        OR public.is_admin()
+      );
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'gamification_profiles'
+      AND policyname = 'Gamification profiles admin manage'
+  ) THEN
+    CREATE POLICY "Gamification profiles admin manage"
+      ON public.gamification_profiles
+      FOR ALL
+      USING (public.is_admin())
+      WITH CHECK (public.is_admin());
+  END IF;
+END;
+$$;
+
+-- Policies for gamification_actions
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'gamification_actions'
+      AND policyname = 'Gamification actions owner select'
+  ) THEN
+    CREATE POLICY "Gamification actions owner select"
+      ON public.gamification_actions
+      FOR SELECT
+      USING (
+        EXISTS (
+          SELECT 1
+          FROM public.profiles p
+          WHERE p.id = public.gamification_actions.profile_id
+            AND p.user_id = auth.uid()
+        )
+        OR public.is_admin()
+      );
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'gamification_actions'
+      AND policyname = 'Gamification actions service writes'
+  ) THEN
+    CREATE POLICY "Gamification actions service writes"
+      ON public.gamification_actions
+      FOR INSERT
+      WITH CHECK (
+        auth.role() = 'service_role'
+      );
+  END IF;
+END;
+$$;
+
+-- Badge catalog policies
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'gamification_badges'
+      AND policyname = 'Gamification badges readable'
+  ) THEN
+    CREATE POLICY "Gamification badges readable"
+      ON public.gamification_badges
+      FOR SELECT
+      USING (true);
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'gamification_badges'
+      AND policyname = 'Gamification badges admin manage'
+  ) THEN
+    CREATE POLICY "Gamification badges admin manage"
+      ON public.gamification_badges
+      FOR ALL
+      USING (public.is_admin())
+      WITH CHECK (public.is_admin());
+  END IF;
+END;
+$$;
+
+-- Profile badges policies
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'profile_badges'
+      AND policyname = 'Profile badges owner access'
+  ) THEN
+    CREATE POLICY "Profile badges owner access"
+      ON public.profile_badges
+      FOR SELECT
+      USING (
+        EXISTS (
+          SELECT 1
+          FROM public.profiles p
+          WHERE p.id = public.profile_badges.profile_id
+            AND p.user_id = auth.uid()
+        )
+        OR public.is_admin()
+      );
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'profile_badges'
+      AND policyname = 'Profile badges admin manage'
+  ) THEN
+    CREATE POLICY "Profile badges admin manage"
+      ON public.profile_badges
+      FOR ALL
+      USING (public.is_admin())
+      WITH CHECK (public.is_admin());
+  END IF;
+END;
+$$;
+
+-- Levels policies
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'gamification_levels'
+      AND policyname = 'Gamification levels public read'
+  ) THEN
+    CREATE POLICY "Gamification levels public read"
+      ON public.gamification_levels
+      FOR SELECT
+      USING (true);
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'gamification_levels'
+      AND policyname = 'Gamification levels admin manage'
+  ) THEN
+    CREATE POLICY "Gamification levels admin manage"
+      ON public.gamification_levels
+      FOR ALL
+      USING (public.is_admin())
+      WITH CHECK (public.is_admin());
+  END IF;
+END;
+$$;
+
+-- Challenge policies
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'gamification_challenges'
+      AND policyname = 'Gamification challenges readable'
+  ) THEN
+    CREATE POLICY "Gamification challenges readable"
+      ON public.gamification_challenges
+      FOR SELECT
+      USING (true);
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'gamification_challenges'
+      AND policyname = 'Gamification challenges admin manage'
+  ) THEN
+    CREATE POLICY "Gamification challenges admin manage"
+      ON public.gamification_challenges
+      FOR ALL
+      USING (public.is_admin())
+      WITH CHECK (public.is_admin());
+  END IF;
+END;
+$$;
+
+-- Challenge progress policies
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'profile_challenge_progress'
+      AND policyname = 'Challenge progress owner access'
+  ) THEN
+    CREATE POLICY "Challenge progress owner access"
+      ON public.profile_challenge_progress
+      FOR SELECT
+      USING (
+        EXISTS (
+          SELECT 1
+          FROM public.profiles p
+          WHERE p.id = public.profile_challenge_progress.profile_id
+            AND p.user_id = auth.uid()
+        )
+        OR public.is_admin()
+      );
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'profile_challenge_progress'
+      AND policyname = 'Challenge progress admin manage'
+  ) THEN
+    CREATE POLICY "Challenge progress admin manage"
+      ON public.profile_challenge_progress
+      FOR ALL
+      USING (public.is_admin())
+      WITH CHECK (public.is_admin());
+  END IF;
+END;
+$$;
+
+-- Leaderboard snapshot policies
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'leaderboard_snapshots'
+      AND policyname = 'Leaderboard snapshots readable'
+  ) THEN
+    CREATE POLICY "Leaderboard snapshots readable"
+      ON public.leaderboard_snapshots
+      FOR SELECT
+      USING (true);
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'leaderboard_snapshots'
+      AND policyname = 'Leaderboard snapshots admin manage'
+  ) THEN
+    CREATE POLICY "Leaderboard snapshots admin manage"
+      ON public.leaderboard_snapshots
+      FOR ALL
+      USING (public.is_admin())
+      WITH CHECK (public.is_admin());
+  END IF;
+END;
+$$;
+
+-- Gamification audit policies
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'gamification_audit'
+      AND policyname = 'Gamification audit admin read'
+  ) THEN
+    CREATE POLICY "Gamification audit admin read"
+      ON public.gamification_audit
+      FOR SELECT
+      USING (public.is_admin());
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'gamification_audit'
+      AND policyname = 'Gamification audit admin write'
+  ) THEN
+    CREATE POLICY "Gamification audit admin write"
+      ON public.gamification_audit
+      FOR ALL
+      USING (public.is_admin())
+      WITH CHECK (public.is_admin());
+  END IF;
+END;
+$$;
+
+-- Seed baseline levels and badges only when not already populated to allow reruns idempotently.
+INSERT INTO public.gamification_levels (level, title, min_xp, perks)
+VALUES
+  (1, 'Curious Sipper', 0, '{"perks": ["Weekly inspiration drip"]}'::jsonb),
+  (2, 'Cafe Collaborator', 250, '{"perks": ["Comment flair", "Priority event RSVP"]}'::jsonb),
+  (3, 'Syntax Storyteller', 750, '{"perks": ["Draft co-review", "Beta feature access"]}'::jsonb),
+  (4, 'Brewer of Ideas', 1500, '{"perks": ["Host community roundtable", "Post spotlight nominations"]}'::jsonb),
+  (5, 'Syntax Sage', 3000, '{"perks": ["Early access to experiments", "Invite-only salons"]}'::jsonb)
+ON CONFLICT (level) DO NOTHING;
+
+INSERT INTO public.gamification_badges (slug, name, description, category, rarity, requirements, reward_points, icon, theme)
+VALUES
+  ('first-sip', 'First Sip', 'Completed onboarding and shared your first intention.', 'achievement', 'common', '{"requires": ["onboarding_completed"]}'::jsonb, 50, 'mug', 'copper'),
+  ('steady-sipper', 'Steady Sipper', 'Posted or commented five days in a row.', 'streak', 'uncommon', '{"streak_days": 5}'::jsonb, 150, 'flame', 'amber'),
+  ('community-barista', 'Community Barista', 'Earned 10 helpful comment upvotes.', 'community', 'rare', '{"helpful_votes": 10}'::jsonb, 250, 'sparkles', 'violet'),
+  ('seasonal-taster', 'Seasonal Taster', 'Participated in a Syntax & Sips seasonal challenge.', 'seasonal', 'rare', '{"challenge_participation": true}'::jsonb, 200, 'calendar', 'rose')
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO public.gamification_challenges (slug, title, description, cadence, requirements, reward_points, reward_badge_id, starts_at, ends_at)
+VALUES
+  ('daily-brew', 'Daily Brew Log', 'Share one learning each day this week.', 'daily', '{"actions_required": [{"action": "comment.approved", "count": 1}]}'::jsonb, 40, NULL, now(), now() + interval '7 days'),
+  ('weekly-roast', 'Weekly Roast Challenge', 'Publish or update one article this week.', 'weekly', '{"actions_required": [{"action": "post.published", "count": 1}]}'::jsonb, 120, NULL, now(), now() + interval '14 days')
+ON CONFLICT (slug) DO NOTHING;
+
+-- Down migration instructions (informational): drop tables in reverse order if rollback is required.
+-- DROP TABLE IF EXISTS public.gamification_audit;
+-- DROP TABLE IF EXISTS public.leaderboard_snapshots;
+-- DROP TABLE IF EXISTS public.profile_challenge_progress;
+-- DROP TABLE IF EXISTS public.gamification_challenges;
+-- DROP TABLE IF EXISTS public.gamification_levels;
+-- DROP TABLE IF EXISTS public.profile_badges;
+-- DROP TABLE IF EXISTS public.gamification_badges;
+-- DROP TABLE IF EXISTS public.gamification_actions;
+-- DROP TABLE IF EXISTS public.gamification_profiles;
+-- DROP TYPE IF EXISTS public.badge_state;
+-- DROP TYPE IF EXISTS public.challenge_progress_status;
+-- DROP TYPE IF EXISTS public.challenge_cadence;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -49,6 +49,13 @@ module.exports = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        gamification: {
+          xp: '#6C63FF',
+          streak: '#FF5252',
+          challenge: '#1B9AAA',
+          prestige: '#FFAF00',
+          neutral: '#F7F1FF',
+        },
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary
- add a dedicated Supabase schema for gamification with policies, triggers, seeds, and audit logging
- implement gamification services, hooks, and API routes for actions, leaderboards, badges, and challenges with caching support
- extend the account and admin dashboards with neobrutalist gamification components plus compliance documentation and theme updates

## Testing
- npm run build *(fails: Next.js binary unavailable in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e68e1f998c832dac6d1621d813b619