### PR TITLE
Align site content with current product status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hcaptcha/react-hcaptcha": "^1.12.1",
         "@radix-ui/react-accordion": "^1.2.8",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.11",
         "@radix-ui/react-navigation-menu": "^1.2.10",
         "@radix-ui/react-slot": "^1.2.0",
@@ -2180,6 +2181,81 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collapsible": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.8.tgz",
@@ -2267,22 +2343,22 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.11.tgz",
-      "integrity": "sha512-yI7S1ipkP5/+99qhSI6nthfo/tR6bL6Zgxi/+1UO6qPa6UeM6nlafWcQ65vB4rU2XjgjMfMhI3k9Y5MztA62VQ==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.7",
-        "@radix-ui/react-focus-guards": "1.1.2",
-        "@radix-ui/react-focus-scope": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
         "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-portal": "1.1.6",
-        "@radix-ui/react-presence": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.0",
-        "@radix-ui/react-slot": "1.2.0",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
@@ -2298,6 +2374,104 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2345,9 +2519,9 @@
       }
     },
     "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.2.tgz",
-      "integrity": "sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2360,13 +2534,13 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.4.tgz",
-      "integrity": "sha512-r2annK27lIW5w9Ho5NyQgqs0MmgZSTIKXWpVCJaLC1q2kZrZkcqnmHkCHMEmv8XLvsLlurKMPT+kbKkRkm/xVA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.0",
+        "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1"
       },
       "peerDependencies": {
@@ -2380,6 +2554,47 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2439,12 +2654,12 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.6.tgz",
-      "integrity": "sha512-XmsIl2z1n/TsYFLIdYam2rmFwf9OC/Sh2avkbmVMDuBZIe7hSpM0cYnWPAo7nHOVx8zTuwDZGByfcqLdnzp3Vw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.0",
+        "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
@@ -2458,6 +2673,47 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@hcaptcha/react-hcaptcha": "^1.12.1",
     "@radix-ui/react-accordion": "^1.2.8",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.11",
     "@radix-ui/react-navigation-menu": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.0",

--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -9,24 +9,23 @@ export function generateMetadata(): Metadata {
   const canonical = buildSiteUrl('/blogs');
 
   return {
-    title: 'AI, Machine Learning & Data Science Blog Library',
+    title: 'Syntax & Sips blog — Build notes & release updates',
     description:
-      'Browse Syntax & Sips articles on machine learning, data science workflows, quantum computing experiments, and coding best practices.',
+      'Browse Syntax & Sips articles documenting how we are building the platform, the decisions we make, and the features we ship.',
     alternates: {
       canonical,
     },
     openGraph: {
       type: 'website',
       url: canonical,
-      title: 'Syntax & Sips Blog — Machine Learning, Quantum & Coding Tutorials',
+      title: 'Syntax & Sips blog — Build notes & release updates',
       description:
-        'Filter hundreds of Syntax & Sips tutorials, reviews, and explainers spanning ML, data engineering, quantum computing, and creative coding.',
+        'Progress updates, documentation drafts, and honest retrospectives from the Syntax & Sips team.',
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Syntax & Sips Blog',
-      description:
-        'Stay current with Syntax & Sips machine learning and quantum computing breakdowns.',
+      title: 'Syntax & Sips blog',
+      description: 'Follow the work as we build Syntax & Sips.',
     },
   };
 }

--- a/src/app/newsletter/page.tsx
+++ b/src/app/newsletter/page.tsx
@@ -1,61 +1,29 @@
 import { Metadata } from 'next';
-import { ArrowRight, BellRing, Coffee, NotebookPen } from 'lucide-react';
+import { Bell, Clock3, Info } from 'lucide-react';
 import { PageShell, PageHero, ContentSection, CtaButton } from '@/components/ui/PageLayout';
 
-const newsletterPerks = [
+const newsletterHighlights = [
   {
-    title: 'Actionable playbooks',
-    description: 'Each issue includes frameworks and templates you can copy-paste into your own workflow the same day.',
-    icon: NotebookPen,
+    title: 'Product updates',
+    description: 'We email when new features ship or the roadmap changes—no weekly filler.',
+    icon: Bell,
   },
   {
-    title: 'Shipping inspiration',
-    description: 'Peek inside real teams as they scale products, run retros, and iterate with empathy.',
-    icon: Coffee,
+    title: 'Behind-the-scenes notes',
+    description: 'Expect honest build logs and lessons learned while the platform is in progress.',
+    icon: Info,
   },
   {
-    title: 'Community spotlights',
-    description: 'We feature wins, experiments, and open-source launches from readers around the globe.',
-    icon: BellRing,
-  },
-];
-
-const subscriptionSteps = [
-  {
-    step: 'Step 01',
-    title: 'Sign up with your best email',
-    description: 'No spam—just one thoughtful edition in your inbox every Friday morning.',
-  },
-  {
-    step: 'Step 02',
-    title: 'Choose your focus',
-    description: 'Let us know what you care about most so we can tailor bonus resources to your goals.',
-  },
-  {
-    step: 'Step 03',
-    title: 'Ship something new',
-    description: 'Every email ends with a challenge or prompt to help you apply what you learned immediately.',
-  },
-];
-
-const recentIssues = [
-  {
-    title: 'Issue #42: Calm velocity',
-    summary: 'How high-performing teams sustain delivery without burning out, plus a meeting audit checklist.',
-  },
-  {
-    title: 'Issue #41: DX like a product',
-    summary: 'Treat your developer experience like a roadmap—prioritize, measure, and celebrate wins.',
-  },
-  {
-    title: 'Issue #40: Debugging rituals',
-    summary: 'Three debugging stories from the community and the tactics that kept incidents calm.',
+    title: 'Occasional deep dives',
+    description: 'When we publish a major guide, we send one follow-up with extra context and resources.',
+    icon: Clock3,
   },
 ];
 
 export const metadata: Metadata = {
-  title: 'Newsletter | Syntax & Sips',
-  description: 'Join the Syntax & Sips newsletter for curated insights, playbooks, and community highlights every Friday.',
+  title: 'Newsletter status | Syntax & Sips',
+  description:
+    'We are collecting interest for the Syntax & Sips newsletter. Here is exactly what to expect and what does not exist yet.',
 };
 
 export default function NewsletterPage() {
@@ -63,16 +31,14 @@ export default function NewsletterPage() {
     <PageShell
       hero={
         <PageHero
-          eyebrow="Weekly Delivery"
-          title="A letter for builders who care about craft"
-          description="Get one thoughtful dispatch every Friday with tactics, templates, and stories from the Syntax & Sips community."
+          eyebrow="Slow inbox"
+          title="No weekly newsletter yet"
+          description="We send updates only when something meaningful ships. Join the list below and we will email you once there is real news to share."
           actions={
             <>
-              <CtaButton href="https://syntaxandsips.com/newsletter" target="_blank" rel="noreferrer">
-                Subscribe free
-              </CtaButton>
-              <CtaButton href="/resources" variant="secondary">
-                Preview resources
+              <CtaButton href="/#newsletter">Join from the homepage</CtaButton>
+              <CtaButton href="/blogs" variant="secondary">
+                Read the latest instead
               </CtaButton>
             </>
           }
@@ -80,97 +46,51 @@ export default function NewsletterPage() {
       }
     >
       <ContentSection
-        eyebrow="Why join"
-        title="A newsletter you will actually finish"
-        description="We respect your time. Every edition is concise, practical, and designed to help you take the next step."
+        eyebrow="What we send"
+        title="A practical update when it matters"
+        description="No automated cadence. You will only hear from us when there is something tangible to show."
         tone="peach"
-        align="center"
       >
-        {newsletterPerks.length > 0 ? (
-          <div className="grid gap-8 md:grid-cols-3">
-            {newsletterPerks.map((perk) => (
-              <article
-                key={perk.title}
-                className="flex flex-col items-center gap-4 rounded-2xl border-2 border-black bg-white/70 p-6 text-center"
-              >
-                <perk.icon className="h-12 w-12 text-[#6C63FF]" aria-hidden="true" />
-                <h3 className="text-lg font-black">{perk.title}</h3>
-                <p className="text-sm text-black/70 leading-relaxed">{perk.description}</p>
-              </article>
-            ))}
-          </div>
-        ) : null}
+        <div className="grid gap-6 md:grid-cols-3">
+          {newsletterHighlights.map((item) => (
+            <article
+              key={item.title}
+              className="flex flex-col items-center gap-4 rounded-2xl border-2 border-black bg-white/70 p-6 text-center"
+            >
+              <item.icon className="h-10 w-10 text-[#6C63FF]" aria-hidden="true" />
+              <h3 className="text-lg font-black">{item.title}</h3>
+              <p className="text-sm text-black/70 leading-relaxed">{item.description}</p>
+            </article>
+          ))}
+        </div>
       </ContentSection>
 
       <ContentSection
-        eyebrow="How it works"
-        title="Set up in minutes"
-        description="We only ask for the essentials so you can start receiving insights right away."
+        eyebrow="Current state"
+        title="Archive and automation"
+        description="There is no archive yet. When the first issue is ready it will appear here with a public link."
         tone="lavender"
       >
-        {subscriptionSteps.length > 0 ? (
-          <div className="grid gap-6 md:grid-cols-3">
-            {subscriptionSteps.map((step) => (
-              <article
-                key={step.step}
-                className="flex h-full flex-col gap-3 rounded-2xl border-2 border-dashed border-black/40 bg-white/80 p-6"
-              >
-                <p className="text-xs font-bold uppercase tracking-[0.3em] text-[#FF5252]">{step.step}</p>
-                <h3 className="text-lg font-black">{step.title}</h3>
-                <p className="text-sm text-black/70 leading-relaxed">{step.description}</p>
-              </article>
-            ))}
-          </div>
-        ) : null}
+        {null}
       </ContentSection>
 
       <ContentSection
-        eyebrow="Fresh off the press"
-        title="Recent issues"
-        description="Catch up on the latest editions and see if our style fits how you learn."
+        eyebrow="Stay connected"
+        title="Prefer RSS or social updates?"
+        description="Follow the blog or changelog today and you will not miss anything while the newsletter is quiet."
         footerContent={
           <div className="flex flex-wrap items-center justify-between gap-4">
-            <p className="text-sm text-black/70">Prefer RSS? You can also read every issue on the site.</p>
-            <CtaButton href="/blogs" variant="secondary">
-              Browse the archive
+            <p className="text-sm text-black/70">You can unsubscribe from emails in one click whenever we start sending them.</p>
+            <CtaButton href="/changelog" variant="secondary">
+              View the changelog
             </CtaButton>
           </div>
         }
       >
-        {recentIssues.length > 0 ? (
-          <div className="grid gap-4">
-            {recentIssues.map((issue) => (
-              <article
-                key={issue.title}
-                className="flex flex-col gap-2 rounded-2xl border-2 border-black bg-white/80 p-6 md:flex-row md:items-center md:justify-between"
-              >
-                <div>
-                  <h3 className="text-lg font-black">{issue.title}</h3>
-                  <p className="text-sm text-black/70 leading-relaxed">{issue.summary}</p>
-                </div>
-                <ArrowRight className="h-6 w-6 text-[#6C63FF]" aria-hidden="true" />
-              </article>
-            ))}
-          </div>
-        ) : null}
-      </ContentSection>
-
-      <ContentSection
-        eyebrow="Questions?"
-        title="We keep things personal"
-        description="Reply to any email and a real human from the Syntax & Sips crew will get back to you."
-        align="center"
-      >
-        <div className="flex flex-col items-center gap-4 rounded-2xl border-2 border-black bg-white/70 p-6 text-center md:flex-row md:justify-between md:text-left">
-          <div className="flex flex-col gap-2">
-            <h3 className="text-lg font-black">Email us anytime</h3>
-            <p className="text-sm text-black/70">
-              We love feedback, story ideas, and learning about the ways you are leveling up your craft.
-            </p>
-          </div>
-          <CtaButton href="mailto:hello@syntaxandsips.com" variant="secondary">
-            Say hello
-          </CtaButton>
+        <div className="rounded-2xl border-2 border-black bg-white/70 p-6 text-sm text-black/70 leading-relaxed">
+          <p>
+            We are still validating the right format and cadence. Until that is settled we will not send regular mail. Signing up now simply tells us you would like a heads-up once the first issue exists.
+          </p>
         </div>
       </ContentSection>
     </PageShell>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,24 +12,23 @@ export function generateMetadata(): Metadata {
   const canonical = buildSiteUrl('/');
 
   return {
-    title: 'Machine Learning Tutorials, Data Science Guides & Tech Reviews',
+    title: 'Syntax & Sips — Build log & documentation',
     description:
-      'Syntax & Sips delivers step-by-step machine learning tutorials, quantum computing explainers, coding reviews, and creator interviews every week.',
+      'Follow the work as we build the Syntax & Sips editorial platform. Read progress notes, documentation drafts, and public release updates.',
     alternates: {
       canonical,
     },
     openGraph: {
       type: 'website',
       url: canonical,
-      title: 'Machine Learning Tutorials & AI Conversations | Syntax & Sips',
+      title: 'Syntax & Sips — Build log & documentation',
       description:
-        'Stay ahead in AI, ML, and quantum computing with Syntax & Sips guides, podcasts, and community deep dives.',
+        'Progress updates, changelog notes, and honest documentation about creating the Syntax & Sips platform.',
     },
     twitter: {
       card: 'summary_large_image',
-      title: 'Syntax & Sips — AI & ML Tutorials',
-      description:
-        'Weekly walkthroughs on machine learning, data science, quantum breakthroughs, and creative coding.',
+      title: 'Syntax & Sips build log',
+      description: 'Progress notes and documentation from the Syntax & Sips team.',
     },
   };
 }

--- a/src/app/podcasts/page.tsx
+++ b/src/app/podcasts/page.tsx
@@ -1,74 +1,40 @@
 import { Metadata } from 'next';
-import { Headphones, Mic, Radio } from 'lucide-react';
+import { Mic, NotebookPen } from 'lucide-react';
 import { PageShell, PageHero, ContentSection, CtaButton } from '@/components/ui/PageLayout';
 
-const podcastSeries = [
+const availableResources = [
   {
-    title: 'Syntax Shots',
-    description: 'Quick, actionable insights on modern web tooling, frameworks, and developer productivity in under 15 minutes.',
-    cadence: 'New episodes every Tuesday',
-    focus: 'Front-end deep dives & DX tips',
+    title: 'Read the build log',
+    description:
+      'We document our progress in long-form articles while we learn what format the podcast should take.',
+    href: '/blogs',
   },
   {
-    title: 'Café Conversations',
-    description: 'Fireside chats with engineers, designers, and community builders who are shaping the web ecosystem.',
-    cadence: 'Long-form interviews every other Thursday',
-    focus: 'Career growth, leadership, and tech culture',
-  },
-  {
-    title: 'Release Radar',
-    description: 'A round-up of the most important releases, changelog highlights, and experimental projects to try.',
-    cadence: 'Weekend recap every Sunday',
-    focus: 'Open source & platform updates',
+    title: 'Follow the changelog',
+    description: 'Every time we ship a notable update we capture it in the public changelog.',
+    href: '/changelog',
   },
 ];
 
-const upcomingEpisodes = [
+const preparationSteps = [
   {
-    title: 'Shipping faster with design systems',
-    guest: 'Amina Khan, Principal Engineer @ Loom',
-    release: 'Tuesday, March 18',
-    takeaway: 'How to balance design consistency with rapid experimentation across squads.',
+    title: 'Recording workflow',
+    description: 'Dialing in the equipment, editing pipeline, and publishing checklist so episodes ship consistently.',
   },
   {
-    title: 'Edge runtime best practices',
-    guest: 'Miguel Oliveira, Solutions Architect @ Vercel',
-    release: 'Thursday, March 27',
-    takeaway: 'Deploying resilient edge functions, cold starts, and observability strategies.',
+    title: 'Story backlog',
+    description: 'Collecting questions and topic requests from the community before we hit record.',
   },
   {
-    title: 'Community-sourced developer UX wins',
-    guest: 'Panel of Syntax & Sips community contributors',
-    release: 'Sunday, April 6',
-    takeaway: 'The small quality-of-life updates that made the biggest impact this quarter.',
-  },
-];
-
-const listeningPlatforms = [
-  {
-    title: 'Listen your way',
-    description:
-      'Stream directly in your browser, queue episodes on mobile, or add us to your podcast player of choice with a private RSS feed.',
-    icon: Headphones,
-  },
-  {
-    title: 'Stay in sync',
-    description:
-      'Enable notifications in the Syntax & Sips app to get alerts for fresh drops, transcripts, and exclusive bonus segments.',
-    icon: Radio,
-  },
-  {
-    title: 'Read while you listen',
-    description:
-      'Every episode ships with a detailed companion note, resource list, and code samples so you can follow along at your own pace.',
-    icon: Mic,
+    title: 'Distribution plan',
+    description: 'Testing hosting providers and RSS tooling to make sure subscribing will be painless on day one.',
   },
 ];
 
 export const metadata: Metadata = {
-  title: 'Podcasts | Syntax & Sips',
+  title: 'Podcasts status | Syntax & Sips',
   description:
-    'Explore all Syntax & Sips podcast series, upcoming episodes, and ways to listen across your favorite platforms.',
+    'Get an honest update on the Syntax & Sips podcast roadmap. No episodes are live yet—we are still preparing the format.',
 };
 
 export default function PodcastsPage() {
@@ -76,14 +42,14 @@ export default function PodcastsPage() {
     <PageShell
       hero={
         <PageHero
-          eyebrow="Podcast Hub"
-          title="Sip, learn, and ship with our developer-first podcasts"
-          description="Fresh conversations, practical deep dives, and real stories from builders on the front lines of the modern web."
+          eyebrow="In development"
+          title="Podcasts are still in pre-production"
+          description="We have not released any audio episodes yet. This page explains what we are working on and how to follow along."
           actions={
             <>
-              <CtaButton href="/newsletter">Get episode alerts</CtaButton>
-              <CtaButton href="/rss" variant="secondary">
-                Listen via RSS
+              <CtaButton href="/blogs">Read the latest updates</CtaButton>
+              <CtaButton href="/newsletter" variant="secondary">
+                Join the interest list
               </CtaButton>
             </>
           }
@@ -91,110 +57,80 @@ export default function PodcastsPage() {
       }
     >
       <ContentSection
-        eyebrow="Featured series"
-        title="Pick a vibe and start listening"
-        description="We curate each show around a unique cadence, so you always know what to expect when you press play."
+        eyebrow="What exists today"
+        title="You can still follow the work in progress"
+        description="While the podcast feed is empty, these resources cover the same themes we plan to explore on mic."
       >
-        {podcastSeries.length > 0 ? (
-          <div className="grid gap-8 md:grid-cols-3">
-            {podcastSeries.map((series) => (
-              <article
-                key={series.title}
-                className="flex h-full flex-col gap-4 rounded-2xl border-2 border-black bg-white/80 p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.08)] transition-transform duration-200 hover:-translate-y-1"
-              >
-                <h3 className="text-xl font-black">{series.title}</h3>
-                <p className="text-sm text-black/70 leading-relaxed">{series.description}</p>
-                <dl className="mt-auto space-y-2 text-sm font-semibold">
-                  <div className="flex items-center justify-between gap-2">
-                    <dt className="uppercase tracking-[0.15em] text-black/60">Cadence</dt>
-                    <dd>{series.cadence}</dd>
-                  </div>
-                  <div className="flex items-center justify-between gap-2">
-                    <dt className="uppercase tracking-[0.15em] text-black/60">Focus</dt>
-                    <dd>{series.focus}</dd>
-                  </div>
-                </dl>
-              </article>
-            ))}
-          </div>
-        ) : null}
+        <div className="grid gap-6 md:grid-cols-2">
+          {availableResources.map((resource) => (
+            <article
+              key={resource.title}
+              className="flex h-full flex-col justify-between gap-4 rounded-2xl border-2 border-black bg-white/80 p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.08)]"
+            >
+              <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.2em] text-black/60">
+                <NotebookPen className="h-5 w-5 text-[#6C63FF]" aria-hidden="true" />
+                {resource.title}
+              </div>
+              <p className="text-sm text-black/70 leading-relaxed">{resource.description}</p>
+              <CtaButton href={resource.href}>Open</CtaButton>
+            </article>
+          ))}
+        </div>
       </ContentSection>
 
       <ContentSection
-        eyebrow="Next up"
-        title="Upcoming conversations"
-        description="Mark your calendar and send us your questions—every episode features community prompts."
+        eyebrow="What we are tackling"
+        title="Pre-production checklist"
+        description="Here is the honest list of tasks we are wrapping up before episode one ships."
         tone="lavender"
       >
-        {upcomingEpisodes.length > 0 ? (
-          <div className="grid gap-6">
-            {upcomingEpisodes.map((episode) => (
-              <article
-                key={`${episode.title}-${episode.release}`}
-                className="flex flex-col gap-3 rounded-2xl border-2 border-dashed border-black/40 bg-white/80 p-6 md:flex-row md:items-center md:justify-between"
-              >
-                <div>
-                  <p className="text-xs font-bold uppercase tracking-[0.3em] text-[#6C63FF]">{episode.release}</p>
-                  <h3 className="text-xl font-black">{episode.title}</h3>
-                  <p className="text-sm text-black/70">Featuring {episode.guest}</p>
-                </div>
-                <p className="text-sm max-w-lg text-black/80 md:text-right">{episode.takeaway}</p>
-              </article>
-            ))}
-          </div>
-        ) : null}
+        <div className="grid gap-4 md:grid-cols-3">
+          {preparationSteps.map((step) => (
+            <article
+              key={step.title}
+              className="flex flex-col gap-3 rounded-2xl border-2 border-dashed border-black/30 bg-white/70 p-6"
+            >
+              <div className="flex items-center gap-2 text-xs font-black uppercase tracking-[0.3em] text-[#6C63FF]">
+                <Mic className="h-4 w-4" aria-hidden="true" />
+                In progress
+              </div>
+              <h3 className="text-lg font-black text-black">{step.title}</h3>
+              <p className="text-sm text-black/70 leading-relaxed">{step.description}</p>
+            </article>
+          ))}
+        </div>
       </ContentSection>
 
       <ContentSection
-        eyebrow="Listening experience"
-        title="Meet listeners where they already are"
-        description="Whether you tune in between standups or during deep focus time, Syntax & Sips is ready when you are."
+        eyebrow="Where updates will land"
+        title="Stay in the loop"
+        description="We will announce the feed, guests, and schedule the moment everything is ready."
         tone="peach"
-        align="center"
-      >
-        {listeningPlatforms.length > 0 ? (
-          <div className="grid gap-8 md:grid-cols-3">
-            {listeningPlatforms.map((platform) => (
-              <article
-                key={platform.title}
-                className="flex flex-col items-center gap-4 rounded-2xl border-2 border-black bg-white/70 p-6 text-center"
-              >
-                <platform.icon className="h-12 w-12 text-[#FF5252]" aria-hidden="true" />
-                <h3 className="text-lg font-black">{platform.title}</h3>
-                <p className="text-sm text-black/70 leading-relaxed">{platform.description}</p>
-              </article>
-            ))}
-          </div>
-        ) : null}
-      </ContentSection>
-
-      <ContentSection
-        eyebrow="Bonus content"
-        title="Prefer reading to listening?"
-        description="Every podcast has an accompanying blog post. You can skim the highlights, copy the snippets, and share the takeaways."
         footerContent={
           <div className="flex flex-wrap items-center justify-between gap-4">
-            <p className="text-sm text-black/70">Download transcripts, request topics, and submit your own lightning questions.</p>
-            <CtaButton href="/blogs" variant="secondary">
-              Explore companion posts
+            <p className="text-sm text-black/70">
+              Prefer RSS? We will publish the feed URL here first once recording begins.
+            </p>
+            <CtaButton href="/newsletter" variant="secondary">
+              Get notified
             </CtaButton>
           </div>
         }
       >
-        <div className="grid gap-4 md:grid-cols-2">
-          <div className="rounded-2xl border-2 border-black bg-white/70 p-6">
-            <h3 className="text-lg font-black">Transcripts & key moments</h3>
-            <p className="text-sm text-black/70 leading-relaxed">
-              Access searchable transcripts with timestamps so you can jump right to the answers you need.
-            </p>
-          </div>
-          <div className="rounded-2xl border-2 border-black bg-white/70 p-6">
-            <h3 className="text-lg font-black">Community AMA sessions</h3>
-            <p className="text-sm text-black/70 leading-relaxed">
-              Join the Syntax & Sips Discord for live recordings, behind-the-scenes notes, and after-hours Q&A sessions.
-            </p>
-          </div>
+        <div className="rounded-2xl border-2 border-black bg-white/70 p-6 text-sm text-black/70 leading-relaxed">
+          <p>
+            No teaser clips, transcripts, or subscription links exist yet. When those are ready this section will list them—until
+            then, the best place for updates is our newsletter or the changelog.
+          </p>
         </div>
+      </ContentSection>
+
+      <ContentSection
+        eyebrow="Launch details"
+        title="Podcast feed"
+        description="As soon as the podcast is published, you will see links here."
+      >
+        {null}
       </ContentSection>
     </PageShell>
   );

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -1,56 +1,38 @@
 import { Metadata } from 'next';
-import { Briefcase, FolderGit2, GraduationCap, Library, Newspaper } from 'lucide-react';
+import { FileText, FolderGit2, LayoutTemplate } from 'lucide-react';
 import { PageShell, PageHero, ContentSection, CtaButton } from '@/components/ui/PageLayout';
 
-const resourceCollections = [
+const availableResources = [
   {
-    title: 'Starter templates',
-    description: 'Opinionated boilerplates for Next.js, Remix, and Astro with testing, linting, and deployment ready to go.',
-    icon: FolderGit2,
-    linkLabel: 'View templates',
-    href: '/docs',
+    title: 'Documentation',
+    description: 'Architecture notes, contribution guides, and editorial standards live in our docs folder.',
+    href: '/docs/markdown-guide.md',
+    icon: FileText,
   },
   {
-    title: 'Team playbooks',
-    description: 'Download battle-tested rituals, meeting cadences, and handoff docs to keep cross-functional teams aligned.',
-    icon: Briefcase,
-    linkLabel: 'Run the play',
+    title: 'Blog library',
+    description: 'Long-form posts break down the experiments and systems we are building in real time.',
     href: '/blogs',
+    icon: LayoutTemplate,
   },
   {
-    title: 'Learning paths',
-    description: 'Step-by-step curriculum recommendations to go from fundamentals to advanced topics without burning out.',
-    icon: GraduationCap,
-    linkLabel: 'Choose a path',
-    href: '/tutorials',
+    title: 'Changelog',
+    description: 'Every release entry explains what shipped and why, serving as lightweight release notes.',
+    href: '/changelog',
+    icon: FolderGit2,
   },
 ];
 
-const guides = [
-  'Accessibility checklists and inclusive design patterns for every component.',
-  'Incident response handbook for small teams shipping on-call rotations.',
-  'Community templates for writing effective RFCs and architecture docs.',
-  'Workshop kits including slide decks, facilitation notes, and recap templates.',
-];
-
-const newsletterHighlights = [
-  {
-    title: 'The Ship Log',
-    description: 'Weekly summary of product releases, developer experience wins, and roadmap updates.',
-  },
-  {
-    title: 'Friday Debug',
-    description: 'A tactical teardown of one tricky issue and how a community member solved it.',
-  },
-  {
-    title: 'Culture Code',
-    description: 'Stories, rituals, and experiments from teams building healthy engineering cultures.',
-  },
+const upcomingDrops = [
+  'Template bundles for editorial planning, currently being reviewed for accuracy.',
+  'Checklists for accessibility and publishing QA.',
+  'Downloadable component inventories once the UI library stabilises.',
 ];
 
 export const metadata: Metadata = {
-  title: 'Resource Library | Syntax & Sips',
-  description: 'Download templates, guides, and curated resources to support your developer workflow from idea to launch.',
+  title: 'Resource hub status | Syntax & Sips',
+  description:
+    'The resource library is still being assembled. Explore the materials that exist today and see what is coming next.',
 };
 
 export default function ResourcesPage() {
@@ -58,14 +40,14 @@ export default function ResourcesPage() {
     <PageShell
       hero={
         <PageHero
-          eyebrow="Resource Library"
-          title="Tools, templates, and guides to accelerate your workflow"
-          description="Save hours of busywork with curated resources crafted by our team and community contributors."
+          eyebrow="In progress"
+          title="Resource downloads are not live yet"
+          description="We are still packaging the files. In the meantime, use these public references to follow our work."
           actions={
             <>
-              <CtaButton href="/newsletter">Get resource drops</CtaButton>
-              <CtaButton href="/podcasts" variant="secondary">
-                Hear how teams use them
+              <CtaButton href="/blogs">Read the latest posts</CtaButton>
+              <CtaButton href="/newsletter" variant="secondary">
+                Get notified when they drop
               </CtaButton>
             </>
           }
@@ -73,75 +55,52 @@ export default function ResourcesPage() {
       }
     >
       <ContentSection
-        eyebrow="Collections"
-        title="Curated libraries for builders"
-        description="Every download comes with context, setup instructions, and recommended next steps."
+        eyebrow="Available today"
+        title="Reference material you can use now"
+        description="These links stay up-to-date as we continue building the platform."
       >
-        {resourceCollections.length > 0 ? (
-          <div className="grid gap-8 md:grid-cols-3">
-            {resourceCollections.map((collection) => (
-              <article
-                key={collection.title}
-                className="flex h-full flex-col gap-4 rounded-2xl border-2 border-black bg-white/80 p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.08)]"
-              >
-                <collection.icon className="h-10 w-10 text-[#6C63FF]" aria-hidden="true" />
-                <h3 className="text-xl font-black">{collection.title}</h3>
-                <p className="text-sm text-black/70 leading-relaxed">{collection.description}</p>
-                <CtaButton href={collection.href}>{collection.linkLabel}</CtaButton>
-              </article>
-            ))}
-          </div>
-        ) : null}
+        <div className="grid gap-6 md:grid-cols-3">
+          {availableResources.map((resource) => (
+            <article
+              key={resource.title}
+              className="flex h-full flex-col gap-4 rounded-2xl border-2 border-black bg-white/80 p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.08)]"
+            >
+              <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.2em] text-black/60">
+                <resource.icon className="h-6 w-6 text-[#6C63FF]" aria-hidden="true" />
+                {resource.title}
+              </div>
+              <p className="text-sm text-black/70 leading-relaxed">{resource.description}</p>
+              <CtaButton href={resource.href}>Open</CtaButton>
+            </article>
+          ))}
+        </div>
       </ContentSection>
 
       <ContentSection
-        eyebrow="Guides & toolkits"
-        title="What you can download today"
-        description="We keep everything updated as frameworks evolve, so you always grab the latest version."
+        eyebrow="Packaging work"
+        title="What we are still compiling"
+        description="We will flip these live once we have verified each download."
         tone="lavender"
       >
-        {guides.length > 0 ? (
-          <ul className="grid gap-4 md:grid-cols-2">
-            {guides.map((guide) => (
-              <li
-                key={guide}
-                className="flex items-start gap-4 rounded-2xl border-2 border-dashed border-black/40 bg-white/80 p-6"
-              >
-                <Library className="mt-1 h-8 w-8 text-[#FF5252]" aria-hidden="true" />
-                <p className="text-sm text-black/80 leading-relaxed">{guide}</p>
-              </li>
-            ))}
-          </ul>
-        ) : null}
+        <ul className="grid gap-4 md:grid-cols-3">
+          {upcomingDrops.map((item) => (
+            <li
+              key={item}
+              className="rounded-2xl border-2 border-dashed border-black/30 bg-white/70 p-6 text-sm text-black/70"
+            >
+              {item}
+            </li>
+          ))}
+        </ul>
       </ContentSection>
 
       <ContentSection
-        eyebrow="Newsletter extras"
-        title="Premium resources delivered on Fridays"
-        description="Subscribers get bonus checklists, partner discounts, and behind-the-scenes case studies."
+        eyebrow="Download shelf"
+        title="Resource bundles"
+        description="When the first packages are ready, download links will appear here."
         tone="peach"
-        align="center"
-        footerContent={
-          <div className="flex flex-wrap items-center justify-between gap-4">
-            <p className="text-sm text-black/70">Unlock access by joining the Syntax & Sips newsletter community.</p>
-            <CtaButton href="/newsletter">Subscribe now</CtaButton>
-          </div>
-        }
       >
-        {newsletterHighlights.length > 0 ? (
-          <div className="grid gap-8 md:grid-cols-3">
-            {newsletterHighlights.map((highlight) => (
-              <article
-                key={highlight.title}
-                className="flex flex-col items-center gap-4 rounded-2xl border-2 border-black bg-white/70 p-6 text-center"
-              >
-                <Newspaper className="h-12 w-12 text-[#FF5252]" aria-hidden="true" />
-                <h3 className="text-lg font-black">{highlight.title}</h3>
-                <p className="text-sm text-black/70 leading-relaxed">{highlight.description}</p>
-              </article>
-            ))}
-          </div>
-        ) : null}
+        {null}
       </ContentSection>
     </PageShell>
   );

--- a/src/app/tutorials/page.tsx
+++ b/src/app/tutorials/page.tsx
@@ -1,71 +1,43 @@
 import { Metadata } from 'next';
-import { Code2, Compass, Sparkles } from 'lucide-react';
+import { BookOpen, ClipboardList, FileText, GraduationCap } from 'lucide-react';
 import { PageShell, PageHero, ContentSection, CtaButton } from '@/components/ui/PageLayout';
 
-const tutorialTracks = [
+const availableLearning = [
   {
-    title: 'Launch fundamentals',
-    level: 'Beginner friendly',
-    description: 'Kickstart your journey with HTML, CSS, accessible layouts, and the tooling you need to ship your first project.',
-    duration: '4 weeks • 12 lessons',
+    title: 'In-depth articles',
+    description: 'Our blog posts capture the same walkthroughs that will become structured lessons.',
+    href: '/blogs',
+    icon: FileText,
   },
   {
-    title: 'Production-grade React',
-    level: 'Intermediate',
-    description: 'Learn how to architect resilient React apps with modern hooks, suspense patterns, and end-to-end testing.',
-    duration: '6 weeks • 18 lessons',
-  },
-  {
-    title: 'Full-stack with Next.js',
-    level: 'Advanced',
-    description: 'Master data fetching, caching strategies, auth flows, and background tasks with the latest Next.js features.',
-    duration: '8 weeks • 20 lessons',
+    title: 'Project documentation',
+    description: 'The documentation folder is public, including content style guides and technical references.',
+    href: '/docs/markdown-guide.md',
+    icon: BookOpen,
   },
 ];
 
-const liveWorkshops = [
-  {
-    title: 'Design systems for devs',
-    host: 'Hosted by Priya Das',
-    date: 'April 2 • 10:00 AM PT',
-    focus: 'Create a scalable token pipeline, theme switching, and accessible components.',
-  },
-  {
-    title: 'Serverless debugging clinic',
-    host: 'Hosted by Evan Brooks',
-    date: 'April 11 • 9:00 AM PT',
-    focus: 'Trace cold starts, optimize logs, and monitor distributed workflows.',
-  },
-  {
-    title: 'Animations that ship',
-    host: 'Hosted by Mako Ito',
-    date: 'April 18 • 12:00 PM PT',
-    focus: 'Blend motion with performance budgets using Framer Motion and CSS Houdini.',
-  },
+const curriculumTasks = [
+  'Finalising the learning objectives for each module.',
+  'Recording practice projects that match the written guides.',
+  'Automating progress tracking so you can pick up where you left off.',
 ];
 
-const learningBenefits = [
+const supportPlans = [
   {
-    title: 'Guided learning paths',
-    description: 'Structured modules with checkpoints, code reviews, and paired practice to reinforce every concept.',
-    icon: Compass,
+    title: 'Feedback loops',
+    description: 'Every tutorial will include a feedback form so we can expand or clarify the tricky steps.',
   },
   {
-    title: 'Hands-on projects',
-    description: 'Build portfolio-ready experiences with clarity on requirements, data models, and real-world constraints.',
-    icon: Code2,
-  },
-  {
-    title: 'Micro-learning moments',
-    description: 'Bite-sized challenges and daily prompts help you grow even when you only have 20 minutes to spare.',
-    icon: Sparkles,
+    title: 'Community sharing',
+    description: 'We are preparing a lightweight showcase to highlight learner projects once the courses launch.',
   },
 ];
 
 export const metadata: Metadata = {
-  title: 'Tutorials | Syntax & Sips',
+  title: 'Tutorials roadmap | Syntax & Sips',
   description:
-    'Structured tutorials, live workshops, and learning paths to help you level up your front-end and full-stack skills.',
+    'See the current status of the Syntax & Sips tutorial library. Lessons are still in production—follow along while we finish them.',
 };
 
 export default function TutorialsPage() {
@@ -73,14 +45,14 @@ export default function TutorialsPage() {
     <PageShell
       hero={
         <PageHero
-          eyebrow="Guided Learning"
-          title="Tutorial tracks built for modern web makers"
-          description="Choose your adventure, follow along with high-quality lesson plans, and get unstuck with community support."
+          eyebrow="Work in progress"
+          title="Tutorial tracks are not live yet"
+          description="We are assembling the curriculum now. Until the full experience is ready, here is what you can access today."
           actions={
             <>
-              <CtaButton href="/newsletter">Join the waitlist</CtaButton>
-              <CtaButton href="/resources" variant="secondary">
-                Browse resources
+              <CtaButton href="/blogs">Browse current guides</CtaButton>
+              <CtaButton href="/newsletter" variant="secondary">
+                Get launch emails
               </CtaButton>
             </>
           }
@@ -88,102 +60,75 @@ export default function TutorialsPage() {
       }
     >
       <ContentSection
-        eyebrow="Learning paths"
-        title="Start where you are and keep moving"
-        description="Each track blends theory with practice, helping you build muscle memory and ship confidently."
+        eyebrow="Start here"
+        title="Learning material that exists today"
+        description="These resources mirror the topics we plan to expand into full tutorials."
       >
-        {tutorialTracks.length > 0 ? (
-          <div className="grid gap-8 md:grid-cols-3">
-            {tutorialTracks.map((track) => (
-              <article
-                key={track.title}
-                className="flex h-full flex-col gap-4 rounded-2xl border-2 border-black bg-white/80 p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.08)]"
-              >
-                <h3 className="text-xl font-black">{track.title}</h3>
-                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#6C63FF]">{track.level}</p>
-                <p className="text-sm text-black/70 leading-relaxed">{track.description}</p>
-                <p className="mt-auto text-sm font-semibold text-black/80">{track.duration}</p>
-              </article>
-            ))}
-          </div>
-        ) : null}
+        <div className="grid gap-6 md:grid-cols-2">
+          {availableLearning.map((item) => (
+            <article
+              key={item.title}
+              className="flex h-full flex-col gap-4 rounded-2xl border-2 border-black bg-white/80 p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.08)]"
+            >
+              <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.25em] text-black/60">
+                <item.icon className="h-5 w-5 text-[#6C63FF]" aria-hidden="true" />
+                {item.title}
+              </div>
+              <p className="text-sm text-black/70 leading-relaxed">{item.description}</p>
+              <CtaButton href={item.href}>Open</CtaButton>
+            </article>
+          ))}
+        </div>
       </ContentSection>
 
       <ContentSection
-        eyebrow="Live sessions"
-        title="Workshops & office hours"
-        description="Join real-time events where you can ask questions, share your screen, and learn from fellow builders."
+        eyebrow="Production status"
+        title="What we are building"
+        description="A quick look at the checklist we are working through before the first cohort launches."
         tone="lavender"
       >
-        {liveWorkshops.length > 0 ? (
-          <div className="grid gap-6">
-            {liveWorkshops.map((workshop) => (
-              <article
-                key={`${workshop.title}-${workshop.date}`}
-                className="flex flex-col gap-3 rounded-2xl border-2 border-dashed border-black/40 bg-white/80 p-6 md:flex-row md:items-center md:justify-between"
-              >
-                <div>
-                  <p className="text-xs font-bold uppercase tracking-[0.3em] text-[#FF5252]">{workshop.date}</p>
-                  <h3 className="text-xl font-black">{workshop.title}</h3>
-                  <p className="text-sm text-black/70">{workshop.host}</p>
-                </div>
-                <p className="text-sm max-w-xl text-black/80 md:text-right">{workshop.focus}</p>
-              </article>
-            ))}
-          </div>
-        ) : null}
+        <ul className="grid gap-4 md:grid-cols-3">
+          {curriculumTasks.map((task) => (
+            <li
+              key={task}
+              className="flex items-start gap-3 rounded-2xl border-2 border-dashed border-black/30 bg-white/70 p-6 text-sm text-black/70"
+            >
+              <ClipboardList className="mt-0.5 h-5 w-5 text-[#6C63FF]" aria-hidden="true" />
+              <span>{task}</span>
+            </li>
+          ))}
+        </ul>
       </ContentSection>
 
       <ContentSection
-        eyebrow="Why learners stay"
-        title="A learning experience designed to fit your schedule"
-        description="From structured roadmaps to on-demand practice, we remove the guesswork so you can focus on progress."
+        eyebrow="Learner support"
+        title="How we will help you stay on track"
+        description="These programs will launch alongside the tutorials."
         tone="peach"
-        align="center"
       >
-        {learningBenefits.length > 0 ? (
-          <div className="grid gap-8 md:grid-cols-3">
-            {learningBenefits.map((benefit) => (
-              <article
-                key={benefit.title}
-                className="flex flex-col items-center gap-4 rounded-2xl border-2 border-black bg-white/70 p-6 text-center"
-              >
-                <benefit.icon className="h-12 w-12 text-[#6C63FF]" aria-hidden="true" />
-                <h3 className="text-lg font-black">{benefit.title}</h3>
-                <p className="text-sm text-black/70 leading-relaxed">{benefit.description}</p>
-              </article>
-            ))}
-          </div>
-        ) : null}
+        <div className="grid gap-6 md:grid-cols-2">
+          {supportPlans.map((plan) => (
+            <article
+              key={plan.title}
+              className="flex flex-col gap-3 rounded-2xl border-2 border-black bg-white/70 p-6"
+            >
+              <div className="flex items-center gap-2 text-xs font-black uppercase tracking-[0.3em] text-[#FF5252]">
+                <GraduationCap className="h-4 w-4" aria-hidden="true" />
+                Planned
+              </div>
+              <h3 className="text-lg font-black text-black">{plan.title}</h3>
+              <p className="text-sm text-black/70 leading-relaxed">{plan.description}</p>
+            </article>
+          ))}
+        </div>
       </ContentSection>
 
       <ContentSection
-        eyebrow="Accountability"
-        title="Keep the momentum going"
-        description="Track your streaks, celebrate wins, and request feedback without leaving the Syntax & Sips platform."
-        footerContent={
-          <div className="flex flex-wrap items-center justify-between gap-4">
-            <p className="text-sm text-black/70">Want personalized guidance? Book a mentor session and get tailored feedback.</p>
-            <CtaButton href="/me" variant="secondary">
-              Meet the mentors
-            </CtaButton>
-          </div>
-        }
+        eyebrow="Course library"
+        title="Published tutorials"
+        description="This space will list every lesson once they go live."
       >
-        <div className="grid gap-4 md:grid-cols-2">
-          <div className="rounded-2xl border-2 border-black bg-white/70 p-6">
-            <h3 className="text-lg font-black">Weekly retros</h3>
-            <p className="text-sm text-black/70 leading-relaxed">
-              Reflect on what you shipped, blockers you faced, and goals for the next sprint with guided templates.
-            </p>
-          </div>
-          <div className="rounded-2xl border-2 border-black bg-white/70 p-6">
-            <h3 className="text-lg font-black">Community checkpoints</h3>
-            <p className="text-sm text-black/70 leading-relaxed">
-              Join small-group sessions to demo work, get code reviews, and crowdsource solutions from peers.
-            </p>
-          </div>
-        </div>
+        {null}
       </ContentSection>
     </PageShell>
   );

--- a/src/app/videos/page.tsx
+++ b/src/app/videos/page.tsx
@@ -1,59 +1,32 @@
 import { Metadata } from 'next';
-import { Camera, MonitorPlay, Video } from 'lucide-react';
+import { Camera, Film, Newspaper } from 'lucide-react';
 import { PageShell, PageHero, ContentSection, CtaButton } from '@/components/ui/PageLayout';
 
-const videoSeries = [
+const currentFormats = [
   {
-    title: 'UI in Motion',
-    length: '8-12 minutes',
-    description: 'Practical lessons on accessible animation, transitions, and micro-interactions with code walkthroughs.',
+    title: 'Blog walkthroughs',
+    description: 'Detailed articles with screenshots and code snippets cover the same concepts we plan to film.',
+    href: '/blogs',
+    icon: Newspaper,
   },
   {
-    title: 'Ship it Live',
-    length: '25-35 minutes',
-    description: 'Unfiltered build sessions where we solve community-submitted tickets and refactor production code.',
-  },
-  {
-    title: 'Tooling deep dives',
-    length: '15-20 minutes',
-    description: 'Learn how to configure linting, CI pipelines, and deployment workflows for real-world teams.',
-  },
-];
-
-const upcomingStreams = [
-  {
-    title: 'Design tokens to production UI',
-    date: 'Friday, March 14 • 1:00 PM PT',
-    focus: 'Connect Figma variables to a typed token pipeline in your Next.js app.',
-  },
-  {
-    title: 'Observability crash course',
-    date: 'Wednesday, March 26 • 9:30 AM PT',
-    focus: 'Instrumenting user journeys with OpenTelemetry and visualizing insights in minutes.',
-  },
-];
-
-const productionPerks = [
-  {
-    title: 'Downloadable project files',
-    description: 'Clone every lesson repo, inspect commits, and reuse ready-to-ship patterns in your own work.',
-    icon: MonitorPlay,
-  },
-  {
-    title: 'Closed captions & transcripts',
-    description: 'Follow along with accurate captions and transcripts available the moment a video goes live.',
-    icon: Video,
-  },
-  {
-    title: 'Pro-grade audio and visuals',
-    description: 'Crisp demos filmed with studio gear so you never miss a detail—perfect for group watch sessions.',
+    title: 'Changelog demos',
+    description: 'Release notes include short Loom-style clips while we build the full video pipeline.',
+    href: '/changelog',
     icon: Camera,
   },
 ];
 
+const productionTodo = [
+  'Standardising recording templates for screen capture and voice-over.',
+  'Setting up accessible captioning and transcript tooling.',
+  'Automating thumbnail generation and metadata publishing.',
+];
+
 export const metadata: Metadata = {
-  title: 'Videos | Syntax & Sips',
-  description: 'On-demand lessons, live streams, and production-grade walkthroughs to help you master modern web development.',
+  title: 'Video hub status | Syntax & Sips',
+  description:
+    'Our video library is still under construction. Follow the honest progress report and see what you can watch today.',
 };
 
 export default function VideosPage() {
@@ -61,14 +34,14 @@ export default function VideosPage() {
     <PageShell
       hero={
         <PageHero
-          eyebrow="Video Library"
-          title="High-definition lessons for visual learners"
-          description="Stream immersive walkthroughs, join live builds, and learn faster with code-forward videos."
+          eyebrow="Coming soon"
+          title="No video lessons yet—here is the plan"
+          description="We are actively building the recording workflow. Until the library is live, use these resources to stay in the loop."
           actions={
             <>
-              <CtaButton href="/newsletter">Never miss a stream</CtaButton>
-              <CtaButton href="/resources" variant="secondary">
-                Download assets
+              <CtaButton href="/blogs">Read the latest guides</CtaButton>
+              <CtaButton href="/newsletter" variant="secondary">
+                Get launch updates
               </CtaButton>
             </>
           }
@@ -76,100 +49,53 @@ export default function VideosPage() {
       }
     >
       <ContentSection
-        eyebrow="Series spotlight"
-        title="Find the perfect format for your learning style"
-        description="Explore series that range from quick tips to full rebuilds—each one includes repos, transcripts, and follow-up prompts."
+        eyebrow="Watch something now"
+        title="Existing content"
+        description="These formats are available today while we finish the full studio workflow."
       >
-        {videoSeries.length > 0 ? (
-          <div className="grid gap-8 md:grid-cols-3">
-            {videoSeries.map((series) => (
-              <article
-                key={series.title}
-                className="flex h-full flex-col gap-4 rounded-2xl border-2 border-black bg-white/80 p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.08)]"
-              >
-                <h3 className="text-xl font-black">{series.title}</h3>
-                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#FF5252]">{series.length} average</p>
-                <p className="text-sm text-black/70 leading-relaxed">{series.description}</p>
-              </article>
-            ))}
-          </div>
-        ) : null}
+        <div className="grid gap-6 md:grid-cols-2">
+          {currentFormats.map((item) => (
+            <article
+              key={item.title}
+              className="flex h-full flex-col gap-4 rounded-2xl border-2 border-black bg-white/80 p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.08)]"
+            >
+              <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.25em] text-black/60">
+                <item.icon className="h-5 w-5 text-[#FF5252]" aria-hidden="true" />
+                {item.title}
+              </div>
+              <p className="text-sm text-black/70 leading-relaxed">{item.description}</p>
+              <CtaButton href={item.href}>Open</CtaButton>
+            </article>
+          ))}
+        </div>
       </ContentSection>
 
       <ContentSection
-        eyebrow="Live calendar"
-        title="Streams happening this month"
-        description="RSVP to join live, drop your questions ahead of time, or catch the replay with timestamped chapters."
+        eyebrow="Production board"
+        title="Steps before we hit record"
+        description="This to-do list guides the launch of the video library."
         tone="lavender"
       >
-        {upcomingStreams.length > 0 ? (
-          <div className="grid gap-6">
-            {upcomingStreams.map((stream) => (
-              <article
-                key={`${stream.title}-${stream.date}`}
-                className="flex flex-col gap-3 rounded-2xl border-2 border-dashed border-black/40 bg-white/80 p-6 md:flex-row md:items-center md:justify-between"
-              >
-                <div>
-                  <p className="text-xs font-bold uppercase tracking-[0.3em] text-[#6C63FF]">{stream.date}</p>
-                  <h3 className="text-xl font-black">{stream.title}</h3>
-                </div>
-                <p className="text-sm max-w-xl text-black/80 md:text-right">{stream.focus}</p>
-              </article>
-            ))}
-          </div>
-        ) : null}
+        <ul className="grid gap-4 md:grid-cols-3">
+          {productionTodo.map((task) => (
+            <li
+              key={task}
+              className="flex items-start gap-3 rounded-2xl border-2 border-dashed border-black/30 bg-white/70 p-6 text-sm text-black/70"
+            >
+              <Film className="mt-0.5 h-5 w-5 text-[#6C63FF]" aria-hidden="true" />
+              <span>{task}</span>
+            </li>
+          ))}
+        </ul>
       </ContentSection>
 
       <ContentSection
-        eyebrow="What to expect"
-        title="Video-first learning without compromise"
-        description="Every video is produced with the same attention to clarity and craft as our written tutorials."
+        eyebrow="Future playlists"
+        title="Video library"
+        description="Once the first episodes publish, the full catalogue will live here."
         tone="peach"
-        align="center"
       >
-        {productionPerks.length > 0 ? (
-          <div className="grid gap-8 md:grid-cols-3">
-            {productionPerks.map((perk) => (
-              <article
-                key={perk.title}
-                className="flex flex-col items-center gap-4 rounded-2xl border-2 border-black bg-white/70 p-6 text-center"
-              >
-                <perk.icon className="h-12 w-12 text-[#FF5252]" aria-hidden="true" />
-                <h3 className="text-lg font-black">{perk.title}</h3>
-                <p className="text-sm text-black/70 leading-relaxed">{perk.description}</p>
-              </article>
-            ))}
-          </div>
-        ) : null}
-      </ContentSection>
-
-      <ContentSection
-        eyebrow="Community picks"
-        title="Not sure where to start?"
-        description="Our team curates playlists for different goals so you can binge-watch with purpose."
-        footerContent={
-          <div className="flex flex-wrap items-center justify-between gap-4">
-            <p className="text-sm text-black/70">Submit your own recommendation and we might feature it in the next lineup.</p>
-            <CtaButton href="/blogs" variant="secondary">
-              Read related articles
-            </CtaButton>
-          </div>
-        }
-      >
-        <div className="grid gap-4 md:grid-cols-2">
-          <div className="rounded-2xl border-2 border-black bg-white/70 p-6">
-            <h3 className="text-lg font-black">Launch your first side project</h3>
-            <p className="text-sm text-black/70 leading-relaxed">
-              A curated path that moves from idea validation to deployment, including design systems, state management, and observability.
-            </p>
-          </div>
-          <div className="rounded-2xl border-2 border-black bg-white/70 p-6">
-            <h3 className="text-lg font-black">Level up your motion design</h3>
-            <p className="text-sm text-black/70 leading-relaxed">
-              Learn how to use motion intentionally with component-driven animations, scroll-triggered effects, and microinteractions.
-            </p>
-          </div>
-        </div>
+        {null}
       </ContentSection>
     </PageShell>
   );

--- a/src/components/auth/AdminLoginForm.tsx
+++ b/src/components/auth/AdminLoginForm.tsx
@@ -18,6 +18,11 @@ import '@/styles/neo-brutalism.css';
 import { createBrowserClient } from '@/lib/supabase/client';
 import { syncAuthState } from '@/lib/supabase/sync-auth-state';
 import { useSupabaseAuthSync } from '@/hooks/useSupabaseAuthSync';
+import {
+  NeobrutalAlert,
+  NeobrutalAlertDescription,
+  NeobrutalAlertTitle,
+} from '@/components/neobrutal/alert';
 
 export const AdminLoginForm = () => {
   const router = useRouter();
@@ -171,25 +176,24 @@ export const AdminLoginForm = () => {
                 Sign in with your admin credentials to publish updates, review pitches, and keep Syntax &amp; Sips running smoothly.
               </p>
 
-              {error && (
-                <div
-                  className="mt-6 flex items-start gap-3 rounded-2xl border-2 border-[#F87171] bg-[#7F1D1D]/60 p-4 text-sm font-semibold text-red-100"
-                  role="alert"
-                >
-                  <ShieldAlert className="mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden="true" />
-                  <p>{error}</p>
-                </div>
-              )}
+              {error ? (
+                <NeobrutalAlert tone="danger" className="mt-6" icon={<ShieldAlert className="h-5 w-5" />}>
+                  <NeobrutalAlertTitle>Admin access blocked</NeobrutalAlertTitle>
+                  <NeobrutalAlertDescription>{error}</NeobrutalAlertDescription>
+                </NeobrutalAlert>
+              ) : null}
 
-              {info && (
-                <div
-                  className="mt-6 flex items-start gap-3 rounded-2xl border-2 border-[#34D399] bg-[#064E3B]/60 p-4 text-sm font-semibold text-emerald-100"
+              {info ? (
+                <NeobrutalAlert
+                  tone="success"
+                  className="mt-6"
+                  icon={<ShieldCheck className="h-5 w-5" />}
                   role="status"
                 >
-                  <ShieldCheck className="mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden="true" />
-                  <p>{info}</p>
-                </div>
-              )}
+                  <NeobrutalAlertTitle>Signed in</NeobrutalAlertTitle>
+                  <NeobrutalAlertDescription>{info}</NeobrutalAlertDescription>
+                </NeobrutalAlert>
+              ) : null}
 
               <form onSubmit={handleSubmit} className="mt-8 space-y-6">
                 <div className="space-y-2">

--- a/src/components/auth/OnboardingFlow.tsx
+++ b/src/components/auth/OnboardingFlow.tsx
@@ -23,6 +23,11 @@ import {
 import { createBrowserClient } from '@/lib/supabase/client';
 import { useAuthenticatedProfile } from '@/hooks/useAuthenticatedProfile';
 import { cn } from '@/lib/utils';
+import {
+  NeobrutalAlert,
+  NeobrutalAlertDescription,
+  NeobrutalAlertTitle,
+} from '@/components/neobrutal/alert';
 import type {
   OnboardingAccountability,
   OnboardingCommunication,
@@ -1025,15 +1030,17 @@ export const OnboardingFlow = ({ profile, initialJourney, defaultRedirect }: Onb
             </div>
 
             {error ? (
-              <div className="rounded-2xl border-2 border-red-500 bg-red-100 p-4 text-sm font-semibold text-red-700" role="alert">
-                {error}
-              </div>
+              <NeobrutalAlert tone="danger">
+                <NeobrutalAlertTitle>We could not save your answers</NeobrutalAlertTitle>
+                <NeobrutalAlertDescription>{error}</NeobrutalAlertDescription>
+              </NeobrutalAlert>
             ) : null}
 
             {successMessage ? (
-              <div className="rounded-2xl border-2 border-emerald-500 bg-emerald-100 p-4 text-sm font-semibold text-emerald-700" role="status">
-                {successMessage}
-              </div>
+              <NeobrutalAlert tone="success" role="status">
+                <NeobrutalAlertTitle>Progress saved</NeobrutalAlertTitle>
+                <NeobrutalAlertDescription>{successMessage}</NeobrutalAlertDescription>
+              </NeobrutalAlert>
             ) : null}
 
             <div>

--- a/src/components/auth/UserSignInForm.tsx
+++ b/src/components/auth/UserSignInForm.tsx
@@ -10,6 +10,11 @@ import { useSupabaseAuthSync } from '@/hooks/useSupabaseAuthSync';
 import '@/styles/neo-brutalism.css';
 import type { AuthenticatedProfileSummary } from '@/utils/types';
 import { sanitizeRedirect } from '@/utils/sanitizeRedirect';
+import {
+  NeobrutalAlert,
+  NeobrutalAlertDescription,
+  NeobrutalAlertTitle,
+} from '@/components/neobrutal/alert';
 
 export const UserSignInForm = () => {
   const router = useRouter();
@@ -156,23 +161,19 @@ export const UserSignInForm = () => {
                 Sign in with your Syntax &amp; Sips account to sync your reading list and follow the latest drops.
               </p>
 
-              {error && (
-                <div
-                  className="mt-6 rounded-lg border-2 border-red-500 bg-red-100 p-4 text-sm font-semibold text-red-700"
-                  role="alert"
-                >
-                  <p>{error}</p>
-                </div>
-              )}
+              {error ? (
+                <NeobrutalAlert tone="danger" className="mt-6">
+                  <NeobrutalAlertTitle>We could not sign you in</NeobrutalAlertTitle>
+                  <NeobrutalAlertDescription>{error}</NeobrutalAlertDescription>
+                </NeobrutalAlert>
+              ) : null}
 
-              {info && (
-                <div
-                  className="mt-6 rounded-lg border-2 border-green-500 bg-green-100 p-4 text-sm font-semibold text-green-700"
-                  role="status"
-                >
-                  <p>{info}</p>
-                </div>
-              )}
+              {info ? (
+                <NeobrutalAlert tone="success" className="mt-6" role="status">
+                  <NeobrutalAlertTitle>Success</NeobrutalAlertTitle>
+                  <NeobrutalAlertDescription>{info}</NeobrutalAlertDescription>
+                </NeobrutalAlert>
+              ) : null}
 
               <form onSubmit={handleSubmit} className="mt-8 space-y-5">
                 <div className="space-y-2">

--- a/src/components/auth/UserSignUpForm.tsx
+++ b/src/components/auth/UserSignUpForm.tsx
@@ -10,6 +10,11 @@ import { useSupabaseAuthSync } from '@/hooks/useSupabaseAuthSync';
 import '@/styles/neo-brutalism.css';
 import { getSiteUrl } from '@/lib/site-url';
 import { sanitizeRedirect } from '@/utils/sanitizeRedirect';
+import {
+  NeobrutalAlert,
+  NeobrutalAlertDescription,
+  NeobrutalAlertTitle,
+} from '@/components/neobrutal/alert';
 
 export const UserSignUpForm = () => {
   const router = useRouter();
@@ -99,23 +104,19 @@ export const UserSignUpForm = () => {
                 Join our community for developer stories, coding hangouts, and exclusive updates.
               </p>
 
-              {error && (
-                <div
-                  className="mt-6 rounded-lg border-2 border-red-500 bg-red-100 p-4 text-sm font-semibold text-red-700"
-                  role="alert"
-                >
-                  <p>{error}</p>
-                </div>
-              )}
+              {error ? (
+                <NeobrutalAlert tone="danger" className="mt-6">
+                  <NeobrutalAlertTitle>We could not create your account</NeobrutalAlertTitle>
+                  <NeobrutalAlertDescription>{error}</NeobrutalAlertDescription>
+                </NeobrutalAlert>
+              ) : null}
 
-              {info && (
-                <div
-                  className="mt-6 rounded-lg border-2 border-green-500 bg-green-100 p-4 text-sm font-semibold text-green-700"
-                  role="status"
-                >
-                  <p>{info}</p>
-                </div>
-              )}
+              {info ? (
+                <NeobrutalAlert tone="success" className="mt-6" role="status">
+                  <NeobrutalAlertTitle>Almost done</NeobrutalAlertTitle>
+                  <NeobrutalAlertDescription>{info}</NeobrutalAlertDescription>
+                </NeobrutalAlert>
+              ) : null}
 
               <form onSubmit={handleSubmit} className="mt-8 space-y-5">
                 <div className="space-y-2">

--- a/src/components/neobrutal/alert-dialog.tsx
+++ b/src/components/neobrutal/alert-dialog.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import * as React from 'react';
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+
+import { cn } from '@/lib/utils';
+
+const basePanelClasses =
+  'relative w-full max-w-lg rounded-3xl border-4 border-black bg-white p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.12)] focus:outline-none';
+
+function NeobrutalAlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="neobrutal-alert-dialog" {...props} />;
+}
+
+function NeobrutalAlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger data-slot="neobrutal-alert-dialog-trigger" {...props} />;
+}
+
+function NeobrutalAlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="neobrutal-alert-dialog-portal" {...props} />;
+}
+
+function NeobrutalAlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="neobrutal-alert-dialog-overlay"
+      className={cn(
+        'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 fixed inset-0 z-50 bg-black/70 backdrop-blur-sm',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function NeobrutalAlertDialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <NeobrutalAlertDialogPortal>
+      <NeobrutalAlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="neobrutal-alert-dialog-content"
+        className={cn(
+          'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2',
+          basePanelClasses,
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </AlertDialogPrimitive.Content>
+    </NeobrutalAlertDialogPortal>
+  );
+}
+
+function NeobrutalAlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="neobrutal-alert-dialog-header"
+      className={cn('flex flex-col gap-2 text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function NeobrutalAlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="neobrutal-alert-dialog-footer"
+      className={cn('mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  );
+}
+
+function NeobrutalAlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="neobrutal-alert-dialog-title"
+      className={cn('text-2xl font-black tracking-tight text-black', className)}
+      {...props}
+    />
+  );
+}
+
+function NeobrutalAlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="neobrutal-alert-dialog-description"
+      className={cn('text-sm font-medium text-black/80', className)}
+      {...props}
+    />
+  );
+}
+
+function NeobrutalAlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      data-slot="neobrutal-alert-dialog-action"
+      className={cn(
+        'inline-flex items-center justify-center rounded-full border-2 border-black bg-black px-5 py-2 text-sm font-black uppercase tracking-[0.2em] text-white transition-transform duration-200 hover:-translate-y-1 hover:shadow-[6px_6px_0px_0px_rgba(108,99,255,0.35)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function NeobrutalAlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      data-slot="neobrutal-alert-dialog-cancel"
+      className={cn(
+        'inline-flex items-center justify-center rounded-full border-2 border-black bg-white px-5 py-2 text-sm font-black uppercase tracking-[0.2em] text-black transition-transform duration-200 hover:-translate-y-1 hover:shadow-[6px_6px_0px_0px_rgba(255,82,82,0.35)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  NeobrutalAlertDialog as AlertDialog,
+  NeobrutalAlertDialogTrigger as AlertDialogTrigger,
+  NeobrutalAlertDialogPortal as AlertDialogPortal,
+  NeobrutalAlertDialogOverlay as AlertDialogOverlay,
+  NeobrutalAlertDialogContent as AlertDialogContent,
+  NeobrutalAlertDialogHeader as AlertDialogHeader,
+  NeobrutalAlertDialogFooter as AlertDialogFooter,
+  NeobrutalAlertDialogTitle as AlertDialogTitle,
+  NeobrutalAlertDialogDescription as AlertDialogDescription,
+  NeobrutalAlertDialogAction as AlertDialogAction,
+  NeobrutalAlertDialogCancel as AlertDialogCancel,
+};
+

--- a/src/components/neobrutal/alert.tsx
+++ b/src/components/neobrutal/alert.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const alertVariants = cva(
+  'relative w-full rounded-2xl border-4 px-5 py-4 font-semibold shadow-[6px_6px_0px_0px_rgba(0,0,0,0.08)] transition-colors',
+  {
+    variants: {
+      tone: {
+        info: 'bg-[#E9F5FF] border-[#118AB2] text-[#0B2A3B]',
+        success: 'bg-[#E6F4EA] border-[#2F855A] text-[#1C4532]',
+        warning: 'bg-[#FFF7D6] border-[#D69E2E] text-[#422006]',
+        danger: 'bg-[#FFE5E5] border-[#D14343] text-[#58151C]',
+        neutral: 'bg-white border-black text-black',
+      },
+    },
+    defaultVariants: {
+      tone: 'info',
+    },
+  },
+);
+
+export interface NeobrutalAlertProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof alertVariants> {
+  icon?: React.ReactNode;
+}
+
+export const NeobrutalAlert = React.forwardRef<HTMLDivElement, NeobrutalAlertProps>(
+  ({ className, tone, icon, children, ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="neobrutal-alert"
+      role="alert"
+      className={cn(alertVariants({ tone }), className)}
+      {...props}
+    >
+      <div className="flex items-start gap-3">
+        {icon ? <span className="mt-0.5 text-lg" aria-hidden="true">{icon}</span> : null}
+        <div className="space-y-1 text-sm font-semibold leading-relaxed">{children}</div>
+      </div>
+    </div>
+  ),
+);
+
+NeobrutalAlert.displayName = 'NeobrutalAlert';
+
+export const NeobrutalAlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(
+  ({ className, ...props }, ref) => (
+    <p
+      ref={ref}
+      data-slot="neobrutal-alert-title"
+      className={cn('text-base font-black tracking-tight', className)}
+      {...props}
+    />
+  ),
+);
+
+NeobrutalAlertTitle.displayName = 'NeobrutalAlertTitle';
+
+export const NeobrutalAlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    data-slot="neobrutal-alert-description"
+    className={cn('text-sm font-medium text-current', className)}
+    {...props}
+  />
+));
+
+NeobrutalAlertDescription.displayName = 'NeobrutalAlertDescription';
+

--- a/src/components/ui/CommentsSection.tsx
+++ b/src/components/ui/CommentsSection.tsx
@@ -2,6 +2,11 @@
 
 import { FormEvent, useCallback, useEffect, useState } from 'react';
 import { Loader2, MessageCircle, Send } from 'lucide-react';
+import {
+  NeobrutalAlert,
+  NeobrutalAlertDescription,
+  NeobrutalAlertTitle,
+} from '@/components/neobrutal/alert';
 
 interface CommentAuthor {
   id: string | null;
@@ -163,11 +168,12 @@ export function CommentsSection({ postSlug }: CommentsSectionProps) {
         <h2 className="text-2xl font-black">Join the discussion</h2>
       </div>
 
-      {hasError && (
-        <div className="mb-4 rounded-md border-2 border-red-300 bg-red-50 p-4 text-red-700" role="alert">
-          {hasError}
-        </div>
-      )}
+      {hasError ? (
+        <NeobrutalAlert tone="danger" className="mb-4">
+          <NeobrutalAlertTitle>Comments are temporarily unavailable</NeobrutalAlertTitle>
+          <NeobrutalAlertDescription>{hasError}</NeobrutalAlertDescription>
+        </NeobrutalAlert>
+      ) : null}
 
       <form className="mb-6 space-y-3" onSubmit={handleSubmit}>
         <label htmlFor="comment-body" className="block text-sm font-semibold text-gray-700">
@@ -206,18 +212,18 @@ export function CommentsSection({ postSlug }: CommentsSectionProps) {
             )}
           </button>
         </div>
-        {submissionMessage && (
-          <p
-            className={`rounded-md border px-3 py-2 text-sm ${
-              submissionState === 'error'
-                ? 'border-red-200 bg-red-50 text-red-700'
-                : 'border-green-200 bg-green-50 text-green-700'
-            }`}
+        {submissionMessage ? (
+          <NeobrutalAlert
+            tone={submissionState === 'error' ? 'danger' : 'success'}
+            className="mt-2"
             role="status"
           >
-            {submissionMessage}
-          </p>
-        )}
+            <NeobrutalAlertTitle>
+              {submissionState === 'error' ? 'We could not submit your comment' : 'Comment received'}
+            </NeobrutalAlertTitle>
+            <NeobrutalAlertDescription>{submissionMessage}</NeobrutalAlertDescription>
+          </NeobrutalAlert>
+        ) : null}
       </form>
 
       {isLoading ? (

--- a/src/components/ui/GeneratePostButton.tsx
+++ b/src/components/ui/GeneratePostButton.tsx
@@ -1,93 +1,39 @@
 "use client";
 
-import React, { useState } from 'react';
+import React from 'react';
 import { Sparkles } from 'lucide-react';
-import { useLoader } from '@/context/LoaderContext';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/neobrutal/alert-dialog';
 
 export default function GeneratePostButton() {
-  const { startLoading, stopLoading } = useLoader();
-  const [isOpen, setIsOpen] = useState(false);
-  const [generatedContent, setGeneratedContent] = useState<string | null>(null);
-
-  const handleGenerate = async () => {
-    // Start the AI generation loader animation
-    startLoading('ai-generate');
-    
-    try {
-      // In a real app, this would be an API call to an AI service
-      // For demo purposes, we'll simulate a response after a delay
-      await new Promise(resolve => setTimeout(resolve, 3000));
-      
-      // Sample generated content
-      const aiContent = `# The Future of Machine Learning
-      
-## Introduction
-
-Machine learning continues to evolve at a rapid pace, transforming industries and creating new possibilities for innovation. This article explores the latest trends and future directions in the field.
-
-## Key Trends
-
-1. **Multimodal Learning**: Systems that can process and understand multiple types of data simultaneously.
-2. **Few-Shot Learning**: Models that can learn from minimal examples.
-3. **Explainable AI**: Making black-box models more transparent and interpretable.
-
-## Practical Applications
-
-The advancements in machine learning are enabling new applications across healthcare, finance, transportation, and more. Organizations are leveraging these technologies to improve decision-making, automate processes, and create more personalized experiences.
-
-## Conclusion
-
-As machine learning continues to mature, we can expect to see more sophisticated applications that blend seamlessly into our daily lives, augmenting human capabilities rather than replacing them.`;
-      
-      setGeneratedContent(aiContent);
-      setIsOpen(true);
-    } catch (error) {
-      console.error('Error generating content:', error);
-    } finally {
-      stopLoading();
-    }
-  };
-
   return (
-    <>
-      <button
-        type="button"
-        onClick={handleGenerate}
-        className="neo-button flex items-center space-x-2 py-2 px-4"
-      >
-        <Sparkles size={16} />
-        <span>Generate Post</span>
-      </button>
-      
-      {isOpen && generatedContent && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="neo-container bg-white p-6 max-w-4xl w-full h-[80vh] overflow-auto">
-            <h3 className="text-2xl font-bold mb-4">Generated Content</h3>
-            <div className="mb-6 whitespace-pre-wrap font-mono text-sm bg-gray-50 p-4 border border-gray-200 rounded">
-              {generatedContent}
-            </div>
-            <div className="flex justify-between">
-              <button
-                type="button"
-                onClick={() => {
-                  navigator.clipboard.writeText(generatedContent);
-                  alert('Content copied to clipboard!');
-                }}
-                className="neo-button py-2 px-4 bg-green-300"
-              >
-                Copy to Clipboard
-              </button>
-              <button
-                type="button"
-                onClick={() => setIsOpen(false)}
-                className="neo-button py-2 px-4"
-              >
-                Close
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-    </>
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <button type="button" className="neo-button flex items-center space-x-2 py-2 px-4">
+          <Sparkles size={16} />
+          <span>Generate Post</span>
+        </button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>The AI generator is not live yet</AlertDialogTitle>
+          <AlertDialogDescription>
+            We are still connecting the automated drafting workflow. For now, you can start from one of the existing
+            articles or our internal templates while we finish the integration.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogAction>Got it</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/src/components/ui/HeroSection.tsx
+++ b/src/components/ui/HeroSection.tsx
@@ -16,39 +16,37 @@ export const HeroSection = () => {
         <div className="max-w-4xl mx-auto">
           <div className="flex flex-col items-center text-center mb-10">
             <div className="inline-block bg-[#FF5252] text-white px-4 py-1 text-sm font-bold mb-6 transform -rotate-2">
-              Welcome to the digital brew
+              Build log in progress
             </div>
             <h1 className="text-5xl md:text-7xl font-black mb-6 leading-tight">
               Where{' '}
               <span className="bg-[#6C63FF] text-white px-2 py-1 inline-block transform rotate-1">
-                Code
+                Syntax
               </span>{' '}
               Meets{' '}
               <span className="bg-[#FF5252] text-white px-2 py-1 inline-block transform -rotate-1">
-                Conversation
+                Candor
               </span>
             </h1>
             <h2 className="text-2xl md:text-3xl font-extrabold uppercase tracking-wider text-gray-700 mb-6">
-              Machine Learning Tutorials · Data Science Playbooks · Quantum Computing Deep Dives
+              Build updates · Documentation · Release notes
             </h2>
             <p className="text-xl md:text-2xl mb-10 max-w-2xl">
-              From applied AI walkthroughs and coding tutorials to product reviews and creator conversations, we brew content
-              that&apos;s both educational and entertaining.
+              Syntax &amp; Sips is an open journal about building our editorial platform. Read honest progress
+              updates, peek at the docs we&apos;re writing, and see what ships in real time.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 sm:gap-6">
               <Link
                 href="/blogs"
                 className="bg-black text-white px-6 py-3 text-lg font-bold rounded-md transform transition hover:translate-y-[-2px] hover:shadow-[4px_4px_0px_0px_rgba(108,99,255)] text-center"
               >
-                Read Latest Blog
+                Read the latest post
               </Link>
               <Link
-                href="https://youtube.com/@syntaxandsips"
-                target="_blank"
-                rel="noopener noreferrer"
+                href="/changelog"
                 className="border-4 border-black bg-white px-6 py-3 text-lg font-bold rounded-md flex items-center justify-center gap-2 transform transition hover:translate-y-[-2px] hover:shadow-[4px_4px_0px_0px_rgba(255,82,82)]"
               >
-                Watch on YouTube <ArrowRight className="w-5 h-5" />
+                View the changelog <ArrowRight className="w-5 h-5" />
               </Link>
             </div>
           </div>

--- a/src/components/ui/NewBlogCard.tsx
+++ b/src/components/ui/NewBlogCard.tsx
@@ -5,6 +5,15 @@ import Link from 'next/link';
 import { MoreHorizontal, Calendar, Clock } from 'lucide-react';
 
 import { NeobrutalCard } from '@/components/neobrutal/card';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/neobrutal/alert-dialog';
 
 interface BlogCardProps {
   title: string;
@@ -44,6 +53,8 @@ export function NewBlogCard({
 }: BlogCardProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [dialogContent, setDialogContent] = useState({ title: '', description: '' });
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -57,32 +68,65 @@ export function NewBlogCard({
     };
   }, []);
 
+  const openDialog = (title: string, description: string) => {
+    setDialogContent({ title, description });
+    setIsDialogOpen(true);
+  };
+
   const handleShare = () => {
     if (navigator.share) {
-      navigator.share({
-        title: title,
-        text: excerpt,
-        url: window.location.origin + '/blogs/' + slug,
-      }).catch(console.error);
+      navigator
+        .share({
+          title,
+          text: excerpt,
+          url: `${window.location.origin}/blogs/${slug}`,
+        })
+        .catch((shareError) => {
+          console.error('Native share failed', shareError);
+          openDialog(
+            'Unable to open the native share dialog',
+            'Copy the link manually or use the copy shortcut in your browser while we improve this flow.',
+          );
+        });
     } else {
-      // Fallback for browsers that don't support the Web Share API
-      navigator.clipboard.writeText(window.location.origin + '/blogs/' + slug)
-        .then(() => alert('Link copied to clipboard!'))
-        .catch(console.error);
+      const shareUrl = `${window.location.origin}/blogs/${slug}`;
+
+      if (navigator.clipboard?.writeText) {
+        navigator.clipboard
+          .writeText(shareUrl)
+          .then(() => {
+            openDialog('Link copied to your clipboard', 'Paste it anywhere to share this post.');
+          })
+          .catch((clipboardError) => {
+            console.error('Clipboard copy failed', clipboardError);
+            openDialog(
+              'Copying is not supported here',
+              'Please highlight the URL from your address bar and copy it manually.',
+            );
+          });
+      } else {
+        openDialog(
+          'Copying is not available in this browser',
+          'Please copy the link from your address bar to share the article.',
+        );
+      }
     }
     setMenuOpen(false);
   };
 
   const handleGenerateWithAI = () => {
-    // This would be implemented with your AI generation functionality
-    alert('Generate with AI functionality would go here');
+    openDialog(
+      'AI drafting is still on the roadmap',
+      'We are testing assisted writing workflows internally and will announce a beta once it is ready.',
+    );
     setMenuOpen(false);
   };
 
   const badgeColor = accentColor ?? getFallbackColor(categoryLabel);
 
   return (
-    <NeobrutalCard as="article" className="overflow-hidden p-0">
+    <>
+      <NeobrutalCard as="article" className="overflow-hidden p-0">
       <div className="space-y-4 p-6">
         <div className="flex justify-between items-start mb-4">
           <span
@@ -143,6 +187,19 @@ export function NewBlogCard({
           </Link>
         </div>
       </div>
-    </NeobrutalCard>
+      </NeobrutalCard>
+
+      <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{dialogContent.title}</AlertDialogTitle>
+            <AlertDialogDescription>{dialogContent.description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction onClick={() => setIsDialogOpen(false)}>Close</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/src/components/ui/NewsletterSection.tsx
+++ b/src/components/ui/NewsletterSection.tsx
@@ -61,10 +61,9 @@ export const NewsletterSection = () => {
             <div className="absolute -top-6 -left-6 w-12 h-12 bg-[#FFD166] border-4 border-black rounded-full" aria-hidden="true"></div>
             <div className="absolute -bottom-6 -right-6 w-12 h-12 bg-[#FF5252] border-4 border-black" aria-hidden="true"></div>
             <div className="text-center mb-6">
-              <h2 className="text-3xl font-black mb-2">Stay in the Loop</h2>
+              <h2 className="text-3xl font-black mb-2">Get launch emails</h2>
               <p className="text-lg">
-                Get the latest articles, tutorials, and updates delivered
-                straight to your inbox.
+                We only email when something new ships. Add your address below to hear about releases first.
               </p>
             </div>
             <form className="flex flex-col sm:flex-row gap-3" onSubmit={handleSubmit}>
@@ -104,7 +103,7 @@ export const NewsletterSection = () => {
               role={state === 'error' || state === 'success' ? 'status' : undefined}
               aria-live={state === 'error' || state === 'success' ? 'polite' : undefined}
             >
-              {message || 'We respect your privacy. Unsubscribe at any time.'}
+              {message || 'No spam, just occasional build notes. Unsubscribe whenever you like.'}
             </p>
           </div>
         </div>

--- a/src/components/ui/TopicsSection.tsx
+++ b/src/components/ui/TopicsSection.tsx
@@ -1,16 +1,30 @@
 "use client";
 
 import React from 'react';
-import {
-  Brain,
-  Database,
-  Atom,
-  Code,
-  FileText,
-  Star,
-  Youtube,
-  Gamepad2,
-} from 'lucide-react';
+import { FileText, NotebookPen, Rocket, Users } from 'lucide-react';
+
+const topicCards = [
+  {
+    icon: NotebookPen,
+    title: 'Build notes',
+    description: 'Short updates about what we shipped, what broke, and what we are learning.',
+  },
+  {
+    icon: FileText,
+    title: 'Living documentation',
+    description: 'Drafts of our internal docs become public references as soon as they are useful.',
+  },
+  {
+    icon: Rocket,
+    title: 'Release recaps',
+    description: 'Track the changelog and roadmap decisions that shape the Syntax & Sips platform.',
+  },
+  {
+    icon: Users,
+    title: 'Community feedback',
+    description: 'Requests, questions, and experiments shared by readers influence what we build next.',
+  },
+];
 
 export const TopicsSection = () => {
   return (
@@ -19,63 +33,24 @@ export const TopicsSection = () => {
         <div className="text-center mb-12">
           <h2 className="text-3xl md:text-4xl font-black mb-4">
             <span className="bg-white text-[#118AB2] px-3 py-1 inline-block transform -rotate-1">
-              Explore Our Topics
+              Follow the work
             </span>
           </h2>
           <p className="text-xl max-w-2xl mx-auto">
-            Dive into our diverse range of content spanning from cutting-edge
-            tech to casual entertainment
+            Everything we publish ties back to building Syntax &amp; Sips in public. These are the themes you will see the most.
           </p>
         </div>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8">
-          <TopicCard
-            icon={<Brain />}
-            title="Machine Learning"
-            color="#FF5252"
-            rotation="-rotate-2"
-          />
-          <TopicCard
-            icon={<Database />}
-            title="Data Science"
-            color="#06D6A0"
-            rotation="rotate-1"
-          />
-          <TopicCard
-            icon={<Atom />}
-            title="Quantum Computing"
-            color="#FFD166"
-            rotation="-rotate-1"
-          />
-          <TopicCard
-            icon={<Code />}
-            title="Coding Tutorials"
-            color="#6C63FF"
-            rotation="rotate-2"
-          />
-          <TopicCard
-            icon={<FileText />}
-            title="Tech Articles"
-            color="#118AB2"
-            rotation="rotate-1"
-          />
-          <TopicCard
-            icon={<Star />}
-            title="Reviews"
-            color="#FF5252"
-            rotation="-rotate-2"
-          />
-          <TopicCard
-            icon={<Youtube />}
-            title="Video Content"
-            color="#06D6A0"
-            rotation="rotate-2"
-          />
-          <TopicCard
-            icon={<Gamepad2 />}
-            title="Gaming"
-            color="#FFD166"
-            rotation="-rotate-1"
-          />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 md:gap-8">
+          {topicCards.map((card, index) => (
+            <TopicCard
+              key={card.title}
+              icon={<card.icon className="h-7 w-7" aria-hidden="true" />}
+              title={card.title}
+              description={card.description}
+              color={['#FF5252', '#06D6A0', '#FFD166', '#6C63FF'][index % 4]}
+              rotation={index % 2 === 0 ? '-rotate-2' : 'rotate-1'}
+            />
+          ))}
         </div>
       </div>
     </section>
@@ -85,23 +60,20 @@ export const TopicsSection = () => {
 interface TopicCardProps {
   icon: React.ReactNode;
   title: string;
+  description: string;
   color: string;
   rotation: string;
 }
 
-const TopicCard = ({ icon, title, color, rotation }: TopicCardProps) => {
+const TopicCard = ({ icon, title, description, color, rotation }: TopicCardProps) => {
   return (
     <div
-      className={`bg-white text-black border-4 border-black p-4 rounded-lg transform ${rotation} transition-all hover:scale-105 hover:shadow-[4px_4px_0px_0px_rgba(0,0,0)] cursor-pointer`}
+      className={`bg-white text-black border-4 border-black p-6 rounded-xl transform ${rotation} transition-all hover:scale-105 hover:shadow-[4px_4px_0px_0px_rgba(0,0,0)]`}
     >
-      <div
-        className="flex flex-col items-center text-center"
-        style={{
-          color: color,
-        }}
-      >
-        <div className="mb-3 text-3xl">{icon}</div>
+      <div className="flex flex-col items-start gap-3 text-left" style={{ color }}>
+        <div className="text-3xl">{icon}</div>
         <h3 className="font-bold text-lg text-black">{title}</h3>
+        <p className="text-sm text-black/70 leading-relaxed">{description}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- rewrite marketing-heavy homepage sections so the hero, topic list, and newsletter CTA accurately frame Syntax & Sips as a public build log
- replace podcasts, tutorials, videos, resources, and newsletter subpages with truthful status updates that surface the material available today and leave unshipped features empty
- add reusable neobrutal alert primitives and adopt them across auth forms, comments, and blog cards to replace intrusive browser alerts with consistent messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6b953709c832db7d57935311c5be0