### PR TITLE
Fix navigation auth actions and sync sitemap

### DIFF
--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,0 +1,107 @@
+import path from 'path';
+import fs from 'fs';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+const allowedExtensions = new Set(['.md', '.mdx']);
+
+const docsMetadata: Record<string, { title: string; summary: string }> = {
+  'markdown-guide': {
+    title: 'Markdown Playbook',
+    summary: 'Formatting conventions, code block styles, and media tips for Syntax & Sips posts.',
+  },
+  'admin-code-guide': {
+    title: 'Admin & Code Standards',
+    summary: 'Reference for platform maintainers covering code quality, tooling, and release rituals.',
+  },
+  'author-guidelines': {
+    title: 'Author Guidelines',
+    summary: 'Expectations and best practices for contributors collaborating with the editorial team.',
+  },
+};
+
+const toTitleCase = (value: string) =>
+  value
+    .split(/[-_\s]+/)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+
+const loadDocumentationIndex = () => {
+  const docsDirectory = path.join(process.cwd(), 'src', 'docs');
+
+  try {
+    const entries = fs.readdirSync(docsDirectory, { withFileTypes: true });
+
+    return entries
+      .filter((entry) => entry.isFile() && allowedExtensions.has(path.extname(entry.name)))
+      .map((entry) => {
+        const slug = entry.name.replace(/\.(md|mdx)$/i, '');
+        const metadata = docsMetadata[slug] ?? {
+          title: toTitleCase(slug),
+          summary: 'Dive into this reference to learn more about the Syntax & Sips platform.',
+        };
+
+        return {
+          slug,
+          ...metadata,
+        };
+      })
+      .sort((a, b) => a.title.localeCompare(b.title));
+  } catch (error) {
+    console.error('Unable to build documentation index', error);
+    return [];
+  }
+};
+
+export const metadata: Metadata = {
+  title: 'Documentation | Syntax & Sips',
+  description: 'Explore contributor guides, platform standards, and publishing references.',
+};
+
+export default function DocumentationIndexPage() {
+  const documents = loadDocumentationIndex();
+
+  return (
+    <section className="container mx-auto px-6 py-16">
+      <header className="mx-auto max-w-3xl text-center">
+        <p className="inline-flex items-center rounded-full border-4 border-black bg-[#FFEB99] px-4 py-1 text-xs font-black uppercase tracking-[0.35em] text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,0.2)]">
+          Documentation Hub
+        </p>
+        <h1 className="mt-6 text-4xl font-black uppercase leading-tight tracking-tight text-[#121212] sm:text-5xl">
+          Ship with Confidence
+        </h1>
+        <p className="mt-4 text-base font-semibold text-[#363636] sm:text-lg">
+          Browse official Syntax &amp; Sips resources covering author workflows, editorial expectations, and platform operations.
+        </p>
+      </header>
+
+      <div className="mt-12 grid gap-6 md:grid-cols-2">
+        {documents.length === 0 ? (
+          <div className="rounded-3xl border-4 border-dashed border-black bg-white p-8 text-center shadow-[8px_8px_0px_0px_rgba(0,0,0,0.08)]">
+            <p className="text-base font-semibold text-[#555]">
+              Documentation is being brewed. Check back soon for fresh guides and references.
+            </p>
+          </div>
+        ) : (
+          documents.map((doc) => (
+            <Link
+              key={doc.slug}
+              href={`/docs/${doc.slug}`}
+              className="group flex flex-col gap-4 rounded-3xl border-4 border-black bg-white p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.15)] transition hover:-translate-y-1 hover:shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)]"
+            >
+              <span className="inline-flex w-fit items-center rounded-full border-2 border-black bg-[#D4F1F4] px-3 py-1 text-[11px] font-black uppercase tracking-[0.3em] text-black shadow-[3px_3px_0px_0px_rgba(0,0,0,0.15)]">
+                Guide
+              </span>
+              <h2 className="text-2xl font-black uppercase text-[#121212]">{doc.title}</h2>
+              <p className="text-sm font-semibold leading-relaxed text-[#3F3F3F]">{doc.summary}</p>
+              <span className="inline-flex items-center gap-2 text-sm font-black uppercase tracking-wide text-[#6C63FF]">
+                Read guide
+                <span aria-hidden className="transition-transform group-hover:translate-x-1">→</span>
+              </span>
+            </Link>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,23 +1,38 @@
+import path from "path";
+import { promises as fs } from "fs";
 import type { MetadataRoute } from "next";
 import { getPublishedPosts } from "@/lib/posts";
 import { buildSiteUrl } from "@/lib/site-url";
+import { navigationSupportingPaths, siteNavigationItems } from "@/lib/navigation";
 
-const staticPaths = [
-  "/",
-  "/blogs",
-  "/podcasts",
-  "/videos",
-  "/tutorials",
-  "/resources",
-  "/roadmap",
-  "/topics",
-];
+const docExtensions = new Set([".md", ".mdx"]);
+
+const loadDocumentationPaths = async () => {
+  try {
+    const docsDirectory = path.join(process.cwd(), "src", "docs");
+    const entries = await fs.readdir(docsDirectory, { withFileTypes: true });
+
+    return entries
+      .filter((entry) => entry.isFile() && docExtensions.has(path.extname(entry.name)))
+      .map((entry) => `/docs/${entry.name.replace(/\.(md|mdx)$/i, "")}`);
+  } catch (error) {
+    console.error("Unable to load documentation paths for sitemap", error);
+    return [];
+  }
+};
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseEntries: MetadataRoute.Sitemap = staticPaths.map((path) => ({
-    url: buildSiteUrl(path),
-    changeFrequency: path === "/" ? "weekly" : "monthly",
-    priority: path === "/" ? 0.9 : 0.6,
+  const navPaths = siteNavigationItems.map((item) => item.href);
+  const docsPaths = await loadDocumentationPaths();
+
+  const uniqueStaticPaths = Array.from(
+    new Set([...navPaths, ...navigationSupportingPaths, ...docsPaths]),
+  );
+
+  const baseEntries: MetadataRoute.Sitemap = uniqueStaticPaths.map((routePath) => ({
+    url: buildSiteUrl(routePath),
+    changeFrequency: routePath === "/" ? "weekly" : "monthly",
+    priority: routePath === "/" ? 0.9 : 0.6,
   }));
 
   const posts = await getPublishedPosts();

--- a/src/components/ui/NewNavbar.tsx
+++ b/src/components/ui/NewNavbar.tsx
@@ -20,7 +20,7 @@ export const NewNavbar = () => {
   const [openCategory, setOpenCategory] = useState<string | null>(null);
   const [expandedSection, setExpandedSection] = useState<string | null>(null);
   const pathname = useClientPathname();
-  const { profile, isLoading } = useAuthenticatedProfile();
+  const { profile } = useAuthenticatedProfile();
   const needsOnboarding = Boolean(profile && profile.onboarding?.status !== 'completed');
   const dropdownRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
@@ -101,9 +101,7 @@ export const NewNavbar = () => {
             ))}
             <GlobalSearch />
             <div className="flex items-center gap-3">
-              {isLoading ? (
-                <span className="h-10 w-10 rounded-full border-2 border-dashed border-black/40 bg-white animate-pulse" aria-hidden />
-              ) : profile ? (
+              {profile ? (
                 <ProfileShortcut profile={profile} />
               ) : (
                 <>
@@ -128,6 +126,7 @@ export const NewNavbar = () => {
             <button
               type="button"
               onClick={() => {
+                setIsOpen(false);
                 window.dispatchEvent(new Event('global-search:open'));
               }}
               className="inline-flex items-center justify-center rounded-md border-2 border-black bg-white p-2 text-sm font-semibold text-black shadow-[3px_3px_0px_0px_rgba(0,0,0,0.12)] transition hover:-translate-y-[1px]"
@@ -173,11 +172,7 @@ export const NewNavbar = () => {
                   isPathActive={isPathActive}
                 />
               ))}
-              {isLoading ? (
-                <div className="grid grid-cols-1">
-                  <span className="h-10 rounded-lg border-2 border-dashed border-black/40 bg-white animate-pulse" aria-hidden />
-                </div>
-              ) : profile ? (
+              {profile ? (
                 <div className="flex flex-col space-y-3">
                   <Link
                     href="/account"

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -89,12 +89,13 @@ export const navigationCategories: NavigationCategory[] = [
         items: [
           {
             label: 'Creator Program',
-            href: '/creator',
-            description: 'Partner with Syntax & Sips to publish long-form pieces and shows.',
+            href: '/creator/workspace',
+            description:
+              'Partner with Syntax & Sips to publish long-form pieces and shows once you join the contributor roster.',
           },
           {
             label: 'Apply as a Contributor',
-            href: '/apply',
+            href: '/apply/author',
             description: 'Pitch story ideas and join the editorial contributor roster.',
           },
           {
@@ -121,52 +122,6 @@ export const navigationCategories: NavigationCategory[] = [
       },
     ],
   },
-  {
-    label: 'Support',
-    description: 'Stay informed about policies, account access, and platform health.',
-    sections: [
-      {
-        title: 'Policy Center',
-        items: [
-          {
-            label: 'Privacy Policy',
-            href: '/privacy',
-            description: 'Understand how we safeguard and process your personal data.',
-          },
-          {
-            label: 'Terms of Use',
-            href: '/terms',
-            description: 'Review the participation guidelines for the Syntax & Sips community.',
-          },
-          {
-            label: 'Cookie Policy',
-            href: '/cookies',
-            description: 'Learn how tracking works and adjust your preference center.',
-          },
-          {
-            label: 'Editorial Disclaimer',
-            href: '/disclaimer',
-            description: 'Read the scope and limitations of our tutorials and commentary.',
-          },
-        ],
-      },
-      {
-        title: 'Account',
-        items: [
-          {
-            label: 'Sign in',
-            href: '/login',
-            description: 'Access your dashboard, badges, and personalized recommendations.',
-          },
-          {
-            label: 'Create an account',
-            href: '/signup',
-            description: 'Join Syntax & Sips to earn XP, submit ideas, and save progress.',
-          },
-        ],
-      },
-    ],
-  },
 ]
 
 export const siteNavigationItems: NavigationItem[] = Array.from(
@@ -177,3 +132,23 @@ export const siteNavigationItems: NavigationItem[] = Array.from(
     ]),
   ).values(),
 )
+
+export const navigationSupportingPaths = [
+  '/login',
+  '/signup',
+  '/account',
+  '/me',
+  '/onboarding',
+  '/newsletter',
+  '/newsletter-confirmed',
+  '/newsletter-unsubscribed',
+  '/creator/workspace',
+  '/apply/author',
+  '/privacy',
+  '/terms',
+  '/cookies',
+  '/disclaimer',
+  '/admin',
+  '/admin/login',
+  '/admin/create',
+]


### PR DESCRIPTION
## Summary
- ensure the navbar always renders sign up/sign in buttons and closes the mobile drawer before opening search
- remove the redundant Support megamenu entries, fix resource links, and add a docs index so navigation items land on live pages
- expand the sitemap to include all navigation/supporting routes and auto-discovered documentation files

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6b887c63c832da75829b3b2a08ad5