### PR TITLE
Add mega navigation structure and improve toggle readability

### DIFF
--- a/src/components/neobrutal/toggle-switch.tsx
+++ b/src/components/neobrutal/toggle-switch.tsx
@@ -53,7 +53,14 @@ export const NeobrutalToggleSwitch = forwardRef<
           >
             {checked ? '✓' : ''}
           </span>
-          <span className="pointer-events-none absolute left-0 right-0 text-center text-xs font-bold uppercase">
+          <span
+            className={cn(
+              'pointer-events-none absolute inset-0 flex items-center justify-center text-[11px] font-black uppercase tracking-wide transition-colors',
+              checked
+                ? 'text-white drop-shadow-[1px_1px_0px_rgba(0,0,0,0.45)]'
+                : 'text-black',
+            )}
+          >
             {checked ? onLabel : offLabel}
           </span>
         </button>

--- a/src/components/seo/SiteNavigationJsonLd.tsx
+++ b/src/components/seo/SiteNavigationJsonLd.tsx
@@ -1,8 +1,8 @@
-import { primaryNavigation } from '@/lib/navigation'
+import { siteNavigationItems } from '@/lib/navigation'
 import { buildSiteUrl } from '@/lib/site-url'
 
 export function SiteNavigationJsonLd() {
-  const itemListElement = primaryNavigation.map((item, index) => ({
+  const itemListElement = siteNavigationItems.map((item, index) => ({
     '@type': 'SiteNavigationElement',
     position: index + 1,
     name: item.label,

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,11 +1,179 @@
-export interface PrimaryNavItem {
+export interface NavigationItem {
   label: string
   href: string
+  description?: string
 }
 
-export const primaryNavigation: PrimaryNavItem[] = [
-  { label: 'Home', href: '/' },
-  { label: 'Blogs', href: '/blogs' },
-  { label: 'Podcasts', href: '/podcasts' },
-  { label: 'Changelog', href: '/changelog' },
+export interface NavigationSection {
+  title: string
+  items: NavigationItem[]
+}
+
+export interface NavigationCategory {
+  label: string
+  description?: string
+  sections: NavigationSection[]
+}
+
+export const topLevelNavigation: NavigationItem[] = [
+  {
+    label: 'Home',
+    href: '/',
+    description: 'Return to the Syntax & Sips landing page.',
+  },
 ]
+
+export const navigationCategories: NavigationCategory[] = [
+  {
+    label: 'Explore',
+    description: 'Dive into stories, shows, and learning paths curated by the Syntax & Sips team.',
+    sections: [
+      {
+        title: 'Editorial',
+        items: [
+          {
+            label: 'Blogs',
+            href: '/blogs',
+            description: 'Read curated insights, experiments, and interviews from the crew.',
+          },
+          {
+            label: 'Topics',
+            href: '/topics',
+            description: 'Explore articles grouped by discipline, industry, and experience level.',
+          },
+          {
+            label: 'Changelog',
+            href: '/changelog',
+            description: 'Catch up on weekly platform improvements and release notes.',
+          },
+        ],
+      },
+      {
+        title: 'Shows & Media',
+        items: [
+          {
+            label: 'Podcasts',
+            href: '/podcasts',
+            description: 'Listen to the Syntax & Sips brew while you code or commute.',
+          },
+          {
+            label: 'Videos',
+            href: '/videos',
+            description: 'Watch livestream replays, workshops, and visual explainers.',
+          },
+        ],
+      },
+      {
+        title: 'Learning',
+        items: [
+          {
+            label: 'Tutorials',
+            href: '/tutorials',
+            description: 'Follow step-by-step builds that level up your technical toolkit.',
+          },
+          {
+            label: 'Docs',
+            href: '/docs',
+            description: 'Reference architecture notes, APIs, and contributor guidelines.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    label: 'Resources',
+    description: 'Programs, downloads, and community touchpoints to keep you shipping.',
+    sections: [
+      {
+        title: 'Community & Programs',
+        items: [
+          {
+            label: 'Creator Program',
+            href: '/creator',
+            description: 'Partner with Syntax & Sips to publish long-form pieces and shows.',
+          },
+          {
+            label: 'Apply as a Contributor',
+            href: '/apply',
+            description: 'Pitch story ideas and join the editorial contributor roster.',
+          },
+          {
+            label: 'Roadmap',
+            href: '/roadmap',
+            description: 'See what features, series, and community perks launch next.',
+          },
+        ],
+      },
+      {
+        title: 'Tools & Downloads',
+        items: [
+          {
+            label: 'Resources Hub',
+            href: '/resources',
+            description: 'Download templates, cheat sheets, and engineering accelerators.',
+          },
+          {
+            label: 'Newsletter',
+            href: '/newsletter',
+            description: 'Subscribe for weekly digests, jobs, and behind-the-scenes notes.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    label: 'Support',
+    description: 'Stay informed about policies, account access, and platform health.',
+    sections: [
+      {
+        title: 'Policy Center',
+        items: [
+          {
+            label: 'Privacy Policy',
+            href: '/privacy',
+            description: 'Understand how we safeguard and process your personal data.',
+          },
+          {
+            label: 'Terms of Use',
+            href: '/terms',
+            description: 'Review the participation guidelines for the Syntax & Sips community.',
+          },
+          {
+            label: 'Cookie Policy',
+            href: '/cookies',
+            description: 'Learn how tracking works and adjust your preference center.',
+          },
+          {
+            label: 'Editorial Disclaimer',
+            href: '/disclaimer',
+            description: 'Read the scope and limitations of our tutorials and commentary.',
+          },
+        ],
+      },
+      {
+        title: 'Account',
+        items: [
+          {
+            label: 'Sign in',
+            href: '/login',
+            description: 'Access your dashboard, badges, and personalized recommendations.',
+          },
+          {
+            label: 'Create an account',
+            href: '/signup',
+            description: 'Join Syntax & Sips to earn XP, submit ideas, and save progress.',
+          },
+        ],
+      },
+    ],
+  },
+]
+
+export const siteNavigationItems: NavigationItem[] = Array.from(
+  new Map(
+    [...topLevelNavigation, ...navigationCategories.flatMap((category) => category.sections.flatMap((section) => section.items))].map((item) => [
+      item.href,
+      item,
+    ]),
+  ).values(),
+)


### PR DESCRIPTION
## Summary
- reorganized the navbar into grouped Explore, Resources, and Support categories with desktop dropdowns and mobile accordions
- defined richer navigation metadata and synced the SiteNavigation JSON-LD output
- increased the Popular/Latest toggle label contrast for better readability

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6b117d994832d80e5918d1d111480