### PR TITLE
docs: refresh documentation suite for Syntax & Sips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the SyntaxBlogs project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.8] - 2025-02-26
+
+### Added
+
+- Introduced a documentation index along with dedicated setup, testing, and API reference guides under `docs/` to centralize onboarding resources.
+- Added TSDoc comments to Supabase helpers and utilities to clarify parameters, return values, and error handling expectations.
+
+### Changed
+
+- Reorganized the hero README with a full table of contents, expanded setup instructions, and direct links to supporting guides.
+- Updated changelog to reflect the documentation overhaul.
+
 ## [1.12.7] - 2025-02-22
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,34 @@
+# Syntax & Sips Documentation Index
+
+Welcome to the Syntax & Sips knowledge base. This index orients contributors to the supporting guides that complement the primary README. Each guide is version-controlled alongside the application so playbooks evolve with the product.
+
+## Directory Map
+
+| Area | File / Folder | Purpose |
+| --- | --- | --- |
+| Local setup | [`docs/setup/local-development.md`](./setup/local-development.md) | Install dependencies, configure Supabase, and run the app locally. |
+| Testing | [`docs/testing/README.md`](./testing/README.md) | Configure Playwright, seed data, and interpret reports. |
+| API reference | [`docs/api/README.md`](./api/README.md) | REST endpoints, request/response shapes, and authentication requirements. |
+| Architecture & roadmaps | [`docs/ai-integration-roadmap.md`](./ai-integration-roadmap.md) | Upcoming integrations, sequencing, and milestones. |
+| Gamification | [`docs/gamification-roadmap.md`](./gamification-roadmap.md) | XP, badges, and leaderboard planning. |
+| Community programs | [`docs/community-author-program.md`](./community-author-program.md) | Contributor workflows and program governance. |
+| Design system | [`neobrutalismthemecomp.MD`](../neobrutalismthemecomp.MD) | Visual language, components, and design tokens. |
+| SEO & content strategy | [`docs/seo/`](./seo) | Search audits, content planning, and visibility improvements. |
+| Code review guidelines | [`docs/code-review.md`](./code-review.md) | Architectural guardrails, component reuse, and performance advice. |
+
+## How to Use These Guides
+
+1. **Start with setup:** Configure your environment before running scripts or tests.
+2. **Read relevant playbooks:** Reference the guide that matches the feature or area you are updating.
+3. **Keep documentation fresh:** When code paths change, update the affected guide in the same pull request.
+4. **Cross-link resources:** Add backlinks between guides where workflows intersect (e.g., API routes that require Supabase migrations).
+5. **Document decisions:** Capture rationale for architectural choices and migrations in these guides so the team retains shared context.
+
+## Maintenance Workflow
+
+- Review documentation in code review checklists; a feature is not complete until its docs reflect reality.
+- Schedule quarterly audits to prune deprecated instructions and surface new learnings.
+- Track documentation updates in the changelog under the "Changed" section for transparency.
+- Encourage contributors to propose documentation issues via GitHub Discussions or Issues when gaps are discovered.
+
+Happy shipping!

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,239 @@
+# Syntax & Sips API Reference
+
+This document catalogues every Next.js route handler exposed under `/api`. All routes return JSON responses unless explicitly noted. Authenticated endpoints rely on Supabase sessions persisted via cookies; ensure requests include the browser session or service role key when using server-side clients.
+
+- **Base URL (local):** `http://localhost:3000`
+- **Base URL (production):** `https://www.syntax-blogs.prashant.sbs`
+- **Authentication:** Supabase Auth via cookies (`sb-access-token`, `sb-refresh-token`). Admin endpoints additionally verify `profiles.is_admin`.
+- **Rate limiting:** `src/lib/rate-limit.ts` provides in-memory throttling for high-risk flows (e.g., community submissions, author applications).
+
+## Contents
+
+1. [Public Content](#1-public-content)
+2. [Newsletter Lifecycle](#2-newsletter-lifecycle)
+3. [Search](#3-search)
+4. [Authentication](#4-authentication)
+5. [Profile & Media](#5-profile--media)
+6. [Gamification](#6-gamification)
+7. [Community Programs](#7-community-programs)
+8. [Admin Console](#8-admin-console)
+
+---
+
+## 1. Public Content
+
+| Method | Path | Description | Auth |
+| --- | --- | --- | --- |
+| GET | `/api/posts` | List published posts ordered by `published_at`. | Not required |
+| GET | `/api/posts/trending` | List top viewed posts. Accepts `limit` query (1-12). | Not required |
+| POST | `/api/posts/{slug}/view` | Increment view count via Supabase RPC `increment_post_views`. | Not required |
+| GET | `/api/posts/{slug}/comments` | Fetch approved comments for a published post. | Not required |
+| POST | `/api/posts/{slug}/comments` | Submit a new comment (pending moderation). | Session optional (anonymous allowed) |
+
+### GET /api/posts
+- **Response:** `{ posts: BlogListPost[] }` (see `src/lib/posts.ts`).
+- **Errors:** `500` on Supabase failure.
+
+### GET /api/posts/trending
+- **Query Parameters:** `limit` (optional, integer, default `6`).
+- **Response:** `{ posts: BlogListPost[] }`.
+- **Errors:** `500` on Supabase failure.
+
+### POST /api/posts/{slug}/view
+- **Body:** None.
+- **Response:** `{ views: number }` after invoking `increment_post_views`.
+- **Errors:** `404` if RPC returns no row, `500` on RPC error.
+
+### GET /api/posts/{slug}/comments
+- **Response:** `{ comments: Array<{ id, content, status, createdAt, author }> }` where `author` includes admin flag and primary role metadata.
+- **Errors:** `404` if post does not exist, `500` on Supabase failure.
+
+### POST /api/posts/{slug}/comments
+- **Body:** `{ content: string }` (minimum 10 characters).
+- **Response:** `201` with message confirming moderation queue entry.
+- **Errors:** `404` when post not found, `422` for validation errors, `500` on insert failure.
+
+---
+
+## 2. Newsletter Lifecycle
+
+| Method | Path | Description | Auth |
+| --- | --- | --- | --- |
+| POST | `/api/newsletter` | Start subscription workflow; emails a confirmation link. | Not required |
+| GET | `/api/newsletter/confirm` | Redirect-based confirmation using `token` and `email` query params. | Not required |
+| GET | `/api/newsletter/unsubscribe` | Redirect-based unsubscribe using `email` query param. | Not required |
+
+### POST /api/newsletter
+- **Body:** `{ email: string }`.
+- **Query Parameters:** `source` (optional) for attribution.
+- **Response:** `{ message: string }` with copy adjusted for resubscribes.
+- **Errors:** `422` invalid email, `500` on Supabase or Mailtrap failure.
+
+### GET /api/newsletter/confirm
+- **Query Parameters:** `token`, `email`.
+- **Response:** HTTP redirect to `/newsletter-confirmed?status={success|expired|invalid|error}`.
+
+### GET /api/newsletter/unsubscribe
+- **Query Parameters:** `email`.
+- **Response:** HTTP redirect to `/newsletter-unsubscribed?status={success|missing|invalid|error}`.
+
+---
+
+## 3. Search
+
+| Method | Path | Description | Auth |
+| --- | --- | --- | --- |
+| GET | `/api/search` | Full-text search across published posts. | Not required |
+
+- **Query Parameters:** `q` (required, string).
+- **Response:** `{ results: BlogListPost[] }` (limited to 20).
+- **Errors:** `500` on Supabase failure.
+
+---
+
+## 4. Authentication
+
+| Method | Path | Description | Auth |
+| --- | --- | --- | --- |
+| POST | `/api/auth/session` | Sync Supabase auth events from the client. | Requires Supabase session cookie |
+| GET | `/api/auth/me` | Return the authenticated profile, roles, and onboarding journey. | Requires Supabase session cookie |
+
+### POST /api/auth/session
+- **Body:** `{ event: 'SIGNED_IN' | 'SIGNED_OUT' | 'TOKEN_REFRESHED', session?: Session }`.
+- **Behavior:** Persists or clears Supabase session server-side using `supabase.auth.setSession` / `signOut`.
+- **Errors:** `400` missing required fields, `500` if Supabase session operations fail.
+
+### GET /api/auth/me
+- **Response:** `{ profileId, userId, email, displayName, roles, onboarding, ... }` (`AuthenticatedProfileSummary`).
+- **Errors:** `401` unauthenticated, `404` if profile not found, `500` on Supabase errors.
+
+---
+
+## 5. Profile & Media
+
+| Method | Path | Description | Auth |
+| --- | --- | --- | --- |
+| POST | `/api/profile/avatar` | Upload a new avatar image to Supabase Storage (bucket `profile-photos`). | Requires Supabase session cookie |
+
+### POST /api/profile/avatar
+- **Body:** `multipart/form-data` with `file` field (PNG, JPG, GIF, SVG, WebP up to 5 MB).
+- **Response:** `{ avatarUrl: string }` and removes any previous avatar owned by the profile.
+- **Errors:** `400` invalid payload or validation error, `401` unauthenticated, `500` storage failures.
+
+---
+
+## 6. Gamification
+
+| Method | Path | Description | Auth |
+| --- | --- | --- | --- |
+| GET | `/api/gamification/profile` | Return XP, badges, and streak data for the current or specified profile. | Requires Supabase session cookie; admin override to inspect others |
+| GET | `/api/gamification/challenges` | List active challenges with optional per-user progress. | Optional (progress requires session) |
+| GET | `/api/gamification/leaderboards` | Fetch leaderboard standings. Accepts `scope`, `category`, `limit`. | Not required |
+| POST | `/api/gamification/actions` | Record a gamification action (points, badge triggers). | Requires Supabase session cookie |
+
+### GET /api/gamification/profile
+- **Query Parameters:** `profileId` (optional; admin required to view others).
+- **Response:** Payload from `fetchGamificationProfile` containing totals, recent actions, badges, and streak metadata.
+
+### GET /api/gamification/challenges
+- **Response:** `{ challenges: Array<{ id, slug, rewardPoints, status, progress, ... }> }` with per-user progress when authenticated.
+
+### GET /api/gamification/leaderboards
+- **Query Parameters:**
+  - `scope`: `global` | `seasonal` | `category` (default `global`).
+  - `category`: optional slug when `scope=category`.
+  - `limit`: integer, default `10`.
+- **Response:** Leaderboard entries with profile display names, XP, and ranks.
+
+### POST /api/gamification/actions
+- **Body:** `{ profileId?, actionType?, metadata?, actionSource?, requestId? }` (defaults to the caller's profile and `custom.manual_adjustment`).
+- **Response:** `{ result }` from `recordAction`, including awarded points/badges.
+- **Errors:** `401` unauthenticated, `403` insufficient permissions, `404` profile not found, `500` processing errors.
+
+---
+
+## 7. Community Programs
+
+Endpoints orchestrate contributor submissions and author applications. All require authenticated Supabase sessions.
+
+| Method | Path | Description | Auth |
+| --- | --- | --- | --- |
+| GET | `/api/community/submissions` | List submissions created by the authenticated contributor. | Requires Supabase session cookie |
+| POST | `/api/community/submissions` | Create, autosave, or submit a draft. Validates via `communitySubmissionSchema`. | Requires Supabase session cookie |
+| POST | `/api/community/submissions/{id}/submit` | Force submit a draft for review. | Requires Supabase session cookie |
+| POST | `/api/community/submissions/{id}/withdraw` | Withdraw a submitted draft. | Requires Supabase session cookie |
+| POST | `/api/community/submissions/{id}/feedback` | Request editorial feedback with optional notes. | Requires Supabase session cookie |
+| POST | `/api/community/submissions/{id}/approve` | Approve submission (editorial staff). | Requires Supabase session cookie with staff privileges |
+| POST | `/api/community/submissions/{id}/decline` | Decline submission with rationale. | Requires Supabase session cookie with staff privileges |
+| GET | `/api/community/author-applications` | Return the latest author application for the session profile. | Requires Supabase session cookie |
+| POST | `/api/community/author-applications` | Submit or update an author application (HCaptcha required). | Requires Supabase session cookie |
+
+### Submission Payload (`POST /api/community/submissions`)
+- Refer to [`communitySubmissionSchema`](../../src/lib/validation/community.ts) for full shape.
+- Key fields: `title`, `summary`, `categories[]`, `tags[]`, `content`, `checklist`, `intent` (`autosave`, `save`, `submit`).
+- Autosave intent stores `last_autosaved_at`; submit enforces editorial checklist completion.
+- **Response:** `{ submission, message }`.
+- **Rate limiting:** 12 writes/minute per profile/IP.
+
+### Submission Transitions
+- Transition routes share a payload of `{ notes?: string }` and rely on `submissionTransitionSchema` within each handler to enforce valid states.
+- Responses return updated submission records or status messages; errors include `403` for permission issues, `409` for invalid state, `500` on Supabase failures.
+
+### Author Applications (`POST /api/community/author-applications`)
+- **Body:** Matches `authorApplicationSchema` including HCaptcha token.
+- **Behavior:** Deduplicates active applications (`submitted`, `under_review`, `accepted`, `needs_more_info`).
+- **Rate limiting:** 6 submissions/minute per profile/IP.
+- **Response:** `{ application, message }` for new or updated submissions.
+
+---
+
+## 8. Admin Console
+
+Admin routes require a Supabase session whose profile has `is_admin = true`. All routes return `401` or `403` if permissions are missing.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/admin/posts` | List all posts with full metadata for dashboard management. |
+| POST | `/api/admin/posts` | Create a new post. |
+| PATCH | `/api/admin/posts/{id}` | Update an existing post. |
+| DELETE | `/api/admin/posts/{id}` | Remove a post. |
+| GET | `/api/admin/users` | List profiles, roles, and admin flags. |
+| PATCH | `/api/admin/users/{id}` | Update profile attributes (roles, admin flag). |
+| DELETE | `/api/admin/users/{id}` | Remove a profile and corresponding Supabase auth user. |
+| GET | `/api/admin/comments` | List comments with moderation metadata. |
+| PATCH | `/api/admin/comments/{id}` | Update comment status or notes. |
+| DELETE | `/api/admin/comments/{id}` | Permanently remove a comment. |
+| GET | `/api/admin/community/queue` | Fetch submission queue with contributor info. |
+| GET | `/api/admin/gamification/analytics` | Return XP totals, streak summaries, and badge stats. |
+| GET | `/api/admin/gamification/challenges` | List challenges for management. |
+| POST | `/api/admin/gamification/challenges` | Create or update a challenge (upsert by slug). |
+| GET | `/api/admin/gamification/badges` | List configured badges. |
+| POST | `/api/admin/gamification/badges` | Create or update a badge (upsert by slug). |
+| POST | `/api/admin/media` | Generate signed upload URLs for Supabase Storage. |
+| GET | `/api/admin/settings` | Retrieve site settings (branding, navigation). |
+| PATCH | `/api/admin/settings` | Update site settings. |
+
+### Admin Payloads
+- **Posts:** JSON aligned with `AdminPost` (`@/utils/types`). Include `title`, `slug`, `content`, `status`, optional media URLs, category and tag IDs.
+- **Users:** Accepts role adjustments and admin toggles (`@/utils/types` → `AdminUser` / `AdminUserRole`).
+- **Comments:** Supports moderation transitions (`approved`, `rejected`, `pending`).
+- **Gamification:** Challenge and badge routes align with schemas in `@/lib/gamification` modules.
+- **Media:** `POST /api/admin/media` expects `{ fileName, contentType }` and responds with signed upload info.
+
+### Error Handling
+- All admin endpoints return structured errors: `{ error: string }` with appropriate HTTP status codes (`400` validation, `401/403` auth, `404` missing records, `409` state conflicts, `500` server errors).
+- Logs include contextual messages; review Vercel/Supabase logs for stack traces when debugging production incidents.
+
+---
+
+## Webhooks & Background Jobs
+
+- Supabase Edge Functions (e.g., `newsletter-subscribe`) complement these APIs for asynchronous tasks. Document additional webhooks alongside their function code when introduced.
+
+---
+
+## Versioning
+
+- Changes to endpoints should be reflected here and in [`CHANGELOG.md`](../../CHANGELOG.md).
+- For breaking changes, bump the major version and provide migration guidance.
+

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -1,0 +1,96 @@
+# Local Development Guide
+
+This guide walks through configuring Syntax & Sips on a local workstation. Follow each section sequentially to avoid missing prerequisites or secrets.
+
+## 1. Prerequisites
+
+| Requirement | Version | Notes |
+| --- | --- | --- |
+| Node.js | 20.x LTS | Use `nvm`, Volta, or fnm to pin the version. |
+| npm | 10.x | Ships with Node 20.x. |
+| Supabase CLI | Latest | Optional but recommended for managing migrations. Install with `npm install -g supabase`. |
+| Git | Latest stable | Required for cloning and managing branches. |
+| Mailtrap (or SMTP provider) | N/A | Needed to exercise newsletter confirmation flows locally. |
+
+## 2. Clone and Install
+
+```bash
+git clone https://github.com/your-org/Syntax-blogs.git
+cd Syntax-blogs
+npm install
+```
+
+> Run `npm install` whenever dependencies change in `package.json` to keep `package-lock.json` up to date.
+
+## 3. Environment Configuration
+
+1. Copy `.env.example` (if present) or create `.env.local` from scratch.
+2. Populate the variables described below:
+
+| Variable | Purpose | Where to Find |
+| --- | --- | --- |
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase REST URL | Supabase dashboard → Project Settings → API |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public anon key | Supabase dashboard → Project Settings → API |
+| `SUPABASE_SERVICE_ROLE_KEY` | Server-side operations (RLS bypass) | Supabase dashboard → Project Settings → API (service_role) |
+| `NEXT_PUBLIC_SITE_URL` | Absolute origin for metadata and sharing | Use `http://localhost:3000` in development |
+| `MAILTRAP_USER` / `MAILTRAP_PASS` | SMTP credentials for newsletter confirmations | Mailtrap Inboxes → SMTP credentials |
+| `MAILTRAP_FROM_EMAIL` / `MAILTRAP_FROM_NAME` | Sender identity | Choose a friendly from address, e.g., `noreply@syntax-blogs.test` |
+
+Store secrets securely (1Password, Vault, environment-specific secret stores). Never commit `.env.local`.
+
+## 4. Supabase Setup
+
+```bash
+# Authenticate and link to your project once
+supabase login
+supabase link --project-ref <your-project-ref>
+
+# Push migrations and seed data
+supabase db push
+
+# Optional: start Supabase locally (Docker required)
+supabase start
+```
+
+- Run `supabase db reset --force` to drop and recreate the database during testing.
+- Keep migrations in sync with the remote project to avoid drift.
+
+## 5. Running the App
+
+```bash
+npm run dev
+```
+
+- Visit `http://localhost:3000` for the public site.
+- Access the admin console at `http://localhost:3000/admin` (requires an admin-enabled Supabase user).
+- Use `npm run start` after `npm run build` to simulate production locally.
+
+## 6. Creating an Admin User
+
+1. Sign up through the public UI or Supabase Auth portal.
+2. In Supabase, update the user's profile record:
+   ```sql
+   update profiles set is_admin = true where email = 'you@example.com';
+   ```
+3. Re-authenticate to refresh permissions.
+
+## 7. Optional Tooling
+
+- **Chunk synchronisation:** `scripts/sync-webpack-chunks.js` keeps dynamic import manifests consistent across dev/build commands.
+- **Browser automation:** Install Playwright browsers with `npx playwright install` before running the end-to-end suite.
+- **Type checking:** Add a `type-check` script (`tsc --noEmit`) if you need strict compilation outside of Next.js builds.
+
+## 8. Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| `Module not found: Can't resolve 'nodemailer'` during `npm run build` | Ensure `npm install` completed and `node_modules` exists. |
+| Newsletter confirmation never arrives | Verify `MAILTRAP_*` credentials and confirm the inbox is active. |
+| Supabase calls fail during `next build` | Provide environment variables in the build environment or guard `generateStaticParams` calls for offline builds. |
+| Avatar uploads fail with `Unauthorized` | Confirm you are signed in and that Supabase `profiles` entry exists for the user. |
+
+## 9. Next Steps
+
+- Read [`docs/testing/README.md`](../testing/README.md) to configure Playwright for CI and local development.
+- Explore [`docs/api/README.md`](../api/README.md) for endpoint contracts used by the front-end and partner integrations.
+- Update this guide when adding new environment variables, scripts, or onboarding steps.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,72 @@
+# Testing Playbook
+
+This playbook captures how Syntax & Sips validates quality across environments. It currently focuses on Playwright-based end-to-end coverage and outlines how to extend into unit and integration tests.
+
+## 1. Test Matrix
+
+| Layer | Tool | Status | Notes |
+| --- | --- | --- | --- |
+| End-to-end | Playwright (`@playwright/test`) | Configured | Suites live in `tests/*.spec.ts`. |
+| Component / unit | Vitest (planned) | Pending | Add when component coverage is required. |
+| Accessibility | Axe / Playwright | Pending | Integrate via Playwright fixtures once UI stabilises. |
+| Performance | Web Vitals logging | Partial | Metrics emitted via `src/lib/analytics/report-web-vitals.ts`. |
+
+## 2. Environment Preparation
+
+1. Install dependencies: `npm install`.
+2. Install browsers: `npx playwright install` (run once per machine or CI agent).
+3. Provide Supabase environment variables (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`).
+4. Seed baseline content using `supabase db push` or import fixtures through the admin UI.
+5. Configure newsletter SMTP credentials if tests exercise subscription flows (`MAILTRAP_*`).
+
+## 3. Running the Suite
+
+| Command | Purpose |
+| --- | --- |
+| `npm run test` | Execute the Playwright suite headlessly (CI default). |
+| `npm run test:ui` | Launch the Playwright UI runner for interactive debugging. |
+| `npm run test:headed` | Run in headed mode with a visible browser window. |
+
+Tests default to Chromium. Override via `npx playwright test --project=firefox` if cross-browser validation is required.
+
+## 4. Test Data & Auth
+
+- Use Supabase policies to create dedicated test users and flag them with non-production roles.
+- When running locally, sign in once in the UI; Playwright preserves authenticated state in `tests/.auth` (configure via fixtures as needed).
+- Reset state between runs using Playwright hooks (`test.beforeEach`) or Supabase `db reset` commands.
+
+## 5. Reporting & Diagnostics
+
+- Enable traces in CI by exporting `PLAYWRIGHT_JUNIT_OUTPUT_NAME` or using the `--reporter=line,junit` flag.
+- Store HTML reports with `npx playwright show-report` after a run.
+- Document failures and resolutions in [`tests/build-verification.md`](../build-verification.md) for historical context.
+
+## 6. Adding New Tests
+
+1. Co-locate specs in `tests/` with descriptive filenames (`feature-name.spec.ts`).
+2. Prefer `test.step` blocks to clarify multi-stage flows.
+3. Wrap network-dependent logic with retries and provide deterministic fixtures for Supabase responses when possible.
+4. Gate expensive journeys (e.g., newsletter flow) behind tagged tests: `test.describe.configure({ mode: 'serial' })` for stateful flows.
+
+## 7. Extending Coverage
+
+- **Unit tests:** Introduce Vitest alongside Testing Library for UI components. Mirror docs in this playbook when the stack is finalised.
+- **Accessibility:** Add `@axe-core/playwright` to capture WCAG regressions as part of nightly runs.
+- **Performance:** Capture Core Web Vitals through `sendToAnalytics` and alert when values regress. (`src/lib/analytics/report-web-vitals.ts`)
+
+## 8. CI Integration
+
+- Run `npm run lint`, `npm run test`, and `npm run build` in pull request workflows.
+- Cache `~/.cache/ms-playwright` to speed up Playwright browser installation on CI.
+- Fail the pipeline if Playwright exits non-zero; upload traces and screenshots as build artifacts for debugging.
+
+## 9. Troubleshooting
+
+| Symptom | Resolution |
+| --- | --- |
+| `Error: useSignInWithEmail` cannot reach Supabase | Ensure environment variables are present in `process.env` for the Playwright run. |
+| Tests hang on newsletter confirmation | Seed Mailtrap inbox credentials and allow outbound SMTP or stub the transport layer. |
+| `page.goto` times out | Increase `test.setTimeout` for data-heavy pages or warm the database with fixtures. |
+| CI fails due to missing browsers | Run `npx playwright install --with-deps` during pipeline setup. |
+
+Keep this playbook current by documenting new fixtures, utilities, or CI conventions as they are introduced.

--- a/src/lib/analytics/report-web-vitals.ts
+++ b/src/lib/analytics/report-web-vitals.ts
@@ -2,6 +2,14 @@ import type { NextWebVitalsMetric } from 'next/app'
 
 const roundToFourDecimals = (value: number) => Math.round(value * 10000) / 10000
 
+/**
+ * Forward Next.js Web Vitals metrics to analytics providers.
+ *
+ * Prefers Google Analytics (`gtag`) but gracefully falls back to pushing events into
+ * a generic `dataLayer` when available.
+ *
+ * @param {NextWebVitalsMetric} metric Metric payload emitted by Next.js.
+ */
 export const sendToAnalytics = (metric: NextWebVitalsMetric) => {
   if (typeof window === 'undefined') {
     return

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -24,6 +24,12 @@ interface CommentRecord {
   } | null
 }
 
+/**
+ * Fetch approved comments for a specific post.
+ *
+ * @param {string} postId Identifier of the post whose comments should be returned.
+ * @returns {Promise<PostComment[]>} Chronologically ordered comments with author metadata.
+ */
 export const getApprovedCommentsForPost = async (postId: string): Promise<PostComment[]> => {
   const supabase = createServiceRoleClient()
 

--- a/src/lib/newsletter.ts
+++ b/src/lib/newsletter.ts
@@ -31,6 +31,17 @@ export type SaveSubscriberResult = {
   wasResent: boolean
 }
 
+/**
+ * Upsert a newsletter subscriber and return a confirmation token.
+ *
+ * Existing subscribers are refreshed with a new confirmation token and metadata snapshot.
+ *
+ * @param {string} email Email address supplied by the user.
+ * @param {string} source Marketing attribution source (e.g., `web`, `footer`).
+ * @param {UpsertMetadata} [metadata] Optional metadata including user agent and referer information.
+ * @returns {Promise<SaveSubscriberResult>} Confirmation token and whether the record already existed.
+ * @throws {Error} When Supabase queries or mutations fail.
+ */
 export const saveSubscriber = async (
   email: string,
   source: string,
@@ -102,6 +113,14 @@ export const saveSubscriber = async (
 
 type ConfirmSubscriberResult = 'confirmed' | 'expired' | 'not-found'
 
+/**
+ * Confirm a pending subscriber using the emailed token.
+ *
+ * @param {string} email Email address associated with the subscription.
+ * @param {string} token Confirmation token provided in the confirmation link.
+ * @returns {Promise<ConfirmSubscriberResult>} `'confirmed'`, `'expired'`, or `'not-found'` to indicate outcome.
+ * @throws {Error} When Supabase operations fail unexpectedly.
+ */
 export const confirmSubscriber = async (
   email: string,
   token: string,
@@ -162,6 +181,13 @@ export const confirmSubscriber = async (
 
 type UnsubscribeResult = 'ok' | 'missing'
 
+/**
+ * Mark a subscriber as unsubscribed.
+ *
+ * @param {string} email Email address to unsubscribe.
+ * @returns {Promise<UnsubscribeResult>} `'ok'` on success or `'missing'` when the email has no record.
+ * @throws {Error} When Supabase queries or updates fail.
+ */
 export const unsubscribeSubscriber = async (
   email: string,
 ): Promise<UnsubscribeResult> => {

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -190,6 +190,14 @@ const mapDetailPost = (record: PostDetailRecord, author: AuthorRecord | null): B
   socialImageUrl: record.social_image_url ?? null,
 })
 
+/**
+ * Retrieve all posts that have been published.
+ *
+ * The result is cached via `react`'s `cache` helper to prevent duplicate Supabase roundtrips
+ * during the same request lifecycle.
+ *
+ * @returns {Promise<BlogListPost[]>} Array of normalized blog posts ordered by `published_at` descending.
+ */
 export const getPublishedPosts = cache(async () => {
   const supabase = createServiceRoleClient()
 
@@ -214,6 +222,12 @@ export const getPublishedPosts = cache(async () => {
   }
 })
 
+/**
+ * Fetch the most viewed published posts.
+ *
+ * @param {number} [limit=6] Upper bound of results to return (values outside 1-12 are coerced).
+ * @returns {Promise<BlogListPost[]>} Ranked list of posts ordered by view count.
+ */
 export const getTrendingPosts = async (limit = 6) => {
   const supabase = createServiceRoleClient()
 
@@ -239,6 +253,13 @@ export const getTrendingPosts = async (limit = 6) => {
   }
 }
 
+/**
+ * Load a single published post by slug, including author, SEO metadata, and tag information.
+ *
+ * @param {string} slug URL slug associated with the post.
+ * @returns {Promise<BlogPostDetail | null>} Detailed post payload or `null` when not found.
+ * @throws {Error} When Supabase returns an unexpected error that is not related to optional columns.
+ */
 export const getPublishedPostBySlug = cache(async (slug: string) => {
   const supabase = createServiceRoleClient()
 
@@ -337,6 +358,13 @@ export const getPublishedPostBySlug = cache(async (slug: string) => {
   return mapDetailPost(record, author)
 })
 
+/**
+ * Perform a case-insensitive search across published posts using Supabase `ilike` filters.
+ *
+ * @param {string} query Raw search query supplied by the caller.
+ * @param {number} [limit=12] Maximum number of matches to return.
+ * @returns {Promise<BlogListPost[]>} Posts whose title, excerpt, or content matches the query.
+ */
 export const searchPublishedPosts = async (query: string, limit = 12) => {
   const supabase = createServiceRoleClient()
 
@@ -377,6 +405,15 @@ export const searchPublishedPosts = async (query: string, limit = 12) => {
   }
 }
 
+/**
+ * Derive a set of related posts based on shared tags and optional category alignment.
+ *
+ * @param {string} postId Identifier for the post to exclude from the result set.
+ * @param {string | null} categorySlug Category slug used for secondary relevance scoring.
+ * @param {string[]} tagNames List of tag names associated with the source post.
+ * @param {number} [limit=3] Desired number of related posts; falls back to recency when insufficient matches exist.
+ * @returns {Promise<BlogListPost[]>} Ranked list of related posts.
+ */
 export const getRelatedPosts = async (postId: string, categorySlug: string | null, tagNames: string[], limit = 3) => {
   const supabase = createServiceRoleClient()
 
@@ -436,6 +473,11 @@ export const getRelatedPosts = async (postId: string, categorySlug: string | nul
   }
 }
 
+/**
+ * Fetch all slugs for published posts.
+ *
+ * @returns {Promise<string[]>} Array of slugs suitable for static generation.
+ */
 export const getPublishedSlugs = cache(async () => {
   const supabase = createServiceRoleClient()
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -21,6 +21,13 @@ export interface RateLimitResult {
   reset: number
 }
 
+/**
+ * Track the number of invocations per key within a sliding time window.
+ *
+ * @param {string} key Unique identifier for the limiter (e.g., `route:userId:ip`).
+ * @param {RateLimitOptions} [options] Optional limit configuration (default: 5 requests per 60s).
+ * @returns {RateLimitResult} Result containing success flag, remaining allowance, and reset timestamp.
+ */
 export const rateLimit = (
   key: string,
   { windowMs = 60_000, limit = 5 }: RateLimitOptions = {}

--- a/src/lib/sanitize-markdown.ts
+++ b/src/lib/sanitize-markdown.ts
@@ -18,6 +18,15 @@ const extendAttributes = (tag: string, attributes: AllowedAttribute[]) => {
   return Array.from(merged)
 }
 
+/**
+ * Sanitise Markdown content before rendering in the browser.
+ *
+ * Extends the default `sanitize-html` configuration to allow additional tags and
+ * attributes used by Syntax & Sips components.
+ *
+ * @param {string} input Raw Markdown converted to HTML.
+ * @returns {string} Sanitised HTML string safe for rendering.
+ */
 export const sanitizeMarkdown = (input: string) =>
   sanitizeHtml(input, {
     allowedTags: extendedAllowedTags,

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -2,6 +2,14 @@ const DEFAULT_SITE_URL = 'http://localhost:3000'
 
 const normalizeUrl = (url: string) => url.replace(/\/$/, '')
 
+/**
+ * Resolve the canonical site URL for the current execution context.
+ *
+ * Falls back to environment variables (`NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_VERCEL_URL`, `VERCEL_URL`)
+ * or localhost when executed server-side.
+ *
+ * @returns {string} Normalised absolute origin without a trailing slash.
+ */
 export const getSiteUrl = () => {
   if (typeof window !== 'undefined' && window.location?.origin) {
     return normalizeUrl(window.location.origin)
@@ -32,4 +40,10 @@ export const getSiteUrl = () => {
 
 const ensureLeadingSlash = (path: string) => (path.startsWith('/') ? path : `/${path}`)
 
+/**
+ * Build an absolute URL by prefixing a path with the resolved site origin.
+ *
+ * @param {string} [path='/'] Relative path to append.
+ * @returns {string} Absolute URL suitable for metadata, emails, or API clients.
+ */
 export const buildSiteUrl = (path = '/') => `${getSiteUrl()}${ensureLeadingSlash(path)}`

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,10 +1,22 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
+/**
+ * Merge conditional class names while applying Tailwind CSS conflict resolution.
+ *
+ * @param {...ClassValue[]} inputs One or more class name values supported by `clsx`.
+ * @returns {string} Space-delimited class string with Tailwind precedence applied.
+ */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+/**
+ * Convert an arbitrary string into a URL-safe slug.
+ *
+ * @param {string} input Source text (e.g., post title).
+ * @returns {string} Lowercase slug truncated to 120 characters with hyphen separators.
+ */
 export function generateSlug(input: string) {
   return input
     .toLowerCase()


### PR DESCRIPTION
## Summary
- rebuild README with a full table of contents, expanded setup instructions, and direct links to supporting guides
- add dedicated setup, testing, and API references under the docs/ directory and introduce an index for navigation
- annotate Supabase helpers with TSDoc comments and record the overhaul in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6ccc448c8832da0e09efd20af4b1a