### PR TITLE
Fix docs route params and author application profile fallback

### DIFF
--- a/src/app/docs/[filename]/page.tsx
+++ b/src/app/docs/[filename]/page.tsx
@@ -80,8 +80,12 @@ export function generateStaticParams() {
 
 type DocsPageParams = { filename: string };
 
-async function DocPageImpl({ params }: { params: DocsPageParams }) {
-  const { filename: rawFilename } = params;
+type DocPageProps = {
+  params: Promise<DocsPageParams>;
+};
+
+export default async function DocPage({ params }: DocPageProps) {
+  const { filename: rawFilename } = await params;
 
   try {
     const resolvedFilename = resolveDocumentFilename(rawFilename);
@@ -110,14 +114,6 @@ async function DocPageImpl({ params }: { params: DocsPageParams }) {
     return notFound();
   }
 }
-
-const DocPage = DocPageImpl as unknown as ({
-  params,
-}: {
-  params: Promise<DocsPageParams>;
-}) => ReturnType<typeof DocPageImpl>;
-
-export default DocPage;
 
 async function renderMarkdown(markdown: string): Promise<string> {
   const [


### PR DESCRIPTION
## Summary
- await dynamic route params on the docs page to comply with the latest Next.js requirements
- add a fallback profile query when the Supabase `pronouns` column is absent so the author application still loads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6bfa5ea78832d991733747d739946