### PR TITLE
feat(admin): improve dashboard responsiveness

### DIFF
--- a/src/components/admin/AnalyticsPanel.tsx
+++ b/src/components/admin/AnalyticsPanel.tsx
@@ -109,7 +109,7 @@ export function AnalyticsPanel({ posts, recentComments }: AnalyticsPanelProps) {
         </p>
       </div>
 
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
         <article className="rounded-xl border-4 border-black bg-white p-5 shadow-[6px_6px_0px_0px_rgba(0,0,0,0.08)]">
           <div className="flex items-center gap-3">
             <BarChart4 className="h-5 w-5 text-[#6C63FF]" aria-hidden="true" />
@@ -173,7 +173,7 @@ export function AnalyticsPanel({ posts, recentComments }: AnalyticsPanelProps) {
 
       <section className="grid gap-6 xl:grid-cols-[2fr_1fr]">
         <article className="rounded-xl border-4 border-black bg-white p-6 shadow-[6px_6px_0px_0px_rgba(0,0,0,0.08)]">
-          <header className="mb-6 flex items-center justify-between">
+          <header className="mb-6 flex flex-wrap items-center justify-between gap-3">
             <div className="flex items-center gap-3">
               <Activity className="h-5 w-5 text-[#6C63FF]" aria-hidden="true" />
               <h2 className="text-xl font-bold text-[#2A2A2A]">Monthly performance</h2>
@@ -183,7 +183,7 @@ export function AnalyticsPanel({ posts, recentComments }: AnalyticsPanelProps) {
               Last 6 months
             </span>
           </header>
-          <div className="grid grid-cols-6 gap-4">
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-6">
             {monthlyPerformance.map((month) => {
               const height = month.views === 0 ? 6 : Math.min(110, Math.round(month.views / 20));
               return (
@@ -211,7 +211,7 @@ export function AnalyticsPanel({ posts, recentComments }: AnalyticsPanelProps) {
         </article>
 
         <article className="rounded-xl border-4 border-black bg-white p-6 shadow-[6px_6px_0px_0px_rgba(0,0,0,0.08)]">
-          <header className="mb-4 flex items-center gap-3">
+          <header className="mb-4 flex flex-wrap items-center gap-3">
             <PieChart className="h-5 w-5 text-[#FF5252]" aria-hidden="true" />
             <h2 className="text-xl font-bold text-[#2A2A2A]">Status distribution</h2>
           </header>
@@ -235,7 +235,7 @@ export function AnalyticsPanel({ posts, recentComments }: AnalyticsPanelProps) {
       </section>
 
       <section className="rounded-xl border-4 border-black bg-white p-6 shadow-[6px_6px_0px_0px_rgba(0,0,0,0.08)]">
-        <header className="mb-4 flex items-center gap-3">
+        <header className="mb-4 flex flex-wrap items-center gap-3">
           <Flame className="h-5 w-5 text-[#6C63FF]" aria-hidden="true" />
           <h2 className="text-xl font-bold text-[#2A2A2A]">Top categories by reach</h2>
         </header>

--- a/src/components/admin/CommunityReviewQueue.tsx
+++ b/src/components/admin/CommunityReviewQueue.tsx
@@ -166,12 +166,12 @@ export const CommunityReviewQueue = ({
 
   return (
     <div className="space-y-8">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <h2 className="text-2xl font-black uppercase text-[#121212]">Community review queue</h2>
         <button
           type="button"
           onClick={() => void handleRefresh()}
-          className="rounded-2xl border-4 border-[#121212] bg-white px-4 py-2 text-sm font-black uppercase tracking-wide text-[#121212] shadow-[4px_4px_0px_#121212] transition hover:-translate-y-1"
+          className="w-full rounded-2xl border-4 border-[#121212] bg-white px-4 py-2 text-sm font-black uppercase tracking-wide text-[#121212] shadow-[4px_4px_0px_#121212] transition hover:-translate-y-1 sm:w-auto"
           disabled={isRefreshing}
         >
           {isRefreshing ? 'Refreshing…' : 'Refresh'}
@@ -182,226 +182,423 @@ export const CommunityReviewQueue = ({
         Supabase, and log moderation events.
       </p>
       <section className="space-y-4">
-        <header className="flex items-center justify-between">
+        <header className="flex flex-wrap items-center justify-between gap-3">
           <h3 className="text-lg font-black uppercase text-[#121212]">Author applications</h3>
           <span className="rounded-full border-2 border-[#121212] bg-white px-3 py-1 text-xs font-black uppercase text-[#121212]">
             {applications.length} in queue
           </span>
         </header>
-        <div className="overflow-hidden rounded-3xl border-4 border-[#121212] bg-white shadow-[8px_8px_0px_#121212]">
-          <table className="min-w-full divide-y-4 divide-[#121212]">
-            <thead className="bg-[#121212] text-white">
-              <tr>
-                <th className="px-4 py-3 text-left text-xs font-black uppercase tracking-wide">Applicant</th>
-                <th className="px-4 py-3 text-left text-xs font-black uppercase tracking-wide">Focus</th>
-                <th className="px-4 py-3 text-left text-xs font-black uppercase tracking-wide">Status</th>
-                <th className="px-4 py-3 text-right text-xs font-black uppercase tracking-wide">Actions</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y-4 divide-[#121212]/30">
-              {applications.length === 0 ? (
-                <tr>
-                  <td colSpan={4} className="px-4 py-6 text-center text-sm font-semibold text-[#4B4B4B]">
-                    {isLoading ? 'Loading applications…' : 'No applications awaiting review.'}
-                  </td>
-                </tr>
-              ) : (
-                applications.map((application) => {
-                  const payload = application.application_payload ?? {}
-                  const focusAreas = Array.isArray(payload?.focusAreas)
-                    ? (payload?.focusAreas as string[])
-                    : []
-                  const applicantName = (payload?.fullName as string | undefined) ?? application.profile_id
+        <div className="space-y-4 md:hidden">
+          {isLoading ? (
+            <div className="rounded-3xl border-4 border-dashed border-[#121212]/40 bg-white p-6 text-center text-sm font-semibold text-[#4B4B4B]">
+              Loading applications…
+            </div>
+          ) : applications.length === 0 ? (
+            <div className="rounded-3xl border-4 border-[#121212] bg-white p-6 text-center text-sm font-semibold text-[#4B4B4B] shadow-[6px_6px_0px_#121212]">
+              No applications awaiting review.
+            </div>
+          ) : (
+            applications.map((application) => {
+              const payload = application.application_payload ?? {}
+              const focusAreas = Array.isArray(payload?.focusAreas)
+                ? (payload?.focusAreas as string[])
+                : []
+              const applicantName = (payload?.fullName as string | undefined) ?? application.profile_id
 
-                  return (
-                    <tr key={application.id} className="bg-white">
-                      <td className="px-4 py-4 align-top">
-                        <p className="font-black text-[#121212]">{applicantName}</p>
-                        <p className="text-xs font-semibold text-[#4B4B4B]">
-                          Submitted {application.submitted_at ? new Date(application.submitted_at).toLocaleDateString() : '—'}
-                        </p>
-                      </td>
-                      <td className="px-4 py-4 align-top text-sm font-semibold text-[#2A2A2A]">
-                        {focusAreas.length > 0 ? focusAreas.join(', ') : '—'}
-                      </td>
-                      <td className="px-4 py-4 align-top">
-                        <span
-                          className={cn(
-                            'inline-flex rounded-full px-3 py-1 text-xs font-black uppercase',
-                            statusBadgeClasses[application.status] ?? 'bg-[#E0E0E0] text-[#424242]',
-                          )}
-                        >
-                          {application.status.replace(/_/g, ' ')}
-                        </span>
-                      </td>
-                      <td className="px-4 py-4 align-top text-right text-xs font-black uppercase text-[#121212]">
-                        <div className="inline-flex flex-wrap justify-end gap-2">
-                          <button
-                            type="button"
-                            onClick={() =>
-                              void runAction(
-                                () => onApplicationAction(application.id, 'approve'),
-                                'Application approved.',
-                              )
-                            }
-                            className="rounded-xl border-3 border-[#121212] bg-[#C8E6C9] px-3 py-2 text-xs font-black text-[#1B5E20] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
-                          >
-                            Approve
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() =>
-                              openNotesComposer({
-                                context: 'application',
-                                id: application.id,
-                                action: 'needs_more_info',
-                                title: 'Request additional information',
-                                description:
-                                  'Share context or clarifying questions for the applicant. This message is sent with the notification.',
-                                placeholder: 'Let the applicant know what else would help you evaluate their submission…',
-                                successMessage: 'Requested additional details.',
-                              })
-                            }
-                            className="rounded-xl border-3 border-[#121212] bg-[#FFF59D] px-3 py-2 text-xs font-black text-[#F57F17] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
-                          >
-                            Needs info
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() =>
-                              openNotesComposer({
-                                context: 'application',
-                                id: application.id,
-                                action: 'decline',
-                                title: 'Decline application',
-                                description:
-                                  'Optionally provide feedback so the applicant understands the decision and next steps.',
-                                placeholder: 'Share constructive feedback or resources for the applicant…',
-                                successMessage: 'Application declined.',
-                              })
-                            }
-                            className="rounded-xl border-3 border-[#121212] bg-[#FFCDD2] px-3 py-2 text-xs font-black text-[#B71C1C] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
-                          >
-                            Decline
-                          </button>
-                        </div>
+              return (
+                <article
+                  key={application.id}
+                  className="space-y-3 rounded-3xl border-4 border-[#121212] bg-white p-4 shadow-[6px_6px_0px_#121212]"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="font-black text-[#121212]">{applicantName}</p>
+                      <p className="text-xs font-semibold text-[#4B4B4B]">
+                        Submitted {application.submitted_at ? new Date(application.submitted_at).toLocaleDateString() : '—'}
+                      </p>
+                    </div>
+                    <span
+                      className={cn(
+                        'inline-flex rounded-full px-3 py-1 text-xs font-black uppercase',
+                        statusBadgeClasses[application.status] ?? 'bg-[#E0E0E0] text-[#424242]',
+                      )}
+                    >
+                      {application.status.replace(/_/g, ' ')}
+                    </span>
+                  </div>
+                  <div className="space-y-1 text-sm text-[#2A2A2A]">
+                    <p className="text-xs font-black uppercase tracking-wide text-[#121212]/60">Focus</p>
+                    <p>{focusAreas.length > 0 ? focusAreas.join(', ') : '—'}</p>
+                  </div>
+                  <div className="flex flex-col gap-2 text-xs font-black uppercase text-[#121212] sm:flex-row">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        void runAction(
+                          () => onApplicationAction(application.id, 'approve'),
+                          'Application approved.',
+                        )
+                      }
+                      className="w-full rounded-xl border-3 border-[#121212] bg-[#C8E6C9] px-3 py-2 text-[#1B5E20] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
+                    >
+                      Approve
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        openNotesComposer({
+                          context: 'application',
+                          id: application.id,
+                          action: 'needs_more_info',
+                          title: 'Request additional information',
+                          description:
+                            'Share context or clarifying questions for the applicant. This message is sent with the notification.',
+                          placeholder: 'Let the applicant know what else would help you evaluate their submission…',
+                          successMessage: 'Requested additional details.',
+                        })
+                      }
+                      className="w-full rounded-xl border-3 border-[#121212] bg-[#FFF59D] px-3 py-2 text-[#F57F17] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
+                    >
+                      Needs info
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        openNotesComposer({
+                          context: 'application',
+                          id: application.id,
+                          action: 'decline',
+                          title: 'Decline application',
+                          description:
+                            'Optionally provide feedback so the applicant understands the decision and next steps.',
+                          placeholder: 'Share constructive feedback or resources for the applicant…',
+                          successMessage: 'Application declined.',
+                        })
+                      }
+                      className="w-full rounded-xl border-3 border-[#121212] bg-[#FFCDD2] px-3 py-2 text-[#B71C1C] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
+                    >
+                      Decline
+                    </button>
+                  </div>
+                </article>
+              )
+            })
+          )}
+        </div>
+        <div className="hidden md:block">
+          <div className="rounded-3xl border-4 border-[#121212] bg-white shadow-[8px_8px_0px_#121212]">
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y-4 divide-[#121212]">
+                <thead className="bg-[#121212] text-white">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-black uppercase tracking-wide">Applicant</th>
+                    <th className="px-4 py-3 text-left text-xs font-black uppercase tracking-wide">Focus</th>
+                    <th className="px-4 py-3 text-left text-xs font-black uppercase tracking-wide">Status</th>
+                    <th className="px-4 py-3 text-right text-xs font-black uppercase tracking-wide">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y-4 divide-[#121212]/30">
+                  {applications.length === 0 ? (
+                    <tr>
+                      <td colSpan={4} className="px-4 py-6 text-center text-sm font-semibold text-[#4B4B4B]">
+                        {isLoading ? 'Loading applications…' : 'No applications awaiting review.'}
                       </td>
                     </tr>
-                  )
-                })
-              )}
-            </tbody>
-          </table>
+                  ) : (
+                    applications.map((application) => {
+                      const payload = application.application_payload ?? {}
+                      const focusAreas = Array.isArray(payload?.focusAreas)
+                        ? (payload?.focusAreas as string[])
+                        : []
+                      const applicantName = (payload?.fullName as string | undefined) ?? application.profile_id
+
+                      return (
+                        <tr key={application.id} className="bg-white">
+                          <td className="px-4 py-4 align-top">
+                            <p className="font-black text-[#121212]">{applicantName}</p>
+                            <p className="text-xs font-semibold text-[#4B4B4B]">
+                              Submitted {application.submitted_at ? new Date(application.submitted_at).toLocaleDateString() : '—'}
+                            </p>
+                          </td>
+                          <td className="px-4 py-4 align-top text-sm font-semibold text-[#2A2A2A]">
+                            {focusAreas.length > 0 ? focusAreas.join(', ') : '—'}
+                          </td>
+                          <td className="px-4 py-4 align-top">
+                            <span
+                              className={cn(
+                                'inline-flex rounded-full px-3 py-1 text-xs font-black uppercase',
+                                statusBadgeClasses[application.status] ?? 'bg-[#E0E0E0] text-[#424242]',
+                              )}
+                            >
+                              {application.status.replace(/_/g, ' ')}
+                            </span>
+                          </td>
+                          <td className="px-4 py-4 align-top text-right text-xs font-black uppercase text-[#121212]">
+                            <div className="inline-flex flex-wrap justify-end gap-2">
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  void runAction(
+                                    () => onApplicationAction(application.id, 'approve'),
+                                    'Application approved.',
+                                  )
+                                }
+                                className="rounded-xl border-3 border-[#121212] bg-[#C8E6C9] px-3 py-2 text-xs font-black text-[#1B5E20] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
+                              >
+                                Approve
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  openNotesComposer({
+                                    context: 'application',
+                                    id: application.id,
+                                    action: 'needs_more_info',
+                                    title: 'Request additional information',
+                                    description:
+                                      'Share context or clarifying questions for the applicant. This message is sent with the notification.',
+                                    placeholder: 'Let the applicant know what else would help you evaluate their submission…',
+                                    successMessage: 'Requested additional details.',
+                                  })
+                                }
+                                className="rounded-xl border-3 border-[#121212] bg-[#FFF59D] px-3 py-2 text-xs font-black text-[#F57F17] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
+                              >
+                                Needs info
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  openNotesComposer({
+                                    context: 'application',
+                                    id: application.id,
+                                    action: 'decline',
+                                    title: 'Decline application',
+                                    description:
+                                      'Optionally provide feedback so the applicant understands the decision and next steps.',
+                                    placeholder: 'Share constructive feedback or resources for the applicant…',
+                                    successMessage: 'Application declined.',
+                                  })
+                                }
+                                className="rounded-xl border-3 border-[#121212] bg-[#FFCDD2] px-3 py-2 text-xs font-black text-[#B71C1C] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
+                              >
+                                Decline
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      )
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
       </section>
 
       <section className="space-y-4">
-        <header className="flex items-center justify-between">
+        <header className="flex flex-wrap items-center justify-between gap-3">
           <h3 className="text-lg font-black uppercase text-[#121212]">Community submissions</h3>
           <span className="rounded-full border-2 border-[#121212] bg-white px-3 py-1 text-xs font-black uppercase text-[#121212]">
             {submissions.length} in queue
           </span>
         </header>
-        <div className="overflow-hidden rounded-3xl border-4 border-[#121212] bg-white shadow-[8px_8px_0px_#121212]">
-          <table className="min-w-full divide-y-4 divide-[#121212]">
-            <thead className="bg-[#121212] text-white">
-              <tr>
-                <th className="px-4 py-3 text-left text-xs font-black uppercase tracking-wide">Title</th>
-                <th className="px-4 py-3 text-left text-xs font-black uppercase tracking-wide">Status</th>
-                <th className="px-4 py-3 text-left text-xs font-black uppercase tracking-wide">Submitted</th>
-                <th className="px-4 py-3 text-right text-xs font-black uppercase tracking-wide">Actions</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y-4 divide-[#121212]/30">
-              {submissions.length === 0 ? (
-                <tr>
-                  <td colSpan={4} className="px-4 py-6 text-center text-sm font-semibold text-[#4B4B4B]">
-                    {isLoading ? 'Loading submissions…' : 'No submissions awaiting review.'}
-                  </td>
-                </tr>
-              ) : (
-                submissions.map((submission) => (
-                  <tr key={submission.id} className="bg-white">
-                    <td className="px-4 py-4 align-top">
-                      <p className="font-black text-[#121212]">{submission.title || 'Untitled draft'}</p>
-                      <p className="mt-1 text-xs font-semibold text-[#4B4B4B]">{submission.summary}</p>
-                    </td>
-                    <td className="px-4 py-4 align-top">
-                      <span
-                        className={cn(
-                          'inline-flex rounded-full px-3 py-1 text-xs font-black uppercase',
-                          statusBadgeClasses[submission.status] ?? 'bg-[#E0E0E0] text-[#424242]',
-                        )}
-                      >
-                        {submission.status.replace(/_/g, ' ')}
-                      </span>
-                    </td>
-                    <td className="px-4 py-4 align-top text-sm font-semibold text-[#2A2A2A]">
-                      {submission.submitted_at ? new Date(submission.submitted_at).toLocaleString() : '—'}
-                    </td>
-                    <td className="px-4 py-4 align-top text-right">
-                      <div className="inline-flex flex-wrap justify-end gap-2 text-xs font-black uppercase text-[#121212]">
-                        <button
-                          type="button"
-                          onClick={() =>
-                            void runAction(
-                              () => onSubmissionAction(submission.id, 'approve'),
-                              'Submission approved and synced.',
-                            )
-                          }
-                          className="rounded-xl border-3 border-[#121212] bg-[#C8E6C9] px-3 py-2 text-xs font-black text-[#1B5E20] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
-                        >
-                          Approve
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() =>
-                            openNotesComposer({
-                              context: 'submission',
-                              id: submission.id,
-                              action: 'feedback',
-                              title: 'Request revisions',
-                              description:
-                                'Outline specific edits or additions the contributor should make before re-submitting.',
-                              placeholder: 'Detail revision requests, references, or editorial suggestions…',
-                              successMessage: 'Feedback shared with contributor.',
-                            })
-                          }
-                          className="rounded-xl border-3 border-[#121212] bg-[#FFF59D] px-3 py-2 text-xs font-black text-[#F57F17] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
-                        >
-                          Request changes
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() =>
-                            openNotesComposer({
-                              context: 'submission',
-                              id: submission.id,
-                              action: 'decline',
-                              title: 'Decline submission',
-                              description:
-                                'Let the contributor know why their draft isn’t moving forward and how they can improve next time.',
-                              placeholder: 'Offer constructive feedback, themes to explore, or community resources…',
-                              successMessage: 'Submission declined.',
-                            })
-                          }
-                          className="rounded-xl border-3 border-[#121212] bg-[#FFCDD2] px-3 py-2 text-xs font-black text-[#B71C1C] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
-                        >
-                          Decline
-                        </button>
-                      </div>
-                    </td>
+        <div className="space-y-4 md:hidden">
+          {isLoading ? (
+            <div className="rounded-3xl border-4 border-dashed border-[#121212]/40 bg-white p-6 text-center text-sm font-semibold text-[#4B4B4B]">
+              Loading submissions…
+            </div>
+          ) : submissions.length === 0 ? (
+            <div className="rounded-3xl border-4 border-[#121212] bg-white p-6 text-center text-sm font-semibold text-[#4B4B4B] shadow-[6px_6px_0px_#121212]">
+              No submissions awaiting review.
+            </div>
+          ) : (
+            submissions.map((submission) => (
+              <article
+                key={submission.id}
+                className="space-y-3 rounded-3xl border-4 border-[#121212] bg-white p-4 shadow-[6px_6px_0px_#121212]"
+              >
+                <div className="space-y-2">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-base font-black text-[#121212]">
+                        {submission.title || 'Untitled draft'}
+                      </p>
+                      {submission.summary ? (
+                        <p className="text-sm font-semibold text-[#4B4B4B]">{submission.summary}</p>
+                      ) : null}
+                    </div>
+                    <span
+                      className={cn(
+                        'inline-flex rounded-full px-3 py-1 text-xs font-black uppercase',
+                        statusBadgeClasses[submission.status] ?? 'bg-[#E0E0E0] text-[#424242]',
+                      )}
+                    >
+                      {submission.status.replace(/_/g, ' ')}
+                    </span>
+                  </div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-[#121212]/60">
+                    Submitted {submission.submitted_at ? new Date(submission.submitted_at).toLocaleString() : '—'}
+                  </p>
+                </div>
+                <div className="flex flex-col gap-2 text-xs font-black uppercase text-[#121212] sm:flex-row">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      void runAction(
+                        () => onSubmissionAction(submission.id, 'approve'),
+                        'Submission approved and synced.',
+                      )
+                    }
+                    className="w-full rounded-xl border-3 border-[#121212] bg-[#C8E6C9] px-3 py-2 text-[#1B5E20] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      openNotesComposer({
+                        context: 'submission',
+                        id: submission.id,
+                        action: 'feedback',
+                        title: 'Request revisions',
+                        description:
+                          'Outline specific edits or additions the contributor should make before re-submitting.',
+                        placeholder: 'Detail revision requests, references, or editorial suggestions…',
+                        successMessage: 'Feedback shared with contributor.',
+                      })
+                    }
+                    className="w-full rounded-xl border-3 border-[#121212] bg-[#FFF59D] px-3 py-2 text-[#F57F17] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
+                  >
+                    Request changes
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      openNotesComposer({
+                        context: 'submission',
+                        id: submission.id,
+                        action: 'decline',
+                        title: 'Decline submission',
+                        description:
+                          'Let the contributor know why their draft isn’t moving forward and how they can improve next time.',
+                        placeholder: 'Offer constructive feedback, themes to explore, or community resources…',
+                        successMessage: 'Submission declined.',
+                      })
+                    }
+                    className="w-full rounded-xl border-3 border-[#121212] bg-[#FFCDD2] px-3 py-2 text-[#B71C1C] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
+                  >
+                    Decline
+                  </button>
+                </div>
+              </article>
+            ))
+          )}
+        </div>
+        <div className="hidden md:block">
+          <div className="rounded-3xl border-4 border-[#121212] bg-white shadow-[8px_8px_0px_#121212]">
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y-4 divide-[#121212]">
+                <thead className="bg-[#121212] text-white">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-black uppercase tracking-wide">Title</th>
+                    <th className="px-4 py-3 text-left text-xs font-black uppercase tracking-wide">Status</th>
+                    <th className="px-4 py-3 text-left text-xs font-black uppercase tracking-wide">Submitted</th>
+                    <th className="px-4 py-3 text-right text-xs font-black uppercase tracking-wide">Actions</th>
                   </tr>
-                ))
-              )}
-            </tbody>
-          </table>
+                </thead>
+                <tbody className="divide-y-4 divide-[#121212]/30">
+                  {submissions.length === 0 ? (
+                    <tr>
+                      <td colSpan={4} className="px-4 py-6 text-center text-sm font-semibold text-[#4B4B4B]">
+                        {isLoading ? 'Loading submissions…' : 'No submissions awaiting review.'}
+                      </td>
+                    </tr>
+                  ) : (
+                    submissions.map((submission) => (
+                      <tr key={submission.id} className="bg-white">
+                        <td className="px-4 py-4 align-top">
+                          <p className="font-black text-[#121212]">{submission.title || 'Untitled draft'}</p>
+                          <p className="mt-1 text-xs font-semibold text-[#4B4B4B]">{submission.summary}</p>
+                        </td>
+                        <td className="px-4 py-4 align-top">
+                          <span
+                            className={cn(
+                              'inline-flex rounded-full px-3 py-1 text-xs font-black uppercase',
+                              statusBadgeClasses[submission.status] ?? 'bg-[#E0E0E0] text-[#424242]',
+                            )}
+                          >
+                            {submission.status.replace(/_/g, ' ')}
+                          </span>
+                        </td>
+                        <td className="px-4 py-4 align-top text-sm font-semibold text-[#2A2A2A]">
+                          {submission.submitted_at ? new Date(submission.submitted_at).toLocaleString() : '—'}
+                        </td>
+                        <td className="px-4 py-4 align-top text-right">
+                          <div className="inline-flex flex-wrap justify-end gap-2 text-xs font-black uppercase text-[#121212]">
+                            <button
+                              type="button"
+                              onClick={() =>
+                                void runAction(
+                                  () => onSubmissionAction(submission.id, 'approve'),
+                                  'Submission approved and synced.',
+                                )
+                              }
+                              className="rounded-xl border-3 border-[#121212] bg-[#C8E6C9] px-3 py-2 text-xs font-black text-[#1B5E20] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
+                            >
+                              Approve
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() =>
+                                openNotesComposer({
+                                  context: 'submission',
+                                  id: submission.id,
+                                  action: 'feedback',
+                                  title: 'Request revisions',
+                                  description:
+                                    'Outline specific edits or additions the contributor should make before re-submitting.',
+                                  placeholder: 'Detail revision requests, references, or editorial suggestions…',
+                                  successMessage: 'Feedback shared with contributor.',
+                                })
+                              }
+                              className="rounded-xl border-3 border-[#121212] bg-[#FFF59D] px-3 py-2 text-xs font-black text-[#F57F17] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
+                            >
+                              Request changes
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() =>
+                                openNotesComposer({
+                                  context: 'submission',
+                                  id: submission.id,
+                                  action: 'decline',
+                                  title: 'Decline submission',
+                                  description:
+                                    'Let the contributor know why their draft isn’t moving forward and how they can improve next time.',
+                                  placeholder: 'Offer constructive feedback, themes to explore, or community resources…',
+                                  successMessage: 'Submission declined.',
+                                })
+                              }
+                              className="rounded-xl border-3 border-[#121212] bg-[#FFCDD2] px-3 py-2 text-xs font-black text-[#B71C1C] shadow-[3px_3px_0px_#121212] hover:-translate-y-0.5"
+                            >
+                              Decline
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
       </section>
       {noteComposer ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6">
+        <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/50 p-4 sm:items-center sm:p-6">
           <div
-            className="w-full max-w-xl rounded-3xl border-4 border-[#121212] bg-[#FDF7ED] p-6 shadow-[12px_12px_0px_#121212]"
+            className="w-full max-w-xl rounded-3xl border-4 border-[#121212] bg-[#FDF7ED] p-5 shadow-[12px_12px_0px_#121212] sm:p-6"
             role="dialog"
             aria-modal="true"
             aria-labelledby="note-composer-title"

--- a/src/components/admin/DashboardOverview.tsx
+++ b/src/components/admin/DashboardOverview.tsx
@@ -116,7 +116,7 @@ export function DashboardOverview({
 
       <div className="grid gap-6 lg:grid-cols-3">
         <article className="lg:col-span-2 rounded-xl border-4 border-black bg-white p-6 shadow-[6px_6px_0px_0px_rgba(0,0,0,0.08)]">
-          <header className="mb-4 flex items-center justify-between">
+          <header className="mb-4 flex flex-wrap items-center justify-between gap-3">
             <div className="flex items-center gap-3">
               <Activity className="h-5 w-5 text-[#6C63FF]" aria-hidden="true" />
               <h2 className="text-xl font-bold text-[#2A2A2A]">Recent publishing</h2>
@@ -204,23 +204,25 @@ export function DashboardOverview({
             <TrendingUp className="h-5 w-5 text-[#6C63FF]" aria-hidden="true" />
             <h2 className="text-xl font-bold text-[#2A2A2A]">Publishing cadence</h2>
           </header>
-          <div className="flex items-end gap-4">
-            {monthlyPublishing.map((month) => {
-              const height = month.published === 0 ? 4 : Math.min(96, month.published * 22);
-              return (
-                <div key={month.key} className="flex flex-1 flex-col items-center gap-2">
-                  <div
-                    className="flex h-24 w-full items-end justify-center rounded-md border-2 border-black bg-[#e7e7ff]"
-                    style={{ height: `${Math.max(height, 6)}px` }}
-                  >
-                    <span className="text-xs font-bold text-[#2A2A2A]">{month.published}</span>
+          <div className="overflow-x-auto pb-2">
+            <div className="flex min-w-[520px] items-end gap-4">
+              {monthlyPublishing.map((month) => {
+                const height = month.published === 0 ? 4 : Math.min(96, month.published * 22);
+                return (
+                  <div key={month.key} className="flex flex-1 flex-col items-center gap-2">
+                    <div
+                      className="flex h-24 w-full items-end justify-center rounded-md border-2 border-black bg-[#e7e7ff]"
+                      style={{ height: `${Math.max(height, 6)}px` }}
+                    >
+                      <span className="text-xs font-bold text-[#2A2A2A]">{month.published}</span>
+                    </div>
+                    <span className="text-xs font-semibold uppercase tracking-wide text-[#2A2A2A]/60">
+                      {month.label}
+                    </span>
                   </div>
-                  <span className="text-xs font-semibold uppercase tracking-wide text-[#2A2A2A]/60">
-                    {month.label}
-                  </span>
-                </div>
-              );
-            })}
+                );
+              })}
+            </div>
           </div>
           <p className="mt-4 text-xs text-gray-500">
             Shows the number of published posts per month across the last six months.
@@ -228,7 +230,7 @@ export function DashboardOverview({
         </section>
 
         <section className="lg:col-span-2 rounded-xl border-4 border-black bg-white p-6 shadow-[6px_6px_0px_0px_rgba(0,0,0,0.08)]">
-          <header className="mb-4 flex items-center gap-3">
+          <header className="mb-4 flex flex-wrap items-center gap-3">
             <Users className="h-5 w-5 text-[#FF5252]" aria-hidden="true" />
             <h2 className="text-xl font-bold text-[#2A2A2A]">Content pipeline</h2>
           </header>

--- a/src/components/admin/PromptMonetizationPanel.tsx
+++ b/src/components/admin/PromptMonetizationPanel.tsx
@@ -156,14 +156,14 @@ export function PromptMonetizationPanel() {
             </p>
           ) : null}
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex w-full flex-wrap items-center gap-3 sm:w-auto sm:justify-end">
           <Dialog>
             <DialogTrigger asChild>
-              <Button className="rounded-full border-2 border-black bg-white px-4 py-2 text-xs font-black uppercase tracking-[0.2em]">
+              <Button className="w-full rounded-full border-2 border-black bg-white px-4 py-2 text-xs font-black uppercase tracking-[0.2em] sm:w-auto">
                 Monetization policy
               </Button>
             </DialogTrigger>
-            <DialogContent className="sm:max-w-xl">
+            <DialogContent className="w-[calc(100vw-2rem)] max-w-2xl sm:max-w-xl">
               <DialogHeader>
                 <DialogTitle className="flex items-center gap-2 text-2xl">
                   <Sparkles className="h-6 w-6 text-[#6C63FF]" aria-hidden="true" />
@@ -187,7 +187,7 @@ export function PromptMonetizationPanel() {
           </Dialog>
           <Button
             onClick={() => toast.info("Pricing controls unlock after beta launch.")}
-            className="rounded-full border-2 border-black bg-[#6C63FF] px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-white"
+            className="w-full rounded-full border-2 border-black bg-[#6C63FF] px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-white sm:w-auto"
           >
             Create pricing rule
           </Button>


### PR DESCRIPTION
## Summary
- add horizontal scrolling and flexible headers so dashboard analytics stay readable on small screens
- introduce mobile card layouts for community review queues to eliminate table overflow
- adjust prompt monetization controls to wrap and fit narrow viewports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e78ce3fa0c832db4fedc2052915596