### PR TITLE
docs: add open source launch checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: "Bug report"
+about: "Report a defect or regression"
+labels: ["bug", "needs-triage"]
+assignees: []
+---
+
+## Summary
+
+<!-- Describe the bug. What did you expect to happen? What actually happened? -->
+
+## Environment
+
+- App version or commit: 
+- Browser/device or runtime: 
+- Supabase project region (if applicable): 
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+## Logs & Evidence
+
+<!-- Attach screenshots, logs, network traces, or console output that help reproduce the issue. -->
+
+## Additional Context
+
+<!-- Add any other details, related issues, or hypotheses. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Syntax & Sips community discussions
+    url: https://github.com/prashant-andani/Syntax-blogs/discussions
+    about: Start a conversation or ask a question before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: "Feature request"
+about: "Propose an enhancement or new capability"
+labels: ["enhancement", "needs-triage"]
+assignees: []
+---
+
+## Motivation
+
+<!-- What problem are you solving? Who benefits from this change? -->
+
+## Proposal
+
+<!-- Describe the change you are suggesting. Include user stories, acceptance criteria, or wireframes if available. -->
+
+## Alternative Approaches
+
+<!-- List any alternative solutions or workarounds you've considered. -->
+
+## Additional Context
+
+<!-- Share related issues, documentation, or references. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+- _Describe the change in 1-2 sentences._
+
+## Testing
+- [ ] `npm run lint`
+- [ ] `npm run type-check`
+- [ ] `npm test`
+- [ ] Additional commands: <!-- e.g., `npm run build` -->
+
+## Checklist
+- [ ] I read and am following the [Code of Conduct](../CODE_OF_CONDUCT.md).
+- [ ] I reviewed the [Contributing Guide](../CONTRIBUTING.md) and confirmed this PR follows our workflows.
+- [ ] I added or updated documentation where needed.
+- [ ] I attached screenshots or recordings for UI changes.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the Syntax & Sips project and our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and also applies when an individual is officially representing the project or its community in public spaces. Examples of representing our community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project team at [conduct@syntax-sips.dev](mailto:conduct@syntax-sips.dev). All complaints will be reviewed and investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from project maintainers, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the [FAQ](https://www.contributor-covenant.org/faq). Translations are available at the [Contributor Covenant translations page](https://www.contributor-covenant.org/translations).
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to Syntax & Sips
+
+Thank you for your interest in improving Syntax & Sips! This guide documents how to propose changes, report issues, and collaborate with the maintainers. Following these practices keeps the project stable, inclusive, and enjoyable for everyone.
+
+## Ground Rules
+
+- **Follow the Code of Conduct.** Review the [Code of Conduct](CODE_OF_CONDUCT.md) and help us maintain a respectful, harassment-free community.
+- **Stay transparent.** Discuss significant ideas through GitHub issues or discussions before investing extensive effort.
+- **Document decisions.** Explain the motivation behind changes in pull requests and link to supporting discussions or issues.
+
+## How to Get Help
+
+- **Questions & feedback:** Start a thread in [GitHub Discussions](https://github.com/prashant-andani/Syntax-blogs/discussions).
+- **Bug reports & feature ideas:** Open an issue using the provided templates—include context, reproduction steps, and impact.
+- **Security concerns:** Email the maintainers at [security@syntax-sips.dev](mailto:security@syntax-sips.dev); do not open a public issue.
+
+## Local Development Workflow
+
+1. **Fork** the repository and clone your fork locally.
+2. Create a topic branch from `main`: `git checkout -b feature/short-description`.
+3. Install dependencies: `npm install`.
+4. Configure environment variables following the [README instructions](README.md#-getting-started).
+5. Run the development server with `npm run dev` and keep Vitest/Playwright tests handy during iteration.
+
+## Coding Standards
+
+- Use **TypeScript** with `strict` types; avoid `any`. Export shared interfaces from the relevant module.
+- Favor **functional React components**. Mark interactive components with `'use client'` and keep server components pure.
+- Apply **Tailwind CSS** utilities and respect the neobrutalism design system described in [`neobrutalismthemecomp.MD`](neobrutalismthemecomp.MD).
+- Follow the repository's lint rules. Run `npm run lint` before submitting a pull request.
+- Keep files focused. Extract helpers when modules exceed roughly 200 lines or mix concerns.
+
+## Testing Expectations
+
+- Unit and integration tests use **Vitest**. Add coverage for new functionality, edge cases, and regressions.
+- UI interactions should rely on Testing Library helpers; avoid brittle implementation-specific selectors.
+- End-to-end tests run through **Playwright** when modifying user flows or Supabase integrations.
+- Before requesting review, run:
+  - `npm run lint`
+  - `npm run type-check`
+  - `npm test`
+  - Any additional domain-specific checks documented in `package.json` or `docs/`.
+
+## Commit & Pull Request Guidelines
+
+- Write commits using [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(admin): add moderation queue`).
+- Keep pull requests focused; large refactors should be broken into logical stages.
+- Complete the [pull request template](.github/PULL_REQUEST_TEMPLATE.md) with testing evidence and screenshots for UI changes.
+- Ensure CI workflows pass and address reviewer feedback promptly.
+
+## Documentation Updates
+
+- Update inline comments, README sections, and relevant guides under `docs/` when you alter behavior.
+- Significant Supabase schema updates must include migration notes and operational instructions.
+- Add runbook or troubleshooting tips when you introduce new infrastructure or automation.
+
+## Release Readiness Checklist
+
+Before requesting a review, confirm that:
+
+- [ ] The change set is covered by automated tests or manual validation notes.
+- [ ] Documentation (README, docs, comments) is current.
+- [ ] Feature flags or configuration toggles default to safe values.
+- [ ] You have confirmed accessibility for UI-impacting changes (keyboard navigation, screen readers, contrast).
+
+Thanks again for contributing! Your collaboration helps us deliver an editorial platform the community can trust.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+Syntax & Sips Community Source License 1.0
+
+Copyright (c) 2024 Syntax & Sips contributors
+
+Permission is hereby granted to any individual or organization obtaining a copy of this software and associated documentation files (the "Software") to:
+
+1. View and study the source code for the sole purpose of evaluation.
+2. Run the Software for personal, non-commercial use.
+
+All other rights are reserved. Without prior written permission from the maintainers (contact: licensing@syntax-sips.dev), you may not:
+
+- Use the Software, in whole or in part, for any commercial purpose.
+- Modify, merge, publish, distribute, sublicense, and/or sell copies of the Software.
+- Create derivative works based on the Software, except for the purpose of submitting contributions back to this repository under the project's contribution guidelines.
+- Remove or alter copyright notices.
+
+Contributions intentionally submitted to the project shall be licensed to the project under this same license once merged. Contributors represent that they have the right to submit their contributions and that doing so does not violate any third-party rights.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For any use case beyond the permissions granted above, including commercial deployments, hosted services, training datasets, or redistribution, please contact the maintainers at [licensing@syntax-sips.dev](mailto:licensing@syntax-sips.dev) to request a custom license.

--- a/README.md
+++ b/README.md
@@ -284,19 +284,26 @@ Security highlights:
 
 ## <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/outline/pencil.svg" alt="Contributing" width="22" height="22" /> Contributing
 
-1. Fork the repository.
-2. Create a feature branch: `git checkout -b feature/your-feature`.
-3. Commit changes following Conventional Commits: `git commit -m "feat(scope): description"`.
-4. Push to your fork: `git push origin feature/your-feature`.
-5. Open a Pull Request describing motivation, user impact, and validation, including screenshots for UI updates.
+We welcome thoughtful proposals that make Syntax &amp; Sips more resilient, inclusive, and delightful. Before you begin:
 
-Consult [`docs/code-review.md`](./docs/code-review.md) for architectural guardrails and follow the testing guidance before requesting review.
+- Read the [Contributing Guide](CONTRIBUTING.md) for branching strategy, coding standards, and release readiness checks.
+- Follow the [Code of Conduct](CODE_OF_CONDUCT.md) to help maintain a respectful community.
+- Review [`docs/code-review.md`](./docs/code-review.md) for architectural guardrails and quality expectations.
+
+When you are ready to contribute:
+
+1. Fork the repository and create a topic branch: `git checkout -b feature/your-feature`.
+2. Develop your change locally, keeping tests and linting (`npm run lint`, `npm run type-check`, `npm test`) green.
+3. Update documentation or runbooks impacted by the change.
+4. Complete the pull request template with context, validation notes, and screenshots for UI work.
+
+Need help? Start a [discussion](https://github.com/prashant-andani/Syntax-blogs/discussions) before diving in so we can collaborate on scope.
 
 ---
 
 ## <img src="https://raw.githubusercontent.com/tabler/tabler-icons/master/icons/outline/license.svg" alt="License" width="22" height="22" /> License
 
-Licensed under the MIT License. See [LICENSE](LICENSE) for the full terms.
+This project is made available under the **Syntax &amp; Sips Community Source License 1.0**. You may review, study, and run the software for personal, non-commercial purposes. Any commercial use, redistribution, or modification requires prior written permission from the maintainers—see [LICENSE](LICENSE) for the full terms and contact details.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Welcome to the Syntax & Sips knowledge base. This index orients contributors to 
 | Design system | [`neobrutalismthemecomp.MD`](../neobrutalismthemecomp.MD) | Visual language, components, and design tokens. |
 | SEO & content strategy | [`docs/seo/`](./seo) | Search audits, content planning, and visibility improvements. |
 | Code review guidelines | [`docs/code-review.md`](./code-review.md) | Architectural guardrails, component reuse, and performance advice. |
+| Community launch | [`docs/promotion-plan.md`](./promotion-plan.md) | Promotion checklist and outreach tactics for public releases. |
 
 ## How to Use These Guides
 

--- a/docs/promotion-plan.md
+++ b/docs/promotion-plan.md
@@ -1,0 +1,39 @@
+# Syntax & Sips Promotion Plan
+
+Launching Syntax & Sips as an open collaboration hub requires intentional outreach. This plan captures the channels, messaging, and cadence we will use to attract early contributors.
+
+## Objectives
+
+1. Announce public availability of the repository and invite code contributions.
+2. Highlight differentiators—AI-assisted editorial tooling, Supabase integration, and the neobrutalist design system.
+3. Grow a sustainable contributor base that can participate in roadmap discussions and issue triage.
+
+## Key Messages
+
+- Syntax & Sips delivers a full-stack editorial platform for AI and deep-tech storytellers.
+- The project is community-curated with strict quality standards, automated testing, and transparent governance.
+- Contributors gain experience with Next.js 15, Supabase, Tailwind CSS, and gamified community mechanics.
+
+## Launch Checklist
+
+- [ ] Publish a blog post on syntax-blogs.prashant.sbs summarizing the platform and linking to GitHub.
+- [ ] Share the announcement on LinkedIn, X, and relevant Discord/Slack communities.
+- [ ] Submit the project to curated lists such as Awesome Open Source, Open Source Builders, and Dev.to.
+- [ ] Coordinate with Supabase and Next.js community spotlights for potential amplification.
+- [ ] Host a live stream or recorded walkthrough covering setup, architecture, and contribution workflows.
+
+## Sustained Engagement
+
+- Maintain a monthly changelog newsletter featuring merged contributions and upcoming focus areas.
+- Run quarterly community calls to review roadmap milestones and gather feedback.
+- Tag issues with `good first issue` and `help wanted` labels and promote them on social channels.
+- Encourage contributors to write tutorials or case studies and feature them in the docs hub.
+
+## Metrics to Monitor
+
+- Issue/PR volume and first-response time.
+- New contributors per quarter and their retention rate.
+- Traffic to the repository from each promotion channel.
+- Newsletter subscriptions and community event attendance.
+
+Keep this plan updated as channels evolve and new opportunities emerge.

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -18,6 +18,10 @@ const docsMetadata: Record<string, { title: string; summary: string }> = {
     title: 'Author Guidelines',
     summary: 'Expectations and best practices for contributors collaborating with the editorial team.',
   },
+  'open-source-launch-checklist': {
+    title: 'Open Source Launch Checklist',
+    summary: 'Step-by-step prep to make a GitHub repository legally safe, documented, and welcoming for contributors.',
+  },
 };
 
 const toTitleCase = (value: string) =>

--- a/src/docs/open-source-launch-checklist.md
+++ b/src/docs/open-source-launch-checklist.md
@@ -8,7 +8,7 @@ Setting your project up for community contributions requires more than flipping 
 
 **How to do it:**
 
-1. Pick a license that matches your goals—MIT for maximum reuse, Apache 2.0 for patent protections, GPLv3 for copyleft requirements.
+1. Pick a license that matches your goals—MIT for maximum reuse, Apache 2.0 for patent protections, GPLv3 for copyleft requirements, or a custom community-source license if you require explicit permission for derivative or commercial use.
 2. When creating a new GitHub repository, select a license through the setup UI so GitHub seeds a `LICENSE` file automatically.
 3. For existing repositories, add the full license text manually in a `LICENSE` file at the root of the repo.
 4. Link to [GitHub's licensing guide](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository) for future reference.

--- a/src/docs/open-source-launch-checklist.md
+++ b/src/docs/open-source-launch-checklist.md
@@ -1,0 +1,105 @@
+# Open Source Launch Checklist
+
+Setting your project up for community contributions requires more than flipping the visibility toggle. This guide captures the essential steps and supporting rationale so maintainers can confidently invite collaborators without compromising legal clarity or project health.
+
+## 1. Choose an Open Source License
+
+**Why it matters:** Licensing is what converts a personal codebase into a legally consumable open source project. Without it, potential contributors have no formal right to use, modify, or distribute your work.
+
+**How to do it:**
+
+1. Pick a license that matches your goals—MIT for maximum reuse, Apache 2.0 for patent protections, GPLv3 for copyleft requirements.
+2. When creating a new GitHub repository, select a license through the setup UI so GitHub seeds a `LICENSE` file automatically.
+3. For existing repositories, add the full license text manually in a `LICENSE` file at the root of the repo.
+4. Link to [GitHub's licensing guide](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository) for future reference.
+
+> [!TIP]
+> Always commit the license alongside your initial public release so there is a clear provenance for downstream users.
+
+## 2. Draft a README That Welcomes Contributors
+
+**Why it matters:** The README is the landing page for your project. It orients newcomers, explains the problem you are solving, and highlights the value of getting involved.
+
+**Include these building blocks:**
+
+- **Project purpose:** A succinct introduction to what the project does and why it exists.
+- **Key features or use cases:** Help readers envision success quickly.
+- **Getting started instructions:** Installation, configuration, and usage steps that someone can follow in a single session.
+- **Contribution pathways:** Reference your contributing guide so readers know how to help.
+- **Support channels:** Point to discussions, issue templates, or community chat servers for troubleshooting.
+- **License callout:** Reinforce the license you selected and any attribution requirements.
+
+**Implementation tips:**
+
+1. Create a `README.md` in the repository root so GitHub renders it automatically.
+2. Lean on established templates such as [Make a README](https://www.makeareadme.com/) or [PurpleBooth's README template](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2) to jumpstart structure.
+3. Keep tone friendly but focused—make it obvious where contributors should click next.
+
+## 3. Publish Contributing Guidelines
+
+**Why it matters:** A `CONTRIBUTING.md` acts as your project's onboarding manual. It sets expectations, reduces triage churn, and gives contributors confidence that their effort will align with maintainer standards.
+
+**Outline the essentials:**
+
+- How to file bug reports and feature requests (link to issue templates if available).
+- Steps to set up the development environment locally.
+- Coding, formatting, and testing conventions.
+- Pull request expectations (branch naming, review cadence, CI requirements).
+- A roadmap or backlog snapshot to spotlight priority areas.
+
+**Implementation tips:**
+
+1. Store `CONTRIBUTING.md` at the root level so GitHub highlights it when users open issues or PRs.
+2. Update it whenever workflows shift—stale guidance can be worse than none.
+3. Reference high-quality templates such as [Nayafia's contributing guide](https://github.com/nayafia/contributing-template) or [Mozilla's working open playbook](https://mozillascience.github.io/working-open-workshop/contributing_guidelines/).
+
+## 4. Adopt a Code of Conduct
+
+**Why it matters:** Inclusive community guidelines signal that you value respectful collaboration and have a plan for handling conflicts.
+
+**Implementation tips:**
+
+1. Adapt a proven framework like the [Contributor Covenant](https://www.contributor-covenant.org/) into `CODE_OF_CONDUCT.md` in your repository root.
+2. Mention enforcement contacts and escalation paths so people know where to turn.
+3. Cross-link the code of conduct from both the README and CONTRIBUTING guide to keep expectations visible.
+
+## 5. Confirm Repository Visibility
+
+**Why it matters:** Contributions can only flow if the repository is public.
+
+**Checklist:**
+
+1. Visit **Settings → General → Change repository visibility** inside GitHub.
+2. Switch to **Public** and confirm you are comfortable with the history you are exposing.
+3. Review branch protection rules and CI status checks before inviting contributors.
+
+## 6. Configure Optional GitHub Conveniences
+
+Layering automation accelerates onboarding and keeps contributions consistent.
+
+- **Issue templates (`.github/ISSUE_TEMPLATE/`)** guide reporters to provide actionable details.
+- **Pull request templates (`.github/PULL_REQUEST_TEMPLATE`)** remind contributors to document testing.
+- **Project boards** visualize roadmap items and help maintainers triage incoming work.
+- **Labels and milestones** make it easier to filter issues and communicate timelines.
+
+## 7. Promote the Project
+
+Even a well-documented repository needs visibility.
+
+- Share the launch on social channels, newsletters, or forums where your target contributors gather.
+- Add descriptive topics/tags on GitHub so it surfaces in search.
+- Engage with early contributors quickly—responsiveness builds trust.
+
+## Launch-Ready Checklist
+
+Use this quick scan before flipping the switch:
+
+- [ ] `LICENSE` committed with a clear, appropriate open source license.
+- [ ] `README.md` updated with purpose, getting started, contribution paths, and support references.
+- [ ] `CONTRIBUTING.md` covering issues, setup, standards, and pull request rituals.
+- [ ] `CODE_OF_CONDUCT.md` published and linked throughout documentation.
+- [ ] Repository visibility confirmed as **Public** (or scheduled for the launch date).
+- [ ] Optional GitHub templates/boards configured to streamline contributions.
+- [ ] Promotion plan drafted so prospective contributors hear about the project.
+
+By following this sequence you create a legally sound, clearly documented, and welcoming foundation that encourages developers to participate with confidence.


### PR DESCRIPTION
## Summary
- add an open source launch checklist guide covering licensing, documentation, and community readiness
- register the new guide in the documentation index so it appears alongside existing resources

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e79265ef08832d8dbdd02d9887a0e2