### PR TITLE
Fix account workspace layout and stabilize leaderboard badges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Welcome to **Syntax & Sips**, a Next.js 15 + Supabase editorial platform featuri
   - Default to **Server Components** for static content or data fetching without client interactivity.
   - Promote **Client Components** (add `'use client'`) for interactivity, Supabase auth hooks, or stateful UI.
   - Compose UI through reusable primitives; avoid deep prop drilling—consider context providers for shared state.
+  - When adopting components from [neobrutalism.dev](https://neobrutalism.dev), install them via the official registry using the npm-based Shadcn CLI (for example `npx shadcn@latest add https://neobrutalism.dev/r/[component].json`) before wiring them up. Follow the setup notes in [`neobrutalismthemecomp.MD`](./neobrutalismthemecomp.MD) and avoid copy-pasting untracked snippets.
 - **File Organization**:
   - Feature-first structure: group routes, components, hooks, tests within feature directories.
   - File naming: kebab-case for route folders/files, PascalCase for component files, camelCase for helpers.

--- a/src/components/auth/UserAccountPanel.tsx
+++ b/src/components/auth/UserAccountPanel.tsx
@@ -680,7 +680,7 @@ const AccountWorkspaceSidebar = ({
   return (
     <Sidebar
       collapsible="icon"
-      className="border-r-4 border-black bg-white shadow-[12px_0_0_rgba(0,0,0,0.12)] lg:sticky lg:top-10 lg:h-[calc(100vh-5rem)]"
+      className="border-r-4 border-black bg-white shadow-[12px_0_0_rgba(0,0,0,0.12)] lg:sticky lg:top-10 lg:h-[calc(100vh-5rem)] lg:flex-shrink-0"
     >
       <SidebarHeader className="bg-[#F9F5FF]">
         <div className="flex items-center justify-between gap-3">
@@ -1286,14 +1286,14 @@ export const UserAccountPanel = ({ profile, contributions }: UserAccountPanelPro
 
   return (
     <SidebarProvider>
-      <div className="neo-brutalism min-h-screen bg-gradient-to-br from-[#FFF5F1] via-[#F8F0FF] to-[#E3F2FF]">
+      <div className="neo-brutalism flex min-h-screen flex-col bg-gradient-to-br from-[#FFF5F1] via-[#F8F0FF] to-[#E3F2FF] lg:flex-row lg:items-start lg:gap-6">
         <AccountWorkspaceSidebar
           profile={currentProfile}
           totals={contributions.totals}
           sections={navigationSections}
         />
 
-        <SidebarInset className="px-4 py-10 sm:px-6 lg:px-8">
+        <SidebarInset className="flex-1 min-w-0 px-4 py-10 sm:px-6 lg:px-8">
           <div className="mx-auto w-full max-w-7xl">
             <div className="mb-6 flex items-center justify-between gap-3 lg:hidden">
               <SidebarTrigger />


### PR DESCRIPTION
## Summary
- ensure the account workspace sidebar and inset use a responsive flex layout so main content stays visible while the navigation collapses
- adjust leaderboard queries to gather badge slugs through nested profile badge joins and deduplicate the results
- document the requirement to install neobrutalism.dev components via the official npm-powered Shadcn CLI in AGENTS.md

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e76f788bac832dbd2b8f2a68826ce6