### PR TITLE
feat: persist leaderboard snapshots and refresh gamification roadmap

### DIFF
--- a/src/lib/gamification/cache.ts
+++ b/src/lib/gamification/cache.ts
@@ -99,6 +99,20 @@ export async function cacheInvalidate(prefix: string) {
   }
 }
 
+export const clearLeaderboardSnapshots = async (supabase: SupabaseClient, scope?: string) => {
+  try {
+    const baseQuery = supabase.from('leaderboard_snapshots').delete()
+    const query = scope ? baseQuery.eq('scope', scope) : baseQuery.gte('captured_at', '1970-01-01T00:00:00Z')
+    const { error } = await query
+
+    if (error) {
+      console.error('Failed to clear leaderboard snapshots', error)
+    }
+  } catch (error) {
+    console.error('Unexpected error while clearing leaderboard snapshots', error)
+  }
+}
+
 export const upsertGamificationProfile = async (
   supabase: SupabaseClient,
   profileId: string,

--- a/src/lib/gamification/points-engine.ts
+++ b/src/lib/gamification/points-engine.ts
@@ -5,6 +5,7 @@ import {
   cacheInvalidate,
   cacheSet,
   buildCacheKey,
+  clearLeaderboardSnapshots,
 } from './cache'
 import type {
   ActionDefinition,
@@ -366,6 +367,7 @@ export const recordAction = async (
   }
 
   await cacheInvalidate(buildCacheKey('gamification', 'leaderboard'))
+  await clearLeaderboardSnapshots(supabase)
 
   const profileSummary = mapProfileRowToSummary(updatedRow, nextLevelXp)
 


### PR DESCRIPTION
## Summary
- update the gamification roadmap to describe the shipped schema, services, UI, and checklist status
- persist leaderboard payloads to the Supabase snapshot table with TTL-backed reuse before recomputing
- clear cached leaderboard snapshots whenever points are awarded to avoid stale rankings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6a9bcc8e4832dbf26e7ca5913c3e8