### PR TITLE
docs: refresh README with tabler icon standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,10 @@ Welcome to **Syntax & Sips**, a Next.js 15 + Supabase editorial platform featuri
   - Maintain API specs (OpenAPI/Markdown) under `docs/api/`.
   - Document deployment runbooks and Supabase migrations in `docs/operations/`.
   - Provide troubleshooting FAQs for local setup, testing, and Supabase connectivity.
+- **README.md Formatting**:
+  - Preserve the hero layout that uses Tabler icon imagery pulled from `https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/outline/*.svg`.
+  - Section headings should include inline Tabler icons sized 22px to maintain consistency with the professional branding.
+  - Keep tone executive-ready: concise paragraphs, bulleted highlights, and updated module references when features evolve.
 - **Inline Comments**:
   - Explain *why* decisions were made; remove obsolete comments promptly.
   - Avoid obvious comments (e.g., `// increment i`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the SyntaxBlogs project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.7] - 2025-02-22
+
+### Changed
+
+- Refined documentation tone with a professional Tabler icon-driven README refresh that highlights core features, setup, and operations.
+- Added README formatting standards to `AGENTS.md` so future updates keep iconography and executive-ready messaging consistent.
+
 ## [1.12.6] - 2025-02-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,128 +1,129 @@
-# Syntax & Sips
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/outline/coffee.svg" alt="Coffee cup icon" width="32" height="32" />
+  <br />
+  Syntax &amp; Sips
+</h1>
 
-<p align="center"><strong>An editorial platform that fuses AI storytelling, human craftsmanship, and a bold neo-brutalist aesthetic.</strong></p>
+<p align="center"><strong>A next-generation editorial platform blending AI-assisted storytelling, human curation, and a neo-brutalist design system.</strong></p>
 
 <p align="center">
-  <a href="https://nextjs.org/">Next.js 15</a> ·
-  <a href="https://supabase.com/">Supabase</a> ·
-  <a href="https://tailwindcss.com/">Tailwind CSS</a> ·
-  <a href="https://www.framer.com/motion/">Framer Motion</a> ·
-  <a href="https://playwright.dev/">Playwright</a>
+  <a href="https://nextjs.org/">
+    <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/brand-nextjs.svg" alt="Next.js" width="20" height="20" />
+    Next.js 15
+  </a>
+  ·
+  <a href="https://supabase.com/">
+    <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/brand-supabase.svg" alt="Supabase" width="20" height="20" />
+    Supabase
+  </a>
+  ·
+  <a href="https://tailwindcss.com/">
+    <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/brand-tailwind.svg" alt="Tailwind CSS" width="20" height="20" />
+    Tailwind CSS
+  </a>
+  ·
+  <a href="https://www.framer.com/motion/">
+    <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/brand-framer-motion.svg" alt="Framer Motion" width="20" height="20" />
+    Framer Motion
+  </a>
+  ·
+  <a href="https://playwright.dev/">
+    <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/device-desktop-analytics.svg" alt="Playwright" width="20" height="20" />
+    Playwright
+  </a>
 </p>
 
-## At a Glance
+---
+
+## <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/outline/info-circle.svg" alt="Info" width="22" height="22" /> Overview
+
+Syntax &amp; Sips delivers an editorial suite for AI, ML, and deep-tech teams who need premium storytelling with operational rigor. The reader-facing experience showcases rich, multi-format content, while authenticated workspaces equip editors with analytics, governance tooling, and gamified engagement loops. Supabase powers authentication, content orchestration, and automation so the platform scales from prototype to production-ready deployments.
 
 - **Live deployment:** [https://www.syntax-blogs.prashant.sbs](https://www.syntax-blogs.prashant.sbs)
-- **Audience experience:** Multi-format content hubs with topic curation, inline code, AI-powered summaries, and rich media embeds. (`src/app`, `src/components/ui`).
-- **Editorial cockpit:** Authenticated admin workspace for analytics, publishing workflow, taxonomy stewardship, and community moderation. (`src/components/admin`).
-- **Modern foundations:** Next.js App Router, Supabase Auth, Edge Functions, and a component-driven design system ready for enterprise hardening. (`src/lib`, `supabase`).
-
-## Table of Contents
-
-- [Product Narrative](#product-narrative)
-- [Feature Highlights](#feature-highlights)
-- [Architecture & Tech Stack](#architecture--tech-stack)
-- [Data Model Snapshot](#data-model-snapshot)
-- [Experience Walkthrough](#experience-walkthrough)
-- [Getting Started](#getting-started)
-- [Development Playbooks](#development-playbooks)
-- [Testing & Quality](#testing--quality)
-- [Security & Compliance](#security--compliance)
-- [Deployment & Operations](#deployment--operations)
-- [Project Structure](#project-structure)
-- [Contributing](#contributing)
-- [License](#license)
-
-## Product Narrative
-
-Syntax & Sips is a fully featured editorial stack for teams telling stories about AI, machine learning, and deep tech. The public site celebrates content with oversized typography, kinetic micro-interactions, and accessible color palettes. Behind the scenes, editors gain a unified workspace to manage content velocity, audience growth, and governance in one place. Supabase anchors authentication, data access, and automation so the platform scales from prototype to production-ready deployment.
+- **Design language:** Neo-brutalist foundations with bold outlines, kinetic micro-interactions, and intentional accessibility choices.
+- **Governance:** Supabase-backed policies, analytics, and moderation tooling keep editorial operations accountable.
 
 <div align="center">
-  <img src=".github/images/Hero.png" alt="Syntax & Sips hero layout" width="100%" />
+  <img src=".github/images/Hero.png" alt="Syntax &amp; Sips hero layout" width="100%" />
 </div>
 
-## Feature Highlights
+---
+
+## <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/outline/hexagons.svg" alt="Highlights" width="22" height="22" /> Why Teams Love It
 
 ### Reader Experience
-
-- **Multi-channel storytelling:** Dedicated routes for blogs, tutorials, podcasts, videos, newsletters, and resource libraries to tailor each medium. (`src/app/blogs`, `src/app/podcasts`, `src/app/videos`, `src/app/tutorials`, `src/app/resources`).
-- **Rich article presentation:** Markdown, code snippets, callouts, and video embeds keep long-form content readable and actionable. (`src/components/ui/CodeBlock.tsx`, `src/components/ui/VideoEmbed.tsx`).
-- **AI-assisted recaps:** One-click summarization leans on Supabase functions to distill articles into shareable insights. (`src/components/ui/NewSummarizeButton.tsx`).
-- **Audience journeys:** Topic explorers, recommended reads, and changelog transparency build trust with returning readers. (`src/app/topics/page.tsx`, `src/app/changelog/page.tsx`).
+- **Multi-channel storytelling:** Dedicated hubs for blogs, tutorials, podcasts, videos, newsletters, and resource libraries. (`src/app/blogs`, `src/app/videos`, `src/app/podcasts`, `src/app/tutorials`, `src/app/resources`)
+- **Rich article presentation:** Markdown, code snippets, callouts, and video embeds tuned for readability. (`src/components/ui/CodeBlock.tsx`, `src/components/ui/VideoEmbed.tsx`)
+- **AI-assisted recaps:** One-click summarization with Supabase functions produces shareable insights. (`src/components/ui/NewSummarizeButton.tsx`)
+- **Audience journeys:** Topic explorers, changelog transparency, and curated recommendations keep readers engaged. (`src/app/topics/page.tsx`, `src/app/changelog/page.tsx`)
 
 ### Editorial Operations
-
-- **Secure admin authentication:** Supabase Auth + server checks guard the `/admin` routes. (`src/app/admin/page.tsx`, `src/components/auth/AdminLoginForm.tsx`).
-- **Dashboard intelligence:** Analytics cards and trend visualizations surface readership health at a glance. (`src/components/admin/DashboardOverview.tsx`, `src/components/admin/AnalyticsPanel.tsx`).
-- **Visual content workflow:** Filterable tables, inline status chips, and post detail drawers streamline publishing operations. (`src/components/admin/PostsTable.tsx`, `src/components/admin/PostForm.tsx`).
-- **Community moderation:** Review, approve, or archive reader comments from a live queue. (`src/components/admin/CommentsModeration.tsx`).
-- **Role-aware management:** Update profiles, roles, and permissions without leaving the console. (`src/components/admin/UserManagement.tsx`).
+- **Secure admin authentication:** Supabase Auth plus server-side guards protect `/admin`. (`src/app/admin/page.tsx`, `src/components/auth/AdminLoginForm.tsx`)
+- **Dashboard intelligence:** Analytics cards and trend visualizations reveal readership health instantly. (`src/components/admin/DashboardOverview.tsx`, `src/components/admin/AnalyticsPanel.tsx`)
+- **Workflow automation:** Filterable tables, inline status chips, and drawers streamline publishing cycles. (`src/components/admin/PostsTable.tsx`, `src/components/admin/PostForm.tsx`)
+- **Community stewardship:** Live moderation queues empower teams to review, approve, or archive comments. (`src/components/admin/CommentsModeration.tsx`)
+- **Role-aware management:** Update profiles, roles, and permissions without leaving the console. (`src/components/admin/UserManagement.tsx`)
 
 ### Platform Intelligence
+- **Supabase Edge Functions:** Drive newsletter lifecycle events and AI integrations with serverless routines. (`supabase/functions/newsletter-subscribe`)
+- **Design system cohesion:** Shared UI primitives deliver consistent neo-brutalism styling across screens. (`src/components/ui`, `src/components/theme-provider.tsx`)
+- **Performance-minded motion:** Framer Motion micro-interactions elevate delight while respecting Core Web Vitals. (`src/components/magicui`, `src/app/page.tsx`)
 
-- **Supabase Edge Functions:** Power newsletter lifecycle events and AI integrations with serverless functions. (`supabase/functions/newsletter-subscribe`).
-- **Neo-brutalist design system:** Shared components and theming utilities keep UX cohesive across surfaces. (`src/components/ui`, `src/components/theme-provider.tsx`).
-- **Performance-minded animations:** Framer Motion micro-interactions layer delight without sacrificing Core Web Vitals. (`src/components/magicui`, `src/app/page.tsx`).
+---
 
-## Architecture & Tech Stack
+## <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/outline/cpu.svg" alt="Stack" width="22" height="22" /> Architecture &amp; Stack
 
-### Core Stack
-
-| Layer | Technologies | Key Modules |
+| Layer | Tooling | Key Modules |
 | --- | --- | --- |
-| Presentation | Next.js App Router, Tailwind CSS, Lucide icons | `src/app`, `src/components/ui`, `src/styles` |
-| Interaction | Framer Motion, custom hooks, Radix Primitives | `src/components/magicui`, `src/hooks` |
-| Authentication | Supabase Auth, SSR helpers, middleware guards | `src/lib/supabase`, `src/middleware.ts` |
-| Data & APIs | Next.js route handlers, Supabase RPC, nodemailer | `src/app/api`, `supabase/functions` |
-| Tooling | Webpack chunk sync, ESLint, Playwright | `scripts/sync-webpack-chunks.js`, `eslint.config.mjs`, `playwright.config.ts` |
+| Presentation | Next.js App Router, Tailwind CSS, Radix, Lucide | `src/app`, `src/components/ui`, `src/styles` |
+| Interaction | Framer Motion, custom hooks, SWR patterns | `src/components/magicui`, `src/hooks` |
+| Authentication | Supabase Auth helpers, middleware guards | `src/lib/supabase`, `src/middleware.ts` |
+| Data &amp; APIs | Route handlers, Supabase RPC, edge functions | `src/app/api`, `supabase/functions` |
+| Tooling | ESLint, Prettier, Playwright, Webpack chunk sync | `eslint.config.mjs`, `scripts/sync-webpack-chunks.js`, `playwright.config.ts` |
 
 ### Service Topology
+- **Client:** Progressive enhancement with streaming routes, suspense boundaries, and accessible motion primitives.
+- **Server:** Next.js API routes orchestrate CRUD for posts, taxonomy, comments, and newsletter workflows. (`src/app/api/admin`)
+- **Database:** Supabase Postgres with RLS, migrations, and SQL helpers. (`supabase/migrations`)
+- **Automation:** Edge Functions handle newsletter subscriptions and AI summarization triggers. (`supabase/functions`)
 
-- **Client:** Progressive enhancement with SSR, streamed routes, and suspense boundaries.
-- **Server:** Next.js API routes orchestrate CRUD for posts, taxonomy, comments, and newsletter management. (`src/app/api/admin`).
-- **Database:** Supabase Postgres with row level security, migrations, and SQL helpers. (`supabase/migrations`).
-- **Automation:** Supabase Edge Functions handle newsletter subscribe events and AI summarization triggers. (`supabase/functions`).
+### Data Model Snapshot
 
-## Data Model Snapshot
-
-| Domain | Key Tables / Views | Purpose |
+| Domain | Tables / Views | Purpose |
 | --- | --- | --- |
 | Content | `posts`, `post_tags`, `categories`, `tags` | Authoring, categorization, scheduling |
-| Editorial Workflow | `profiles`, `roles`, `profile_roles` | Admin access, hierarchy, and permissions |
-| Engagement | `comments`, `newsletter_subscribers` | Reader participation and lifecycle programs |
+| Editorial Workflow | `profiles`, `roles`, `profile_roles` | Access control and permissions |
+| Engagement | `comments`, `newsletter_subscribers` | Community programs and lifecycle management |
 | Configuration | `site_settings` | Global branding, navigation, and operational toggles |
 
-> Review `supabase/migrations` for the authoritative schema and business logic, including triggers and RLS policies.
+> Review `supabase/migrations` for canonical schema changes, triggers, and row-level security policies.
 
-## Experience Walkthrough
+---
 
-1. **Discover stories:** Readers land on the home page hero with animated headlines and quick access to trending categories. (`src/app/page.tsx`).
-2. **Navigate content hubs:** Dedicated routes for each medium showcase curated content with tailored layouts. (`src/app/blogs`, `src/app/resources`).
-3. **Dive into detail:** Article pages stitch together markdown, code blocks, video embeds, and AI summary toggles. (`src/app/blogs/[slug]/page.tsx`, `src/app/blogs/[slug]/NewBlogPostClient.tsx`).
-4. **Engage and subscribe:** Newsletter capture and comment sections invite deeper community participation. (`src/app/newsletter/page.tsx`, `src/components/ui/CommentsSection.tsx`).
-5. **Admin login:** Authorized team members authenticate via `/admin/login` with Supabase-backed credentials. (`src/components/auth/AdminLoginForm.tsx`).
-6. **Manage the newsroom:** Editors monitor analytics, publish or edit posts, manage media, and adjust taxonomy settings from the admin dashboard. (`src/components/admin/AdminDashboard.tsx`, `src/components/admin/TaxonomyManager.tsx`, `src/components/admin/MediaLibraryDialog.tsx`).
+## <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/outline/route.svg" alt="Journey" width="22" height="22" /> Experience Blueprint
 
-Additional hero and dashboard visuals live under `.github/images` for reference.
+1. **Discover stories:** Animated hero headlines and trending categories greet visitors. (`src/app/page.tsx`)
+2. **Navigate content hubs:** Medium-specific layouts surface curated content per channel. (`src/app/blogs`, `src/app/tutorials`, `src/app/videos`)
+3. **Deep-dive into articles:** Summaries, code, and embeds keep long-form content actionable. (`src/components/ui`)
+4. **Engage with community:** Comments, newsletters, and gamified rewards boost retention. (`src/app/changelog/page.tsx`, `supabase/functions`)
+5. **Administer operations:** Dashboards, moderation queues, and role management keep teams aligned. (`src/components/admin`)
 
-## Getting Started
+---
+
+## <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/outline/rocket.svg" alt="Getting Started" width="22" height="22" /> Getting Started
 
 ### Prerequisites
-
-- Node.js 20+
-- npm 10+
-- Supabase project with the Syntax & Sips schema deployed
-- (Optional) Supabase CLI for local Postgres + auth emulation
+- Node.js 20+ and npm 10+
+- Supabase project with service role and anon keys
+- Optional: Supabase CLI for local development (`supabase start`)
 
 ### Installation
-
 ```bash
 npm install
 ```
 
 ### Environment Variables
-
-Create a `.env.local` file in the project root and supply Supabase credentials (never commit this file):
+Create `.env.local` in the project root:
 
 ```bash
 NEXT_PUBLIC_SUPABASE_URL=<your-supabase-url>
@@ -131,90 +132,68 @@ SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
 NEXT_PUBLIC_SITE_URL=https://www.syntax-blogs.prashant.sbs
 ```
 
-- The `NEXT_PUBLIC_*` keys enable client-side session handling.
-- The service role key must remain on the server—load it via secure secrets management only.
-- `NEXT_PUBLIC_SITE_URL` should point at the fully qualified domain serving the app (include the protocol). The production deployment is hosted at `https://www.syntax-blogs.prashant.sbs`.
-- Mirror production locally with `supabase start` if you use the Supabase CLI.
+- `NEXT_PUBLIC_*` keys power client-side session management.
+- Keep the service role key server-side only via secure secrets management.
+- Mirror production locally with `supabase start` to exercise migrations and RLS behavior.
 
 ### Database Setup
-
-Deploy migrations to your Supabase instance:
-
 ```bash
 supabase db push
 ```
 
-For a clean slate during development you can reset the local database:
-
+For a clean slate during development:
 ```bash
 supabase db reset --force
 ```
 
 ### Run the App
-
 ```bash
 npm run dev
 ```
 
-Visit [http://localhost:3000](http://localhost:3000) for the local reader experience (or the deployed instance at [https://www.syntax-blogs.prashant.sbs](https://www.syntax-blogs.prashant.sbs)) and `/admin` for authenticated tooling once your admin account is prepared.
+Visit [http://localhost:3000](http://localhost:3000) (and `/admin` for authenticated tooling once an admin account exists).
 
-## Development Playbooks
+---
+
+## <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/outline/shield-check.svg" alt="Quality" width="22" height="22" /> Operational Playbooks
 
 | Scenario | Command |
 | --- | --- |
 | Start development server with chunk sync | `npm run dev` |
 | Compile production assets | `npm run build` |
-| Serve the production build locally | `npm run start` |
-| Lint codebase | `npm run lint` |
-| Execute Playwright tests in headless mode | `npm run test` |
+| Serve production bundle locally | `npm run start` |
+| Lint the codebase | `npm run lint` |
+| Execute Playwright regression suites | `npm run test` |
 | Debug Playwright suites with UI runner | `npm run test:ui` |
 | Run headed browser tests | `npm run test:headed` |
 
-### Debugging Tips
+### Quality &amp; Observability
+- Playwright validates core journeys from authentication to publishing. Provide credentials via environment variables before running suites.
+- ESLint and TypeScript guard code quality; see `eslint.config.mjs` and `tsconfig.json` for project-wide rules.
+- Consult `QA_PRODUCTION_READINESS.md` for manual verification checklists before launch windows.
 
-- Next.js route handlers in `src/app/api` log useful context for Supabase queries; wire up `console` output or structured logging as needed.
-- Keep `scripts/sync-webpack-chunks.js` running during development to align generated chunk manifests with the Next.js build. (`scripts/sync-webpack-chunks.js`).
-- Supabase logs are accessible from the dashboard when evaluating row level security rules or cron triggers.
+### Security &amp; Compliance
+- Admin access requires Supabase-managed accounts with `profiles.is_admin = true`. (`src/app/admin/page.tsx`)
+- Secrets live exclusively in environment variables; never bundle credentials in the repository.
+- RLS policies gate reader data—inspect migrations prior to schema updates. (`supabase/migrations`)
+- Dedicated privacy, cookies, and disclaimer pages surface policy obligations. (`src/app/privacy/page.tsx`, `src/app/cookies/page.tsx`, `src/app/disclaimer/page.tsx`)
 
-## Testing & Quality
-
-Playwright safeguards critical user journeys from login to publishing. Provide credentials via environment variables before running end-to-end suites:
-
-```bash
-PLAYWRIGHT_TEST_BASE_URL=http://localhost:3000 \
-PLAYWRIGHT_E2E_EMAIL=<admin-email> \
-PLAYWRIGHT_E2E_PASSWORD=<admin-password> \
-npm run test
-```
-
-Linting is configured through `eslint.config.mjs`, and TypeScript types are enforced project-wide via `tsconfig.json`.
-
-Refer to `QA_PRODUCTION_READINESS.md` for manual verification checklists prior to launching new environments.
-
-## Security & Compliance
-
-- Admin access requires Supabase-managed accounts with the `profiles.is_admin` flag set to `true`. (`src/app/admin/page.tsx`).
-- Secrets live only in environment variables; never bundle credentials in the repository.
-- Row Level Security and Supabase policies gate access to reader data—review migrations before altering schemas. (`supabase/migrations`).
-- Communicate privacy, legal, cookies, and disclaimer obligations through dedicated content pages. (`src/app/privacy/page.tsx`, `src/app/cookies/page.tsx`, `src/app/disclaimer/page.tsx`).
-
-## Deployment & Operations
-
-Syntax & Sips deploys cleanly to Vercel, Netlify, or containerized infrastructure that supports Next.js 15.
-
-1. Configure environment variables for your target environment (Supabase URL, anon key, service role key).
-2. Apply database migrations and confirm the `newsletter-subscribe` Edge Function is deployed if you rely on email capture. (`supabase/functions/newsletter-subscribe`).
+### Deployment &amp; Operations
+1. Configure Supabase keys per environment (local, staging, production).
+2. Apply database migrations and confirm the `newsletter-subscribe` Edge Function is deployed. (`supabase/functions/newsletter-subscribe`)
 3. Run `npm run build` locally to validate the production bundle.
-4. Ship the build via your hosting provider and monitor Supabase logs plus application analytics for the first 24 hours.
+4. Deploy via Vercel, Netlify, or containerized infrastructure, then monitor Supabase logs and analytics within the first 24 hours.
 
-## Project Structure
+---
+
+## <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/outline/layout-grid-add.svg" alt="Structure" width="22" height="22" /> Project Structure
 
 ```
 .
 ├── src
-│   ├── app              # Next.js routes for readers, admin, marketing, and legal pages
+│   ├── app              # Next.js routes for reader, admin, marketing, and legal pages
 │   ├── components       # UI primitives, admin tooling, and design system modules
-│   ├── hooks            # Custom React hooks for session management and UI behavior
+│   ├── hooks            # Custom React hooks for sessions and UI behavior
 │   ├── lib              # Supabase clients, helpers, and configuration glue
 │   └── utils            # Shared types, formatters, and constants
 ├── supabase             # SQL migrations, seed references, and edge functions
@@ -224,14 +203,27 @@ Syntax & Sips deploys cleanly to Vercel, Netlify, or containerized infrastructur
 └── .github/images       # Marketing and documentation visuals
 ```
 
-## Contributing
+---
+
+## <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/outline/book.svg" alt="Documentation" width="22" height="22" /> Documentation &amp; Support
+- Deep dives on AI integrations, gamification strategy, and community programs live in [`docs/`](./docs).
+- Reference [`neobrutalismthemecomp.MD`](./neobrutalismthemecomp.MD) for design tokens and layout principles.
+- Supabase guidance and environment variables live alongside platform runbooks in [`docs/`](./docs) (expand as playbooks evolve).
+
+For questions or enhancements, open an issue or start a discussion—maintainers actively triage requests.
+
+---
+
+## <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/outline/pencil.svg" alt="Contributing" width="22" height="22" /> Contributing
 
 1. Fork the repository.
-2. Create a feature branch: `git checkout -b feature/amazing-feature`.
-3. Commit changes: `git commit -m "Add amazing feature"`.
-4. Push to your fork: `git push origin feature/amazing-feature`.
-5. Open a Pull Request describing the user impact and validation.
+2. Create a feature branch: `git checkout -b feature/your-feature`.
+3. Commit changes: `git commit -m "feat(scope): description"`.
+4. Push to your fork: `git push origin feature/your-feature`.
+5. Open a Pull Request describing motivation, user impact, and validation.
 
-## License
+---
 
-Licensed under the MIT License. See [LICENSE](LICENSE) for full terms.
+## <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/outline/license.svg" alt="License" width="22" height="22" /> License
+
+Licensed under the MIT License. See [LICENSE](LICENSE) for the full terms.


### PR DESCRIPTION
## Summary
- rewrite the README with an executive overview, feature breakdown, and setup guidance that leans on Tabler iconography
- add explicit README formatting standards to AGENTS.md so future updates keep the new structure intact
- log the documentation refresh in CHANGELOG.md for the 1.12.7 release entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6bc655c64832d82e5b2c269f42097