### PR TITLE
docs: add marketing enablement pack

### DIFF
--- a/docs/marketing/2025-02-26-social-strategy.md
+++ b/docs/marketing/2025-02-26-social-strategy.md
@@ -1,0 +1,141 @@
+# Syntax & Sips Marketing Enablement Pack — 2025-02-26
+
+## Executive Summary
+Syntax & Sips blends a Next.js 15 app-router front end with Supabase auth, Postgres, and edge functions to deliver a multi-channel editorial platform and gamified community hub. The visitor experience surfaces curated AI, ML, and quantum computing stories through the homepage hero, trending modules, and channel hubs, while authenticated members unlock personalized dashboards, onboarding flows, and creator workspaces. Administrators orchestrate publishing, analytics, taxonomy, gamification, and community moderation from a consolidated dashboard protected by Supabase role checks. Newsletter growth is supported by a double opt-in flow backed by a Supabase edge function and Mailtrap transactional email integration.
+
+## Architecture Overview
+- **Presentation layer:** Next.js App Router with server-side metadata generation and client-side interactivity composed from neo-brutalist design primitives (e.g., `HeroSection`, `TopicsSection`, `TrendingPosts`).
+- **Content orchestration:** Supabase service-role helpers fetch and normalize posts, categories, tags, and author metadata (`getPublishedPosts`, `searchPublishedPosts`), feeding list and detail experiences.
+- **Authentication & profiles:** Supabase SSR client gatekeeps `/account`, `/admin`, and creator spaces, mapping roles, onboarding journeys, and contribution snapshots for signed-in users.
+- **Admin console:** A client-side dashboard fetches posts, taxonomy, comments, analytics, gamification data, and community queues through `/api/admin/**` endpoints, supporting CRUD, moderation, and reviewer feedback loops.
+- **Gamification services:** Supabase-backed points, streaks, badge evaluation, and challenge progression flow through cached service-role utilities to keep leaderboards responsive.
+- **Newsletter lifecycle:** `/api/newsletter` orchestrates validation, Supabase persistence, and Mailtrap confirmation emails, while an edge function (`newsletter-subscribe`) supports integrations outside the app shell.
+- **Search & discovery:** Global command menu (`Cmd/Ctrl + K`) queries Supabase via `/api/search`, returning highlighted summaries for rapid navigation.
+
+## Feature Inventory & Technical Highlights
+- **Homepage hero & discovery rails:** Compose hero storytelling, trending posts, newsletter CTA, and content previews to funnel readers into channel hubs.
+- **Channel hubs (`/blogs`, `/videos`, `/podcasts`, `/tutorials`, `/resources`):** Filterable, paginated lists derived from Supabase queries with accent-color theming.
+- **Topic exploration & changelog:** Taxonomy-driven journeys and release timelines maintain reader engagement and transparency.
+- **Account dashboard:** Aggregates authored posts, comment history, onboarding progress, and role badges for authenticated profiles.
+- **Comments & moderation:** Anonymous-friendly comment submission with admin review queues, filters, and status transitions.
+- **Creator workspace:** MDX drafting environment with autosave, editorial checklists, submission statuses, and reviewer feedback threads.
+- **Admin suite:** Tabs for overview analytics, posts management, comments moderation, taxonomy controls, user management, gamification settings, and community queues.
+- **Gamification engine:** XP, points, streaks, badge evaluation, challenge progression, and leaderboard cache invalidation.
+- **Newsletter workflow:** Double opt-in with confirmation token persistence, resend detection, and transactional email dispatch.
+- **Search command palette:** Debounced fetching, highlighted matches, keyboard navigation, and empty/error states.
+
+## User Value Propositions
+- **AI & engineering practitioners:** Depth-over-hype editorial coverage, multi-format learning paths, and community conversations anchored around trending technical topics.
+- **Community contributors:** Clear application funnel, collaborative workspace, autosave safety nets, and transparent review loops to build a public portfolio.
+- **Editorial leads:** Centralized operations with analytics, gamification levers, moderation queues, and role management to sustain a healthy publication.
+- **Growth teams:** Newsletter automation, SEO-friendly content surfaces, and shareable AI summaries to amplify reach across channels.
+
+## Competitive Advantages
+- **Neo-brutalist design system** keeps brand differentiation high while remaining responsive and accessible.
+- **Deep Supabase integration** consolidates auth, storage, automation, and analytics without bespoke infrastructure.
+- **Gamified engagement** elevates retention through streaks, badges, and challenges beyond typical blog platforms.
+- **Contributor pipeline automation** scales community storytelling with structured feedback and admin tooling.
+- **Extensible AI services** (context builders, prompt templates, workflow tracking) lay groundwork for autonomous research and summarization agents.
+
+## Target Audience & Messaging Pillars
+- **Primary:** Applied AI/ML engineers, data scientists, and technical product builders seeking actionable playbooks and community insights.
+- **Secondary:** Editorial leads and developer relations managers aiming to operationalize multi-channel storytelling and contributor programs.
+
+**Core messages**
+1. Syntax & Sips unifies rich storytelling, analytics, and gamified community mechanics in a single Next.js + Supabase stack.
+2. Editorial teams get admin-grade tooling—analytics, moderation, taxonomy, gamification—from day one.
+3. Contributors enjoy a supportive workspace with autosave, feedback, and portfolio-ready publishing flows.
+4. Growth loops are wired in: command-menu search, AI summaries, newsletters, and multi-format distribution.
+5. The architecture is production-ready yet extensible—edge functions, typed clients, and modular services accelerate roadmap experiments.
+
+## Social Media Scripts
+### LinkedIn (Professional Spotlight) — ~650 words
+**Hook:**
+"Most editorial teams ship content OR community. Syntax & Sips decided to ship both." 
+
+**Problem:**
+AI, ML, and devrel teams need storytelling that scales without sacrificing craft or data visibility. Traditional CMSes bolt on analytics, auth, and contributor workflows piecemeal, slowing every launch. 
+
+**Solution:**
+Syntax & Sips is a Next.js 15 + Supabase platform built for multi-channel publishing, community collaboration, and gamified engagement. Visitors get curated AI/ML stories with streaming performance; members unlock personalized dashboards and onboarding journeys; admins orchestrate publishing, analytics, and governance without leaving one console. 
+
+**Technical Details & Highlights:**
+- **Neo-brutalist front end:** App Router hero, trending feeds, and channel hubs powered by Supabase queries keep discovery effortless. 
+- **Supabase-native auth & profiles:** Secure `/account`, `/admin`, and creator spaces use SSR clients to hydrate roles, onboarding status, and contribution analytics. 
+- **Creator workspace:** Approved authors draft MDX, autosave versions, tick editorial checklists, and submit for review—complete with Supabase-backed feedback threads. 
+- **Admin cockpit:** Posts, comments, taxonomy, gamification, and community queues live in one React dashboard with optimistic UI patterns and service-role API routes. 
+- **Gamification engine:** XP, streaks, badge evaluation, and challenge progression motivate readers and contributors alike. 
+- **Newsletter automation:** Double opt-in workflow integrates Mailtrap and a Supabase edge function so growth teams can run campaigns safely. 
+- **Global search:** Command-menu search (`Cmd/Ctrl + K`) fans out across published content with debounced Supabase queries. 
+
+**Business Value:**
+- Launch AI/ML content channels with governance-ready workflows on day one. 
+- Operationalize contributor programs without bloated plugin stacks. 
+- Turn engagement into measurable streaks, badges, and leaderboards. 
+- Ship newsletters, changelogs, and updates from the same stack. 
+
+**Call to Action:**
+Ready to brew smarter editorial ops? Explore the live experience (syntax-blogs.prashant.sbs), request a guided tour, or DM for a contributor onboarding deck. 
+
+**Hashtags:**
+#NextJS #Supabase #AIMarketing #DeveloperExperience #ContentStrategy #CommunityBuilding #Gamification #DataScience
+
+### Instagram Carousel (8 slides)
+1. **Slide 1 – Hook Visual:** Bold headline: "Brew better AI stories." Background: neon hero imagery with coffee + code motif. Caption overlay: "Syntax & Sips blends editorial craft with community energy." 
+2. **Slide 2 – Multi-channel content:** Grid of blog, video, podcast cards. Text: "Blogs, tutorials, videos & more – all in one hub." 
+3. **Slide 3 – Personalized journeys:** Illustration of dashboards/onboarding. Text: "Members get dashboards, onboarding, and topic trails tailored to their goals." 
+4. **Slide 4 – Contributor love:** Workspace screenshot mock. Text: "Creators draft in MDX, autosave, and submit with feedback loops." 
+5. **Slide 5 – Admin superpowers:** Dashboard metrics and moderation chips. Text: "Admins moderate, analyze, and gamify from one command center." 
+6. **Slide 6 – Gamified engagement:** Badges, streak counters. Text: "XP, streaks, and challenges keep the community buzzing." 
+7. **Slide 7 – Newsletter loop:** Email preview & CTA button. Text: "Double opt-in newsletter automation keeps the audience close." 
+8. **Slide 8 – CTA:** Brand lockup with button-style overlay: "Sip the experience at syntaxandsips.com • Join the newsletter • Apply to contribute." 
+
+**Caption:**
+"From AI tutorials to community challenges, Syntax & Sips is where builders learn together. Neo-brutalist vibes, Supabase-powered workflows, and a gamified contributor pipeline make every story count. Tap the link in bio to explore. ☕💡" 
+
+**Hashtags:**
+#SyntaxAndSips #AIBuilders #MachineLearning #DeveloperCommunity #ContentCreators #GamifiedLearning #NextJS #Supabase #NeoBrutalism #TechStorytelling
+
+### YouTube Video Script (3–4 minutes)
+**Intro (0:00 – 0:20):**
+- On-screen: Host at a coffee shop workspace; overlay text "Syntax & Sips Tour".
+- Script: "Welcome to Syntax & Sips—where AI and engineering stories brew with community energy. Today I’ll show you how this Next.js + Supabase platform powers editors, contributors, and readers in one experience." 
+
+**Problem (0:20 – 0:50):**
+- B-roll: Overwhelming CMS dashboards, scattered tools. 
+- Script: "Most teams juggle separate tools for publishing, analytics, contributor onboarding, and newsletters. That friction slows launches and buries community momentum." 
+
+**Solution Overview (0:50 – 1:30):**
+- On-screen: Homepage hero, trending posts, channel navigation. 
+- Script: "Syntax & Sips centralizes it all: curated AI/ML stories, channel hubs for blogs, videos, podcasts, and resources, plus a command menu to jump anywhere." 
+
+**Feature Demos (1:30 – 2:50):**
+1. **Member Experience:** Show account dashboard, onboarding steps. Narration emphasizes Supabase auth, role-aware views, and personalized stats. 
+2. **Creator Workspace:** Screen capture of MDX editor, autosave indicator, submission statuses, review comments. Highlight Supabase-backed workflows. 
+3. **Admin Dashboard:** Display analytics, posts table, comments moderation, gamification panel, community queue. Mention service-role APIs and cached metrics. 
+4. **Gamification & Newsletter:** Show badge graphics, streak counter, and newsletter confirmation email UI. Explain double opt-in flow. 
+
+**Benefits (2:50 – 3:20):**
+- On-screen: Overlay bullets "Launch faster", "Grow community", "Measure engagement". 
+- Script: "Teams get production-grade governance from day one, contributors feel supported, and growth loops—newsletters, AI summaries, gamification—are ready to scale." 
+
+**Outro & CTA (3:20 – 3:40):**
+- On-screen: URL animation + CTA buttons. 
+- Script: "Want to brew your own editorial experience? Explore syntaxandsips.com, subscribe to the newsletter, or reach out for a contributor invite. See you inside!" 
+
+**Suggested B-roll & On-screen Text:**
+- B-roll: Hero animations, command menu interaction, analytics graphs, newsletter confirmation.
+- On-screen text: "Next.js + Supabase", "Creator Workspace", "Gamified Community", "Double Opt-in Newsletter". 
+
+## Content Calendar & Activation
+- **LinkedIn:** Tuesdays at 9:00 AM PT (aligned with B2B engagement peaks). Encourage team members to comment with takeaways. Track saves, reshares, and lead form clicks.
+- **Instagram:** Thursdays at 11:00 AM PT to capture mid-week inspiration. Use carousel + Stories teaser; monitor saves, replies, and link-in-bio clicks.
+- **YouTube:** Publish Monday at 8:00 AM PT with Shorts cutdowns scheduled Wednesday. Measure watch time, click-through to site, and subscriber growth.
+- **Cross-promotion:** Repurpose hero quotes for Twitter/X threads and newsletter teaser. Embed YouTube video on `/resources` and include carousel slides in community Slack/Discord.
+- **Engagement tactics:** Pin the LinkedIn post for a week, run an Instagram Story poll about next tutorial topics, and host a live AMA 48 hours after the YouTube drop.
+
+## Success Metrics
+- **Awareness:** Post impressions, unique site sessions, YouTube watch time.
+- **Engagement:** LinkedIn reactions/comments, Instagram saves/shares, average view duration.
+- **Conversion:** Newsletter sign-ups per channel, contributor application clicks, admin demo requests.
+- **Retention:** Repeat sessions from newsletter traffic, gamification actions completed post-campaign.


### PR DESCRIPTION
## Summary
- add a marketing enablement pack outlining architecture insights, feature inventory, and campaign messaging for Syntax & Sips
- capture platform-specific social media scripts plus posting cadence, engagement tactics, and success metrics

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e73b26aef4832d9056adb57809d715