### PR TITLE
fix: polish prompt wizard styling and model catalog onboarding

### DIFF
--- a/src/app/api/admin/model-categories/[id]/route.ts
+++ b/src/app/api/admin/model-categories/[id]/route.ts
@@ -81,17 +81,16 @@ const sanitizeOptionalText = (value: unknown): string | null => {
   return trimmed.length > 0 ? trimmed : null
 }
 
-interface RouteContext {
-  params: { id: string }
-}
-
-export async function PATCH(request: Request, context: RouteContext) {
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
   const result = await getAdminProfile()
   if ('response' in result) {
     return result.response
   }
 
-  const id = context.params.id
+  const { id } = await params
   if (!id) {
     return NextResponse.json({ error: 'Category ID is required.' }, { status: 400 })
   }
@@ -139,13 +138,16 @@ export async function PATCH(request: Request, context: RouteContext) {
   return NextResponse.json({ category: mapCategory(data) })
 }
 
-export async function DELETE(_request: Request, context: RouteContext) {
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
   const result = await getAdminProfile()
   if ('response' in result) {
     return result.response
   }
 
-  const id = context.params.id
+  const { id } = await params
   if (!id) {
     return NextResponse.json({ error: 'Category ID is required.' }, { status: 400 })
   }

--- a/src/app/api/admin/model-categories/[id]/route.ts
+++ b/src/app/api/admin/model-categories/[id]/route.ts
@@ -1,0 +1,164 @@
+import { NextResponse } from 'next/server'
+import slugify from '@sindresorhus/slugify'
+import { createServerComponentClient, createServiceRoleClient } from '@/lib/supabase/server-client'
+import type { AdminModelCategory } from '@/utils/types'
+
+const mapCategory = (record: {
+  id: string
+  name: string
+  slug: string
+  description: string | null
+  accent_color: string | null
+  created_at: string
+  updated_at: string
+}): AdminModelCategory => ({
+  id: record.id,
+  name: record.name,
+  slug: record.slug,
+  description: record.description ?? null,
+  accentColor: record.accent_color ?? null,
+  createdAt: record.created_at,
+  updatedAt: record.updated_at,
+})
+
+const getAdminProfile = async (): Promise<
+  | { response: NextResponse }
+  | { profile: { id: string } }
+> => {
+  const supabase = createServerComponentClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return {
+      response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    }
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, is_admin')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (error) {
+    return {
+      response: NextResponse.json(
+        { error: `Unable to load profile: ${error.message}` },
+        { status: 500 },
+      ),
+    }
+  }
+
+  if (!profile || !profile.is_admin) {
+    return {
+      response: NextResponse.json(
+        { error: 'Forbidden: admin access required.' },
+        { status: 403 },
+      ),
+    }
+  }
+
+  return { profile: { id: profile.id } }
+}
+
+const sanitizeName = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const sanitizeSlug = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? slugify(trimmed) : null
+}
+
+const sanitizeOptionalText = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+interface RouteContext {
+  params: { id: string }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const id = context.params.id
+  if (!id) {
+    return NextResponse.json({ error: 'Category ID is required.' }, { status: 400 })
+  }
+
+  const body = (await request.json()) as Record<string, unknown>
+
+  const updates: Record<string, unknown> = {}
+
+  const name = sanitizeName(body.name)
+  if (name !== null) {
+    updates.name = name
+  }
+
+  const slug = sanitizeSlug(body.slug)
+  if (slug !== null) {
+    updates.slug = slug
+  }
+
+  if ('description' in body) {
+    updates.description = sanitizeOptionalText(body.description)
+  }
+
+  if ('accentColor' in body) {
+    updates.accent_color = sanitizeOptionalText(body.accentColor)
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'No updates provided.' }, { status: 400 })
+  }
+
+  const client = createServiceRoleClient()
+  const { data, error } = await client
+    .from('ai_model_categories')
+    .update(updates)
+    .eq('id', id)
+    .select('*')
+    .single()
+
+  if (error || !data) {
+    const message = error?.message ?? 'Unable to update model category.'
+    const status = message.includes('duplicate key value') ? 409 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+
+  return NextResponse.json({ category: mapCategory(data) })
+}
+
+export async function DELETE(_request: Request, context: RouteContext) {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const id = context.params.id
+  if (!id) {
+    return NextResponse.json({ error: 'Category ID is required.' }, { status: 400 })
+  }
+
+  const client = createServiceRoleClient()
+  const { error } = await client.from('ai_model_categories').delete().eq('id', id)
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Unable to delete model category: ${error.message}` },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/admin/model-categories/route.ts
+++ b/src/app/api/admin/model-categories/route.ts
@@ -1,0 +1,147 @@
+import { NextResponse } from 'next/server'
+import slugify from '@sindresorhus/slugify'
+import { createServerComponentClient, createServiceRoleClient } from '@/lib/supabase/server-client'
+import type { AdminModelCategory } from '@/utils/types'
+
+const mapCategory = (record: {
+  id: string
+  name: string
+  slug: string
+  description: string | null
+  accent_color: string | null
+  created_at: string
+  updated_at: string
+}): AdminModelCategory => ({
+  id: record.id,
+  name: record.name,
+  slug: record.slug,
+  description: record.description ?? null,
+  accentColor: record.accent_color ?? null,
+  createdAt: record.created_at,
+  updatedAt: record.updated_at,
+})
+
+const getAdminProfile = async (): Promise<
+  | { response: NextResponse }
+  | { profile: { id: string } }
+> => {
+  const supabase = createServerComponentClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return {
+      response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    }
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, is_admin')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (error) {
+    return {
+      response: NextResponse.json(
+        { error: `Unable to load profile: ${error.message}` },
+        { status: 500 },
+      ),
+    }
+  }
+
+  if (!profile || !profile.is_admin) {
+    return {
+      response: NextResponse.json(
+        { error: 'Forbidden: admin access required.' },
+        { status: 403 },
+      ),
+    }
+  }
+
+  return { profile: { id: profile.id } }
+}
+
+const sanitizeName = (value: unknown): string => {
+  if (typeof value !== 'string') return ''
+  return value.trim()
+}
+
+const sanitizeSlug = (value: unknown, fallback: string): string => {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return slugify(value.trim())
+  }
+  return slugify(fallback)
+}
+
+const sanitizeOptionalText = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export async function GET() {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const client = createServiceRoleClient()
+  const { data, error } = await client
+    .from('ai_model_categories')
+    .select('*')
+    .order('name')
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Unable to load model categories: ${error.message}` },
+      { status: 500 },
+    )
+  }
+
+  const categories = (data ?? []).map((record) => mapCategory(record))
+  return NextResponse.json({ categories })
+}
+
+export async function POST(request: Request) {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const body = (await request.json()) as Record<string, unknown>
+
+  const name = sanitizeName(body.name)
+  const slug = sanitizeSlug(body.slug, name)
+  const description = sanitizeOptionalText(body.description)
+  const accentColor = sanitizeOptionalText(body.accentColor)
+
+  if (!name) {
+    return NextResponse.json({ error: 'Category name is required.' }, { status: 400 })
+  }
+
+  if (!slug) {
+    return NextResponse.json({ error: 'Category slug is required.' }, { status: 400 })
+  }
+
+  const client = createServiceRoleClient()
+  const { data, error } = await client
+    .from('ai_model_categories')
+    .insert({
+      name,
+      slug,
+      description,
+      accent_color: accentColor,
+    })
+    .select('*')
+    .single()
+
+  if (error || !data) {
+    const message = error?.message ?? 'Unable to create model category.'
+    const status = message.includes('duplicate key value') ? 409 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+
+  return NextResponse.json({ category: mapCategory(data) })
+}

--- a/src/app/api/admin/models/[id]/route.ts
+++ b/src/app/api/admin/models/[id]/route.ts
@@ -7,7 +7,6 @@ const MODEL_SELECT = `
   id,
   name,
   display_name,
-  category,
   category_id,
   version,
   description,
@@ -26,11 +25,17 @@ const MODEL_SELECT = `
   )
 `
 
+type ModelCategoryRecord = {
+  id: string | null
+  name: string | null
+  slug: string | null
+  accent_color?: string | null
+}
+
 type ModelRecord = {
   id: string
   name: string
   display_name: string
-  category: string | null
   category_id: string | null
   version: string | null
   description: string | null
@@ -41,12 +46,7 @@ type ModelRecord = {
   is_active: boolean
   created_at: string
   updated_at: string
-  category?: {
-    id: string | null
-    name: string | null
-    slug: string | null
-    accent_color?: string | null
-  } | null
+  category?: ModelCategoryRecord | ModelCategoryRecord[] | null
 }
 
 const mapModelRecord = (record: ModelRecord): AdminModelSummary => ({
@@ -54,8 +54,16 @@ const mapModelRecord = (record: ModelRecord): AdminModelSummary => ({
   name: record.name as string,
   displayName: record.display_name as string,
   categoryId: (record.category_id as string | null) ?? null,
-  categoryName: (record.category?.name as string | null) ?? null,
-  categorySlug: (record.category?.slug as string | null) ?? record.category ?? null,
+  ...(() => {
+    const categoryData = Array.isArray(record.category)
+      ? (record.category[0] as ModelCategoryRecord | undefined)
+      : (record.category as ModelCategoryRecord | null)
+
+    return {
+      categoryName: categoryData?.name ?? null,
+      categorySlug: categoryData?.slug ?? null,
+    }
+  })(),
   family: (record.family as string | null) ?? null,
   provider: (record.provider as string | null) ?? null,
   version: (record.version as string | null) ?? null,
@@ -200,17 +208,16 @@ const resolveCategory = async (
   }
 }
 
-interface RouteContext {
-  params: { id: string }
-}
-
-export async function PATCH(request: Request, context: RouteContext) {
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
   const result = await getAdminProfile()
   if ('response' in result) {
     return result.response
   }
 
-  const id = context.params.id
+  const { id } = await params
   if (!id) {
     return NextResponse.json({ error: 'Model ID is required.' }, { status: 400 })
   }
@@ -302,13 +309,16 @@ export async function PATCH(request: Request, context: RouteContext) {
   return NextResponse.json({ model: mapModelRecord(data) })
 }
 
-export async function DELETE(_request: Request, context: RouteContext) {
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
   const result = await getAdminProfile()
   if ('response' in result) {
     return result.response
   }
 
-  const id = context.params.id
+  const { id } = await params
   if (!id) {
     return NextResponse.json({ error: 'Model ID is required.' }, { status: 400 })
   }

--- a/src/app/api/admin/models/[id]/route.ts
+++ b/src/app/api/admin/models/[id]/route.ts
@@ -1,0 +1,327 @@
+import { NextResponse } from 'next/server'
+import slugify from '@sindresorhus/slugify'
+import { createServerComponentClient, createServiceRoleClient } from '@/lib/supabase/server-client'
+import type { AdminModelSummary } from '@/utils/types'
+
+const MODEL_SELECT = `
+  id,
+  name,
+  display_name,
+  category,
+  category_id,
+  version,
+  description,
+  icon_url,
+  parameters_schema,
+  family,
+  provider,
+  is_active,
+  created_at,
+  updated_at,
+  category:ai_model_categories!ai_models_category_id_fkey (
+    id,
+    name,
+    slug,
+    accent_color
+  )
+`
+
+type ModelRecord = {
+  id: string
+  name: string
+  display_name: string
+  category: string | null
+  category_id: string | null
+  version: string | null
+  description: string | null
+  icon_url: string | null
+  parameters_schema: Record<string, unknown> | null
+  family: string | null
+  provider: string | null
+  is_active: boolean
+  created_at: string
+  updated_at: string
+  category?: {
+    id: string | null
+    name: string | null
+    slug: string | null
+    accent_color?: string | null
+  } | null
+}
+
+const mapModelRecord = (record: ModelRecord): AdminModelSummary => ({
+  id: record.id as string,
+  name: record.name as string,
+  displayName: record.display_name as string,
+  categoryId: (record.category_id as string | null) ?? null,
+  categoryName: (record.category?.name as string | null) ?? null,
+  categorySlug: (record.category?.slug as string | null) ?? record.category ?? null,
+  family: (record.family as string | null) ?? null,
+  provider: (record.provider as string | null) ?? null,
+  version: (record.version as string | null) ?? null,
+  description: (record.description as string | null) ?? null,
+  iconUrl: (record.icon_url as string | null) ?? null,
+  parametersSchema: (record.parameters_schema as Record<string, unknown> | null) ?? null,
+  isActive: Boolean(record.is_active),
+  createdAt: record.created_at as string,
+  updatedAt: record.updated_at as string,
+})
+
+const getAdminProfile = async (): Promise<
+  | { response: NextResponse }
+  | { profile: { id: string } }
+> => {
+  const supabase = createServerComponentClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return {
+      response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    }
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, is_admin')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (error) {
+    return {
+      response: NextResponse.json(
+        { error: `Unable to load profile: ${error.message}` },
+        { status: 500 },
+      ),
+    }
+  }
+
+  if (!profile || !profile.is_admin) {
+    return {
+      response: NextResponse.json(
+        { error: 'Forbidden: admin access required.' },
+        { status: 403 },
+      ),
+    }
+  }
+
+  return { profile: { id: profile.id } }
+}
+
+const sanitizeName = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  return slugify(trimmed)
+}
+
+const sanitizeDisplayName = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const sanitizeOptionalText = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const sanitizeParametersSchema = (value: unknown):
+  | Record<string, unknown>
+  | null
+  | { error: string } => {
+  if (!(value ?? false)) {
+    return null
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      return null
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed)
+      return typeof parsed === 'object' && parsed
+        ? (parsed as Record<string, unknown>)
+        : null
+    } catch {
+      return { error: 'Parameters schema must be valid JSON.' }
+    }
+  }
+
+  if (typeof value === 'object') {
+    return value as Record<string, unknown>
+  }
+
+  return { error: 'Parameters schema must be valid JSON.' }
+}
+
+const resolveCategory = async (
+  client: ReturnType<typeof createServiceRoleClient>,
+  categoryId: string | null,
+): Promise<
+  | { categoryId: string | null; categoryLabel: string }
+  | { error: NextResponse }
+> => {
+  if (!categoryId) {
+    return { categoryId: null, categoryLabel: 'uncategorized' }
+  }
+
+  const { data, error } = await client
+    .from('ai_model_categories')
+    .select('id, name, slug')
+    .eq('id', categoryId)
+    .maybeSingle()
+
+  if (error) {
+    return {
+      error: NextResponse.json(
+        { error: `Unable to load model category: ${error.message}` },
+        { status: 500 },
+      ),
+    }
+  }
+
+  if (!data) {
+    return {
+      error: NextResponse.json(
+        { error: 'Model category not found.' },
+        { status: 404 },
+      ),
+    }
+  }
+
+  return {
+    categoryId: data.id,
+    categoryLabel: (data.slug ?? data.name) ?? 'uncategorized',
+  }
+}
+
+interface RouteContext {
+  params: { id: string }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const id = context.params.id
+  if (!id) {
+    return NextResponse.json({ error: 'Model ID is required.' }, { status: 400 })
+  }
+
+  const body = (await request.json()) as Record<string, unknown>
+  const updates: Record<string, unknown> = {}
+  const client = createServiceRoleClient()
+
+  if ('name' in body) {
+    const name = sanitizeName(body.name)
+    if (!name) {
+      return NextResponse.json({ error: 'Model name cannot be empty.' }, { status: 400 })
+    }
+    updates.name = name
+  }
+
+  if ('displayName' in body) {
+    const displayName = sanitizeDisplayName(body.displayName)
+    if (!displayName) {
+      return NextResponse.json({ error: 'Display name cannot be empty.' }, { status: 400 })
+    }
+    updates.display_name = displayName
+  }
+
+  if ('family' in body) {
+    updates.family = sanitizeOptionalText(body.family)
+  }
+
+  if ('provider' in body) {
+    updates.provider = sanitizeOptionalText(body.provider)
+  }
+
+  if ('version' in body) {
+    updates.version = sanitizeOptionalText(body.version)
+  }
+
+  if ('description' in body) {
+    updates.description = sanitizeOptionalText(body.description)
+  }
+
+  if ('iconUrl' in body) {
+    updates.icon_url = sanitizeOptionalText(body.iconUrl)
+  }
+
+  if ('isActive' in body) {
+    updates.is_active = Boolean(body.isActive)
+  }
+
+  if ('parametersSchema' in body) {
+    const parsed = sanitizeParametersSchema(body.parametersSchema)
+    if (parsed && 'error' in parsed) {
+      return NextResponse.json({ error: parsed.error }, { status: 400 })
+    }
+    updates.parameters_schema = parsed
+  }
+
+  if ('categoryId' in body) {
+    const rawCategoryId = typeof body.categoryId === 'string' ? body.categoryId.trim() : null
+    const categoryResult = await resolveCategory(
+      client,
+      rawCategoryId && rawCategoryId.length > 0 ? rawCategoryId : null,
+    )
+
+    if ('error' in categoryResult) {
+      return categoryResult.error
+    }
+
+    updates.category_id = categoryResult.categoryId
+    updates.category = categoryResult.categoryLabel
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'No updates provided.' }, { status: 400 })
+  }
+
+  const { data, error } = await client
+    .from('ai_models')
+    .update(updates)
+    .eq('id', id)
+    .select(MODEL_SELECT)
+    .single()
+
+  if (error || !data) {
+    const message = error?.message ?? 'Unable to update AI model.'
+    const status = message.includes('duplicate key value') ? 409 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+
+  return NextResponse.json({ model: mapModelRecord(data) })
+}
+
+export async function DELETE(_request: Request, context: RouteContext) {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const id = context.params.id
+  if (!id) {
+    return NextResponse.json({ error: 'Model ID is required.' }, { status: 400 })
+  }
+
+  const client = createServiceRoleClient()
+  const { error } = await client.from('ai_models').delete().eq('id', id)
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Unable to delete AI model: ${error.message}` },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/admin/models/route.ts
+++ b/src/app/api/admin/models/route.ts
@@ -7,7 +7,6 @@ const MODEL_SELECT = `
   id,
   name,
   display_name,
-  category,
   category_id,
   version,
   description,
@@ -26,11 +25,17 @@ const MODEL_SELECT = `
   )
 `
 
+type ModelCategoryRecord = {
+  id: string | null
+  name: string | null
+  slug: string | null
+  accent_color?: string | null
+}
+
 type ModelRecord = {
   id: string
   name: string
   display_name: string
-  category: string | null
   category_id: string | null
   version: string | null
   description: string | null
@@ -41,12 +46,7 @@ type ModelRecord = {
   is_active: boolean
   created_at: string
   updated_at: string
-  category?: {
-    id: string | null
-    name: string | null
-    slug: string | null
-    accent_color?: string | null
-  } | null
+  category?: ModelCategoryRecord | ModelCategoryRecord[] | null
 }
 
 const mapModelRecord = (record: ModelRecord): AdminModelSummary => ({
@@ -54,8 +54,16 @@ const mapModelRecord = (record: ModelRecord): AdminModelSummary => ({
   name: record.name as string,
   displayName: record.display_name as string,
   categoryId: (record.category_id as string | null) ?? null,
-  categoryName: (record.category?.name as string | null) ?? null,
-  categorySlug: (record.category?.slug as string | null) ?? record.category ?? null,
+  ...(() => {
+    const categoryData = Array.isArray(record.category)
+      ? (record.category[0] as ModelCategoryRecord | undefined)
+      : (record.category as ModelCategoryRecord | null)
+
+    return {
+      categoryName: categoryData?.name ?? null,
+      categorySlug: categoryData?.slug ?? null,
+    }
+  })(),
   family: (record.family as string | null) ?? null,
   provider: (record.provider as string | null) ?? null,
   version: (record.version as string | null) ?? null,

--- a/src/app/api/admin/models/route.ts
+++ b/src/app/api/admin/models/route.ts
@@ -1,0 +1,280 @@
+import { NextResponse } from 'next/server'
+import slugify from '@sindresorhus/slugify'
+import { createServerComponentClient, createServiceRoleClient } from '@/lib/supabase/server-client'
+import type { AdminModelSummary } from '@/utils/types'
+
+const MODEL_SELECT = `
+  id,
+  name,
+  display_name,
+  category,
+  category_id,
+  version,
+  description,
+  icon_url,
+  parameters_schema,
+  family,
+  provider,
+  is_active,
+  created_at,
+  updated_at,
+  category:ai_model_categories!ai_models_category_id_fkey (
+    id,
+    name,
+    slug,
+    accent_color
+  )
+`
+
+type ModelRecord = {
+  id: string
+  name: string
+  display_name: string
+  category: string | null
+  category_id: string | null
+  version: string | null
+  description: string | null
+  icon_url: string | null
+  parameters_schema: Record<string, unknown> | null
+  family: string | null
+  provider: string | null
+  is_active: boolean
+  created_at: string
+  updated_at: string
+  category?: {
+    id: string | null
+    name: string | null
+    slug: string | null
+    accent_color?: string | null
+  } | null
+}
+
+const mapModelRecord = (record: ModelRecord): AdminModelSummary => ({
+  id: record.id as string,
+  name: record.name as string,
+  displayName: record.display_name as string,
+  categoryId: (record.category_id as string | null) ?? null,
+  categoryName: (record.category?.name as string | null) ?? null,
+  categorySlug: (record.category?.slug as string | null) ?? record.category ?? null,
+  family: (record.family as string | null) ?? null,
+  provider: (record.provider as string | null) ?? null,
+  version: (record.version as string | null) ?? null,
+  description: (record.description as string | null) ?? null,
+  iconUrl: (record.icon_url as string | null) ?? null,
+  parametersSchema: (record.parameters_schema as Record<string, unknown> | null) ?? null,
+  isActive: Boolean(record.is_active),
+  createdAt: record.created_at as string,
+  updatedAt: record.updated_at as string,
+})
+
+const getAdminProfile = async (): Promise<
+  | { response: NextResponse }
+  | { profile: { id: string } }
+> => {
+  const supabase = createServerComponentClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return {
+      response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    }
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, is_admin')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (error) {
+    return {
+      response: NextResponse.json(
+        { error: `Unable to load profile: ${error.message}` },
+        { status: 500 },
+      ),
+    }
+  }
+
+  if (!profile || !profile.is_admin) {
+    return {
+      response: NextResponse.json(
+        { error: 'Forbidden: admin access required.' },
+        { status: 403 },
+      ),
+    }
+  }
+
+  return { profile: { id: profile.id } }
+}
+
+const sanitizeName = (value: unknown): string => {
+  if (typeof value !== 'string') return ''
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? slugify(trimmed) : ''
+}
+
+const sanitizeDisplayName = (value: unknown): string => {
+  if (typeof value !== 'string') return ''
+  return value.trim()
+}
+
+const sanitizeOptionalText = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const sanitizeParametersSchema = (value: unknown): Record<string, unknown> | null => {
+  if (!value) return null
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    try {
+      const parsed = JSON.parse(trimmed)
+      return typeof parsed === 'object' && parsed ? (parsed as Record<string, unknown>) : null
+    } catch {
+      throw new Error('Parameters schema must be valid JSON.')
+    }
+  }
+  if (typeof value === 'object') {
+    return value as Record<string, unknown>
+  }
+  return null
+}
+
+const resolveCategory = async (
+  client: ReturnType<typeof createServiceRoleClient>,
+  categoryId: string | null,
+): Promise<
+  | { categoryId: string | null; categoryLabel: string }
+  | { error: NextResponse }
+> => {
+  if (!categoryId) {
+    return { categoryId: null, categoryLabel: 'uncategorized' }
+  }
+
+  const { data, error } = await client
+    .from('ai_model_categories')
+    .select('id, name, slug')
+    .eq('id', categoryId)
+    .maybeSingle()
+
+  if (error) {
+    return {
+      error: NextResponse.json(
+        { error: `Unable to load model category: ${error.message}` },
+        { status: 500 },
+      ),
+    }
+  }
+
+  if (!data) {
+    return {
+      error: NextResponse.json(
+        { error: 'Model category not found.' },
+        { status: 404 },
+      ),
+    }
+  }
+
+  return {
+    categoryId: data.id,
+    categoryLabel: (data.slug ?? data.name) ?? 'uncategorized',
+  }
+}
+
+export async function GET() {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const client = createServiceRoleClient()
+  const { data, error } = await client
+    .from('ai_models')
+    .select(MODEL_SELECT)
+    .order('display_name')
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Unable to load AI models: ${error.message}` },
+      { status: 500 },
+    )
+  }
+
+  const models = (data ?? []).map((record) => mapModelRecord(record))
+  return NextResponse.json({ models })
+}
+
+export async function POST(request: Request) {
+  const result = await getAdminProfile()
+  if ('response' in result) {
+    return result.response
+  }
+
+  const body = (await request.json()) as Record<string, unknown>
+
+  const name = sanitizeName(body.name)
+  const displayName = sanitizeDisplayName(body.displayName)
+  const family = sanitizeOptionalText(body.family)
+  const provider = sanitizeOptionalText(body.provider)
+  const version = sanitizeOptionalText(body.version)
+  const description = sanitizeOptionalText(body.description)
+  const iconUrl = sanitizeOptionalText(body.iconUrl)
+  const isActive = body.isActive === undefined ? true : Boolean(body.isActive)
+
+  if (!name) {
+    return NextResponse.json({ error: 'Model name is required.' }, { status: 400 })
+  }
+
+  if (!displayName) {
+    return NextResponse.json({ error: 'Display name is required.' }, { status: 400 })
+  }
+
+  let parametersSchema: Record<string, unknown> | null = null
+  try {
+    parametersSchema = sanitizeParametersSchema(body.parametersSchema)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid parameters schema.'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+
+  const rawCategoryId = typeof body.categoryId === 'string' ? body.categoryId.trim() : null
+
+  const client = createServiceRoleClient()
+  const categoryResult = await resolveCategory(client, rawCategoryId && rawCategoryId.length > 0 ? rawCategoryId : null)
+
+  if ('error' in categoryResult) {
+    return categoryResult.error
+  }
+
+  const { categoryId, categoryLabel } = categoryResult
+
+  const { data, error } = await client
+    .from('ai_models')
+    .insert({
+      name,
+      display_name: displayName,
+      category: categoryLabel,
+      category_id: categoryId,
+      family,
+      provider,
+      version,
+      description,
+      icon_url: iconUrl,
+      parameters_schema: parametersSchema,
+      is_active: isActive,
+    })
+    .select(MODEL_SELECT)
+    .single()
+
+  if (error || !data) {
+    const message = error?.message ?? 'Unable to create AI model.'
+    const status = message.includes('duplicate key value') ? 409 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+
+  return NextResponse.json({ model: mapModelRecord(data) })
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,15 @@
 @import "tw-animate-css";
 @tailwind utilities;
 
+@layer components {
+  .neo-select-arrow {
+    background-image: url("data:image/svg+xml,%3Csvg%20width='20'%20height='20'%20viewBox='0%200%2024%2024'%20fill='none'%20xmlns='http://www.w3.org/2000/svg'%3E%3Cpath%20d='M6%209l6%206%206-6'%20stroke='%23000000'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-size: 18px 18px;
+    background-position: calc(100% - 20px) 50%;
+  }
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -17,6 +17,7 @@ import { DashboardOverview } from './DashboardOverview'
 import { AnalyticsPanel } from './AnalyticsPanel'
 import { SettingsPanel } from './SettingsPanel'
 import { PromptMonetizationPanel } from './PromptMonetizationPanel'
+import { ModelManager } from './ModelManager'
 import {
   CommunityQueueApplication,
   CommunityQueueSubmission,
@@ -37,6 +38,10 @@ import {
   PostFormValues,
   PostStatus,
   UpdateAdminUserPayload,
+  AdminModelSummary,
+  AdminModelCategory,
+  CreateAdminModelPayload,
+  UpdateAdminModelPayload,
 } from '@/utils/types'
 
 export interface AdminDashboardProps {
@@ -75,6 +80,11 @@ const DashboardContent = ({
   const [communityApplications, setCommunityApplications] = useState<CommunityQueueApplication[]>([])
   const [communitySubmissions, setCommunitySubmissions] = useState<CommunityQueueSubmission[]>([])
   const [isLoadingCommunityQueue, setIsLoadingCommunityQueue] = useState(false)
+  const [modelCategories, setModelCategories] = useState<AdminModelCategory[]>([])
+  const [aiModels, setAiModels] = useState<AdminModelSummary[]>([])
+  const [isLoadingModelCatalog, setIsLoadingModelCatalog] = useState(false)
+  const [hasLoadedModelCatalog, setHasLoadedModelCatalog] = useState(false)
+  const [isModelMutationInFlight, setIsModelMutationInFlight] = useState(false)
 
   const mapPostsFromPayload = useCallback((data: AdminPost[]) => {
     return data.map((post) => ({
@@ -222,6 +232,12 @@ const DashboardContent = ({
       void fetchCommunityQueue()
     }
   }, [currentView, fetchCommunityQueue])
+
+  useEffect(() => {
+    if (currentView === 'models' && !hasLoadedModelCatalog && !isLoadingModelCatalog) {
+      void fetchModelCatalog()
+    }
+  }, [currentView, fetchModelCatalog, hasLoadedModelCatalog, isLoadingModelCatalog])
 
   const handleRefreshPosts = useCallback(async () => {
     try {
@@ -576,6 +592,451 @@ const DashboardContent = ({
   const requestRefreshTags = useCallback(
     () => runTaxonomyAction(() => refreshTags(), 'Tags refreshed.'),
     [refreshTags, runTaxonomyAction],
+  )
+
+  const refreshModelCategories = useCallback(
+    async ({ silent = false }: { silent?: boolean } = {}) => {
+      if (!silent) {
+        setIsModelMutationInFlight(true)
+      }
+
+      try {
+        const response = await fetch('/api/admin/model-categories', {
+          method: 'GET',
+          cache: 'no-store',
+        })
+
+        const payload = await response.json()
+
+        if (!response.ok) {
+          throw new Error(payload.error ?? 'Unable to load model categories.')
+        }
+
+        setModelCategories((payload.categories ?? []) as AdminModelCategory[])
+
+        if (!silent) {
+          showToast({
+            variant: 'success',
+            title: 'Model categories refreshed',
+            description: 'Latest categories loaded successfully.',
+          })
+        }
+
+        return true
+      } catch (error) {
+        showToast({
+          variant: 'error',
+          title: 'Unable to load model categories',
+          description:
+            error instanceof Error
+              ? error.message
+              : 'Unable to load model categories.',
+        })
+        return false
+      } finally {
+        if (!silent) {
+          setIsModelMutationInFlight(false)
+        }
+      }
+    },
+    [showToast],
+  )
+
+  const refreshModels = useCallback(
+    async ({ silent = false }: { silent?: boolean } = {}) => {
+      if (!silent) {
+        setIsModelMutationInFlight(true)
+      }
+
+      try {
+        const response = await fetch('/api/admin/models', {
+          method: 'GET',
+          cache: 'no-store',
+        })
+
+        const payload = await response.json()
+
+        if (!response.ok) {
+          throw new Error(payload.error ?? 'Unable to load AI models.')
+        }
+
+        setAiModels((payload.models ?? []) as AdminModelSummary[])
+
+        if (!silent) {
+          showToast({
+            variant: 'success',
+            title: 'AI models refreshed',
+            description: 'Model catalog updated successfully.',
+          })
+        }
+
+        return true
+      } catch (error) {
+        showToast({
+          variant: 'error',
+          title: 'Unable to load AI models',
+          description:
+            error instanceof Error ? error.message : 'Unable to load AI models.',
+        })
+        return false
+      } finally {
+        if (!silent) {
+          setIsModelMutationInFlight(false)
+        }
+      }
+    },
+    [showToast],
+  )
+
+  const fetchModelCatalog = useCallback(async () => {
+    setIsLoadingModelCatalog(true)
+    const [categoriesOk, modelsOk] = await Promise.all([
+      refreshModelCategories({ silent: true }),
+      refreshModels({ silent: true }),
+    ])
+
+    setHasLoadedModelCatalog(categoriesOk && modelsOk)
+    setIsLoadingModelCatalog(false)
+    return categoriesOk && modelsOk
+  }, [refreshModelCategories, refreshModels])
+
+  const handleCreateModelCategory = useCallback(
+    async (values: {
+      name: string
+      slug?: string
+      description?: string | null
+      accentColor?: string | null
+    }) => {
+      setIsModelMutationInFlight(true)
+
+      try {
+        const response = await fetch('/api/admin/model-categories', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(values),
+        })
+
+        const payload = await response.json()
+
+        if (!response.ok) {
+          throw new Error(payload.error ?? 'Unable to create model category.')
+        }
+
+        const category = payload.category as AdminModelCategory
+        setModelCategories((prev) => {
+          const filtered = prev.filter((item) => item.id !== category.id)
+          return [category, ...filtered]
+        })
+
+        showToast({
+          variant: 'success',
+          title: 'Model category created',
+          description: `${category.name} is ready for new models.`,
+        })
+
+        return true
+      } catch (error) {
+        showToast({
+          variant: 'error',
+          title: 'Unable to create model category',
+          description:
+            error instanceof Error
+              ? error.message
+              : 'Unable to create model category.',
+        })
+        return false
+      } finally {
+        setIsModelMutationInFlight(false)
+      }
+    },
+    [showToast],
+  )
+
+  const handleUpdateModelCategory = useCallback(
+    async (
+      id: string,
+      values: {
+        name?: string
+        slug?: string
+        description?: string | null
+        accentColor?: string | null
+      },
+    ) => {
+      setIsModelMutationInFlight(true)
+
+      try {
+        const response = await fetch(`/api/admin/model-categories/${id}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(values),
+        })
+
+        const payload = await response.json()
+
+        if (!response.ok) {
+          throw new Error(payload.error ?? 'Unable to update model category.')
+        }
+
+        const category = payload.category as AdminModelCategory
+        setModelCategories((prev) =>
+          prev.map((item) => (item.id === category.id ? category : item)),
+        )
+
+        showToast({
+          variant: 'success',
+          title: 'Model category updated',
+          description: `${category.name} saved successfully.`,
+        })
+
+        return true
+      } catch (error) {
+        showToast({
+          variant: 'error',
+          title: 'Unable to update model category',
+          description:
+            error instanceof Error
+              ? error.message
+              : 'Unable to update model category.',
+        })
+        return false
+      } finally {
+        setIsModelMutationInFlight(false)
+      }
+    },
+    [showToast],
+  )
+
+  const handleDeleteModelCategory = useCallback(
+    async (id: string) => {
+      setIsModelMutationInFlight(true)
+
+      try {
+        const response = await fetch(`/api/admin/model-categories/${id}`, {
+          method: 'DELETE',
+        })
+
+        const payload = await response.json()
+
+        if (!response.ok) {
+          throw new Error(payload.error ?? 'Unable to delete model category.')
+        }
+
+        setModelCategories((prev) => prev.filter((item) => item.id !== id))
+        setAiModels((prev) =>
+          prev.map((model) =>
+            model.categoryId === id
+              ? {
+                  ...model,
+                  categoryId: null,
+                  categoryName: null,
+                  categorySlug: null,
+                }
+              : model,
+          ),
+        )
+
+        showToast({
+          variant: 'success',
+          title: 'Model category deleted',
+          description: 'Any linked models are now uncategorized.',
+        })
+
+        return true
+      } catch (error) {
+        showToast({
+          variant: 'error',
+          title: 'Unable to delete model category',
+          description:
+            error instanceof Error
+              ? error.message
+              : 'Unable to delete model category.',
+        })
+        return false
+      } finally {
+        setIsModelMutationInFlight(false)
+      }
+    },
+    [showToast],
+  )
+
+  const handleCreateModel = useCallback(
+    async (values: CreateAdminModelPayload) => {
+      setIsModelMutationInFlight(true)
+
+      try {
+        const response = await fetch('/api/admin/models', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(values),
+        })
+
+        const payload = await response.json()
+
+        if (!response.ok) {
+          throw new Error(payload.error ?? 'Unable to create model.')
+        }
+
+        const model = payload.model as AdminModelSummary
+        setAiModels((prev) => {
+          const filtered = prev.filter((item) => item.id !== model.id)
+          return [model, ...filtered]
+        })
+
+        showToast({
+          variant: 'success',
+          title: 'Model added',
+          description: `${model.displayName} is now available in the prompt wizard.`,
+        })
+
+        return true
+      } catch (error) {
+        showToast({
+          variant: 'error',
+          title: 'Unable to create model',
+          description:
+            error instanceof Error ? error.message : 'Unable to create model.',
+        })
+        return false
+      } finally {
+        setIsModelMutationInFlight(false)
+      }
+    },
+    [showToast],
+  )
+
+  const handleUpdateModel = useCallback(
+    async (id: string, values: UpdateAdminModelPayload) => {
+      setIsModelMutationInFlight(true)
+
+      try {
+        const response = await fetch(`/api/admin/models/${id}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(values),
+        })
+
+        const payload = await response.json()
+
+        if (!response.ok) {
+          throw new Error(payload.error ?? 'Unable to update model.')
+        }
+
+        const model = payload.model as AdminModelSummary
+        setAiModels((prev) => prev.map((item) => (item.id === model.id ? model : item)))
+
+        showToast({
+          variant: 'success',
+          title: 'Model updated',
+          description: `${model.displayName} saved successfully.`,
+        })
+
+        return true
+      } catch (error) {
+        showToast({
+          variant: 'error',
+          title: 'Unable to update model',
+          description:
+            error instanceof Error ? error.message : 'Unable to update model.',
+        })
+        return false
+      } finally {
+        setIsModelMutationInFlight(false)
+      }
+    },
+    [showToast],
+  )
+
+  const handleDeleteModel = useCallback(
+    async (id: string) => {
+      setIsModelMutationInFlight(true)
+
+      try {
+        const response = await fetch(`/api/admin/models/${id}`, {
+          method: 'DELETE',
+        })
+
+        const payload = await response.json()
+
+        if (!response.ok) {
+          throw new Error(payload.error ?? 'Unable to delete model.')
+        }
+
+        setAiModels((prev) => prev.filter((item) => item.id !== id))
+
+        showToast({
+          variant: 'success',
+          title: 'Model deleted',
+          description: 'The model has been removed from the catalog.',
+        })
+
+        return true
+      } catch (error) {
+        showToast({
+          variant: 'error',
+          title: 'Unable to delete model',
+          description:
+            error instanceof Error ? error.message : 'Unable to delete model.',
+        })
+        return false
+      } finally {
+        setIsModelMutationInFlight(false)
+      }
+    },
+    [showToast],
+  )
+
+  const handleToggleModelStatus = useCallback(
+    async (id: string, isActive: boolean) => {
+      setIsModelMutationInFlight(true)
+
+      try {
+        const response = await fetch(`/api/admin/models/${id}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ isActive }),
+        })
+
+        const payload = await response.json()
+
+        if (!response.ok) {
+          throw new Error(payload.error ?? 'Unable to update model status.')
+        }
+
+        const model = payload.model as AdminModelSummary
+        setAiModels((prev) => prev.map((item) => (item.id === model.id ? model : item)))
+
+        showToast({
+          variant: 'success',
+          title: isActive ? 'Model activated' : 'Model paused',
+          description: `${model.displayName} ${isActive ? 'is now visible to creators.' : 'will no longer appear in the wizard.'}`,
+        })
+
+        return true
+      } catch (error) {
+        showToast({
+          variant: 'error',
+          title: 'Unable to update model status',
+          description:
+            error instanceof Error
+              ? error.message
+              : 'Unable to update model status.',
+        })
+        return false
+      } finally {
+        setIsModelMutationInFlight(false)
+      }
+    },
+    [showToast],
   )
 
   const handleDeletePost = async (id: string) => {
@@ -988,6 +1449,7 @@ const DashboardContent = ({
             recentComments={recentComments}
             onNavigateToPosts={() => handleNavigate('posts')}
             onNavigateToComments={() => handleNavigate('comments')}
+            onNavigateToModels={() => handleNavigate('models')}
           />
         )
       case 'posts':
@@ -1030,6 +1492,24 @@ const DashboardContent = ({
             onUpdateTag={requestUpdateTag}
             onDeleteTag={requestDeleteTag}
             onRefreshTags={requestRefreshTags}
+          />
+        )
+      case 'models':
+        return (
+          <ModelManager
+            categories={modelCategories}
+            models={aiModels}
+            isLoading={isLoadingModelCatalog}
+            isMutating={isModelMutationInFlight}
+            onRefreshModels={() => refreshModels()}
+            onRefreshCategories={() => refreshModelCategories()}
+            onCreateCategory={handleCreateModelCategory}
+            onUpdateCategory={handleUpdateModelCategory}
+            onDeleteCategory={handleDeleteModelCategory}
+            onCreateModel={handleCreateModel}
+            onUpdateModel={handleUpdateModel}
+            onDeleteModel={handleDeleteModel}
+            onToggleModelStatus={handleToggleModelStatus}
           />
         )
       case 'users':

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -233,12 +233,6 @@ const DashboardContent = ({
     }
   }, [currentView, fetchCommunityQueue])
 
-  useEffect(() => {
-    if (currentView === 'models' && !hasLoadedModelCatalog && !isLoadingModelCatalog) {
-      void fetchModelCatalog()
-    }
-  }, [currentView, fetchModelCatalog, hasLoadedModelCatalog, isLoadingModelCatalog])
-
   const handleRefreshPosts = useCallback(async () => {
     try {
       await fetchPosts()
@@ -699,6 +693,12 @@ const DashboardContent = ({
     setIsLoadingModelCatalog(false)
     return categoriesOk && modelsOk
   }, [refreshModelCategories, refreshModels])
+
+  useEffect(() => {
+    if (currentView === 'models' && !hasLoadedModelCatalog && !isLoadingModelCatalog) {
+      void fetchModelCatalog()
+    }
+  }, [currentView, fetchModelCatalog, hasLoadedModelCatalog, isLoadingModelCatalog])
 
   const handleCreateModelCategory = useCallback(
     async (values: {

--- a/src/components/admin/DashboardOverview.tsx
+++ b/src/components/admin/DashboardOverview.tsx
@@ -5,8 +5,11 @@ import {
   Activity,
   BarChart2,
   Clock,
+  Cpu,
+  Layers,
   MessageSquare,
   PenTool,
+  Sparkles,
   TrendingUp,
   Users,
 } from "lucide-react";
@@ -18,6 +21,7 @@ interface DashboardOverviewProps {
   recentComments: AdminCommentSummary[];
   onNavigateToPosts: () => void;
   onNavigateToComments: () => void;
+  onNavigateToModels: () => void;
 }
 
 const formatDate = (value: string) =>
@@ -42,6 +46,7 @@ export function DashboardOverview({
   recentComments,
   onNavigateToPosts,
   onNavigateToComments,
+  onNavigateToModels,
 }: DashboardOverviewProps) {
   const [recentPosts, monthlyPublishing, categoryBreakdown, pipeline] = useMemo(() => {
     const sortedPosts = [...posts].sort(
@@ -110,6 +115,35 @@ export function DashboardOverview({
         <p className="text-sm text-[#2A2A2A]/70">
           Monitor publishing cadence, engagement, and moderation at a glance.
         </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        <article className="rounded-[32px] border-[3px] border-black bg-white p-6 shadow-[12px_12px_0_rgba(0,0,0,0.08)]">
+          <header className="flex items-center gap-3">
+            <Cpu className="h-5 w-5 text-[#6C63FF]" aria-hidden="true" />
+            <h2 className="text-xl font-bold text-[#2A2A2A]">Connect your AI model catalog</h2>
+          </header>
+          <p className="mt-3 text-sm text-[#2A2A2A]/80">
+            Unlock richer prompt submissions by curating providers, families, and categories in the model manager.
+          </p>
+          <ul className="mt-4 space-y-2 text-sm text-[#2A2A2A]">
+            <li className="flex items-start gap-2">
+              <Layers className="mt-0.5 h-4 w-4 text-[#FF5252]" aria-hidden="true" />
+              Organize models into themed categories so creators can browse the right tooling.
+            </li>
+            <li className="flex items-start gap-2">
+              <Sparkles className="mt-0.5 h-4 w-4 text-[#6C63FF]" aria-hidden="true" />
+              Capture provider and family metadata so the upload wizard stays accurate.
+            </li>
+          </ul>
+          <button
+            type="button"
+            onClick={onNavigateToModels}
+            className="mt-5 inline-flex items-center gap-2 rounded-[28px] border-[3px] border-black bg-[#6C63FF] px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-white shadow-[6px_6px_0_rgba(0,0,0,0.2)] transition-transform hover:-translate-y-0.5 hover:shadow-[9px_9px_0_rgba(0,0,0,0.26)]"
+          >
+            Manage models
+          </button>
+        </article>
       </div>
 
       <StatsSection posts={posts} />

--- a/src/components/admin/ModelManager.tsx
+++ b/src/components/admin/ModelManager.tsx
@@ -1,0 +1,939 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import {
+  Loader2,
+  Pencil,
+  Plus,
+  RefreshCcw,
+  Trash2,
+  Power,
+  Save,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  AdminModelCategory,
+  AdminModelSummary,
+  CreateAdminModelPayload,
+  UpdateAdminModelPayload,
+} from '@/utils/types'
+import {
+  neoInputClass,
+  neoSelectClass,
+  neoTextareaClass,
+  neoBadgeClass,
+  neoCardClass,
+} from '@/components/ui/neobrutalistFieldStyles'
+
+interface ModelManagerProps {
+  categories: AdminModelCategory[]
+  models: AdminModelSummary[]
+  isLoading: boolean
+  isMutating: boolean
+  onRefreshModels: () => Promise<boolean>
+  onRefreshCategories: () => Promise<boolean>
+  onCreateCategory: (payload: {
+    name: string
+    slug?: string
+    description?: string | null
+    accentColor?: string | null
+  }) => Promise<boolean>
+  onUpdateCategory: (
+    id: string,
+    payload: {
+      name?: string
+      slug?: string
+      description?: string | null
+      accentColor?: string | null
+    },
+  ) => Promise<boolean>
+  onDeleteCategory: (id: string) => Promise<boolean>
+  onCreateModel: (payload: CreateAdminModelPayload) => Promise<boolean>
+  onUpdateModel: (id: string, payload: UpdateAdminModelPayload) => Promise<boolean>
+  onDeleteModel: (id: string) => Promise<boolean>
+  onToggleModelStatus: (id: string, isActive: boolean) => Promise<boolean>
+}
+
+interface ModelFormState {
+  name: string
+  displayName: string
+  categoryId: string
+  provider: string
+  family: string
+  version: string
+  description: string
+  iconUrl: string
+  parametersSchema: string
+  isActive: boolean
+}
+
+const defaultModelForm: ModelFormState = {
+  name: '',
+  displayName: '',
+  categoryId: '',
+  provider: '',
+  family: '',
+  version: '',
+  description: '',
+  iconUrl: '',
+  parametersSchema: '',
+  isActive: true,
+}
+
+const normalizeSlug = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+
+const parseParametersSchema = (value: string): { data: Record<string, unknown> | null; error?: string } => {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return { data: null }
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (typeof parsed !== 'object' || parsed === null) {
+      return { data: null }
+    }
+    return { data: parsed as Record<string, unknown> }
+  } catch (error) {
+    return {
+      data: null,
+      error: error instanceof Error ? error.message : 'Invalid JSON',
+    }
+  }
+}
+
+export function ModelManager({
+  categories,
+  models,
+  isLoading,
+  isMutating,
+  onRefreshCategories,
+  onRefreshModels,
+  onCreateCategory,
+  onUpdateCategory,
+  onDeleteCategory,
+  onCreateModel,
+  onUpdateModel,
+  onDeleteModel,
+  onToggleModelStatus,
+}: ModelManagerProps) {
+  const [categoryName, setCategoryName] = useState('')
+  const [categorySlug, setCategorySlug] = useState('')
+  const [categoryDescription, setCategoryDescription] = useState('')
+  const [categoryAccent, setCategoryAccent] = useState('')
+  const [editingCategoryId, setEditingCategoryId] = useState<string | null>(null)
+  const [categoryDrafts, setCategoryDrafts] = useState<
+    Record<string, { name: string; slug: string; description: string; accentColor: string }>
+  >({})
+
+  const [modelForm, setModelForm] = useState<ModelFormState>(defaultModelForm)
+  const [editingModelId, setEditingModelId] = useState<string | null>(null)
+  const [modelDrafts, setModelDrafts] = useState<Record<string, ModelFormState>>({})
+  const [createParametersError, setCreateParametersError] = useState<string | null>(null)
+  const [editParameterErrors, setEditParameterErrors] = useState<Record<string, string | null>>({})
+
+  const sortedCategories = useMemo(
+    () => [...categories].sort((a, b) => a.name.localeCompare(b.name)),
+    [categories],
+  )
+
+  const sortedModels = useMemo(
+    () => [...models].sort((a, b) => a.displayName.localeCompare(b.displayName)),
+    [models],
+  )
+
+  const handleCreateCategory = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const name = categoryName.trim()
+    const slug = (categorySlug.trim() || normalizeSlug(categoryName)).trim()
+
+    if (!name) {
+      return
+    }
+
+    const success = await onCreateCategory({
+      name,
+      slug,
+      description: categoryDescription.trim() || null,
+      accentColor: categoryAccent.trim() || null,
+    })
+
+    if (success) {
+      setCategoryName('')
+      setCategorySlug('')
+      setCategoryDescription('')
+      setCategoryAccent('')
+    }
+  }
+
+  const handleStartEditCategory = (category: AdminModelCategory) => {
+    setEditingCategoryId(category.id)
+    setCategoryDrafts((prev) => ({
+      ...prev,
+      [category.id]: {
+        name: category.name,
+        slug: category.slug,
+        description: category.description ?? '',
+        accentColor: category.accentColor ?? '',
+      },
+    }))
+  }
+
+  const handleCategoryDraftChange = (
+    id: string,
+    field: 'name' | 'slug' | 'description' | 'accentColor',
+    value: string,
+  ) => {
+    setCategoryDrafts((prev) => ({
+      ...prev,
+      [id]: {
+        ...(prev[id] ?? { name: '', slug: '', description: '', accentColor: '' }),
+        [field]: field === 'slug' ? normalizeSlug(value) : value,
+      },
+    }))
+  }
+
+  const handleSaveCategory = async (id: string) => {
+    const draft = categoryDrafts[id]
+    if (!draft) return
+
+    const success = await onUpdateCategory(id, {
+      name: draft.name.trim(),
+      slug: draft.slug.trim(),
+      description: draft.description.trim() || null,
+      accentColor: draft.accentColor.trim() || null,
+    })
+
+    if (success) {
+      setEditingCategoryId(null)
+      setCategoryDrafts((prev) => {
+        const next = { ...prev }
+        delete next[id]
+        return next
+      })
+    }
+  }
+
+  const handleCreateModel = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const name = modelForm.name.trim() || modelForm.displayName
+    const displayName = modelForm.displayName.trim()
+
+    if (!displayName) {
+      return
+    }
+
+    const { data, error } = parseParametersSchema(modelForm.parametersSchema)
+    if (error) {
+      setCreateParametersError(error)
+      return
+    }
+
+    setCreateParametersError(null)
+
+    const success = await onCreateModel({
+      name,
+      displayName,
+      categoryId: modelForm.categoryId || undefined,
+      provider: modelForm.provider.trim() || undefined,
+      family: modelForm.family.trim() || undefined,
+      version: modelForm.version.trim() || undefined,
+      description: modelForm.description.trim() || undefined,
+      iconUrl: modelForm.iconUrl.trim() || undefined,
+      parametersSchema: data,
+      isActive: modelForm.isActive,
+    })
+
+    if (success) {
+      setModelForm(defaultModelForm)
+    }
+  }
+
+  const handleStartEditModel = (model: AdminModelSummary) => {
+    setEditingModelId(model.id)
+    setEditParameterErrors((prev) => ({
+      ...prev,
+      [model.id]: null,
+    }))
+    setModelDrafts((prev) => ({
+      ...prev,
+      [model.id]: {
+        name: model.name,
+        displayName: model.displayName,
+        categoryId: model.categoryId ?? '',
+        provider: model.provider ?? '',
+        family: model.family ?? '',
+        version: model.version ?? '',
+        description: model.description ?? '',
+        iconUrl: model.iconUrl ?? '',
+        parametersSchema: model.parametersSchema
+          ? JSON.stringify(model.parametersSchema, null, 2)
+          : '',
+        isActive: model.isActive,
+      },
+    }))
+  }
+
+  const handleModelDraftChange = <Key extends keyof ModelFormState>(
+    id: string,
+    key: Key,
+    value: ModelFormState[Key],
+  ) => {
+    setModelDrafts((prev) => ({
+      ...prev,
+      [id]: {
+        ...(prev[id] ?? defaultModelForm),
+        [key]: value,
+      },
+    }))
+  }
+
+  const handleSaveModel = async (id: string) => {
+    const draft = modelDrafts[id]
+    if (!draft) return
+
+    const name = draft.name.trim() || draft.displayName
+    const displayName = draft.displayName.trim()
+
+    if (!displayName) {
+      return
+    }
+
+    const { data, error } = parseParametersSchema(draft.parametersSchema)
+    if (error) {
+      setEditParameterErrors((prev) => ({
+        ...prev,
+        [id]: error,
+      }))
+      return
+    }
+
+    const success = await onUpdateModel(id, {
+      name,
+      displayName,
+      categoryId: draft.categoryId || undefined,
+      provider: draft.provider.trim() || undefined,
+      family: draft.family.trim() || undefined,
+      version: draft.version.trim() || undefined,
+      description: draft.description.trim() || undefined,
+      iconUrl: draft.iconUrl.trim() || undefined,
+      parametersSchema: data,
+      isActive: draft.isActive,
+    })
+
+    if (success) {
+      setEditParameterErrors((prev) => {
+        const next = { ...prev }
+        delete next[id]
+        return next
+      })
+      setEditingModelId(null)
+      setModelDrafts((prev) => {
+        const next = { ...prev }
+        delete next[id]
+        return next
+      })
+    }
+  }
+
+  return (
+    <div className="space-y-10">
+      <header className="space-y-3">
+        <p className="text-xs font-black uppercase tracking-[0.3em] text-black/60">AI Model Directory</p>
+        <h2 className="text-3xl font-black text-black">Curate families, providers, and deployment targets</h2>
+        <p className="max-w-3xl text-sm text-black/70">
+          Keep the prompt gallery grounded in real tooling by mapping every workflow to a provider, model family, and curated
+          category. Administrators can add new models, organize them into themed collections, and toggle availability without
+          touching code.
+        </p>
+      </header>
+
+      <div
+        className={`${neoCardClass} bg-[#FFF5D6] text-sm font-semibold text-black shadow-[12px_12px_0_rgba(0,0,0,0.08)]`}
+      >
+        <p>
+          Add a category for each modality, then register the models that power your prompts. Capture the provider and family so
+          creators can confidently pick the right stack in the upload wizard.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => {
+            void onRefreshModels()
+          }}
+          className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-[#B9FBC0] px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-black shadow-[5px_5px_0_rgba(0,0,0,0.15)] transition-transform hover:-translate-y-0.5 hover:shadow-[7px_7px_0_rgba(0,0,0,0.18)]"
+          disabled={isMutating}
+        >
+          <RefreshCcw className="h-4 w-4" /> Refresh models
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            void onRefreshCategories()
+          }}
+          className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-[#FFE066] px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-black shadow-[5px_5px_0_rgba(0,0,0,0.15)] transition-transform hover:-translate-y-0.5 hover:shadow-[7px_7px_0_rgba(0,0,0,0.18)]"
+          disabled={isMutating}
+        >
+          <RefreshCcw className="h-4 w-4" /> Refresh categories
+        </button>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center gap-3 rounded-3xl border-2 border-dashed border-black/20 bg-white/70 px-4 py-3 text-sm font-semibold text-black/70 shadow-[6px_6px_0_rgba(0,0,0,0.08)]">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading the latest model catalog…
+        </div>
+      ) : null}
+
+      <div className="grid gap-10 lg:grid-cols-[360px_1fr]">
+        <section className="space-y-6">
+          <form onSubmit={handleCreateCategory} className={`${neoCardClass} space-y-4`}>
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-black text-black">Create category</h3>
+              <Plus className="h-5 w-5 text-[#6C63FF]" />
+            </div>
+            <div>
+              <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Name</label>
+              <input
+                value={categoryName}
+                onChange={(event) => {
+                  setCategoryName(event.target.value)
+                  if (!categorySlug.trim()) {
+                    setCategorySlug(normalizeSlug(event.target.value))
+                  }
+                }}
+                className={`mt-2 ${neoInputClass}`}
+                placeholder="Image generation"
+                disabled={isMutating}
+              />
+            </div>
+            <div>
+              <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Slug</label>
+              <input
+                value={categorySlug}
+                onChange={(event) => setCategorySlug(normalizeSlug(event.target.value))}
+                className={`mt-2 ${neoInputClass}`}
+                placeholder="image-generation"
+                disabled={isMutating}
+              />
+            </div>
+            <div>
+              <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Description</label>
+              <textarea
+                value={categoryDescription}
+                onChange={(event) => setCategoryDescription(event.target.value)}
+                className={`mt-2 ${neoTextareaClass} min-h-[120px]`}
+                placeholder="Short blurb to explain when to use this category."
+                disabled={isMutating}
+              />
+            </div>
+            <div>
+              <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Accent color</label>
+              <input
+                value={categoryAccent}
+                onChange={(event) => setCategoryAccent(event.target.value)}
+                className={`mt-2 ${neoInputClass}`}
+                placeholder="#6C63FF"
+                disabled={isMutating}
+              />
+            </div>
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center gap-2 rounded-full border-2 border-black bg-[#6C63FF] px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-white shadow-[5px_5px_0_rgba(0,0,0,0.2)] transition-transform hover:-translate-y-0.5 hover:shadow-[7px_7px_0_rgba(0,0,0,0.25)] disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={isMutating || !categoryName.trim()}
+            >
+              <Plus className="h-4 w-4" /> Save category
+            </button>
+          </form>
+
+          <div className="space-y-4">
+            {sortedCategories.length === 0 ? (
+              <div className={`${neoCardClass} text-sm font-semibold text-black/70`}>
+                No categories yet. Create one to cluster related models.
+              </div>
+            ) : (
+              sortedCategories.map((category) => {
+                const draft = categoryDrafts[category.id]
+                const isEditing = editingCategoryId === category.id
+
+                return (
+                  <div key={category.id} className={`${neoCardClass} space-y-3`}>
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="space-y-1">
+                        <h4 className="text-lg font-black text-black">{category.name}</h4>
+                        <p className="text-xs uppercase tracking-[0.2em] text-black/50">/{category.slug}</p>
+                        {category.description ? (
+                          <p className="text-sm text-black/70">{category.description}</p>
+                        ) : null}
+                        {category.accentColor ? (
+                          <span className={`${neoBadgeClass} mt-1 bg-white/80`}>Accent {category.accentColor}</span>
+                        ) : null}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => (isEditing ? handleSaveCategory(category.id) : handleStartEditCategory(category))}
+                          className="inline-flex items-center justify-center rounded-full border-2 border-black bg-white px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-black shadow-[4px_4px_0_rgba(0,0,0,0.12)] transition-transform hover:-translate-y-0.5 hover:shadow-[6px_6px_0_rgba(0,0,0,0.18)] disabled:cursor-not-allowed disabled:opacity-50"
+                          disabled={isMutating}
+                        >
+                          {isEditing ? (
+                            <>
+                              <Save className="mr-1 h-4 w-4" /> Save
+                            </>
+                          ) : (
+                            <>
+                              <Pencil className="mr-1 h-4 w-4" /> Edit
+                            </>
+                          )}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            void onDeleteCategory(category.id)
+                          }}
+                          className="inline-flex items-center justify-center rounded-full border-2 border-black bg-[#FFADAD] px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-black shadow-[4px_4px_0_rgba(0,0,0,0.12)] transition-transform hover:-translate-y-0.5 hover:shadow-[6px_6px_0_rgba(0,0,0,0.18)] disabled:cursor-not-allowed disabled:opacity-50"
+                          disabled={isMutating}
+                        >
+                          <Trash2 className="mr-1 h-4 w-4" /> Delete
+                        </button>
+                      </div>
+                    </div>
+
+                    {isEditing ? (
+                      <div className="grid gap-3">
+                        <div>
+                          <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Name</label>
+                          <input
+                            value={draft?.name ?? ''}
+                            onChange={(event) => handleCategoryDraftChange(category.id, 'name', event.target.value)}
+                            className={`mt-2 ${neoInputClass}`}
+                            disabled={isMutating}
+                          />
+                        </div>
+                        <div>
+                          <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Slug</label>
+                          <input
+                            value={draft?.slug ?? ''}
+                            onChange={(event) => handleCategoryDraftChange(category.id, 'slug', event.target.value)}
+                            className={`mt-2 ${neoInputClass}`}
+                            disabled={isMutating}
+                          />
+                        </div>
+                        <div>
+                          <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Description</label>
+                          <textarea
+                            value={draft?.description ?? ''}
+                            onChange={(event) => handleCategoryDraftChange(category.id, 'description', event.target.value)}
+                            className={`mt-2 ${neoTextareaClass} min-h-[100px]`}
+                            disabled={isMutating}
+                          />
+                        </div>
+                        <div>
+                          <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Accent color</label>
+                          <input
+                            value={draft?.accentColor ?? ''}
+                            onChange={(event) => handleCategoryDraftChange(category.id, 'accentColor', event.target.value)}
+                            className={`mt-2 ${neoInputClass}`}
+                            disabled={isMutating}
+                          />
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                )
+              })
+            )}
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          <form onSubmit={handleCreateModel} className={`${neoCardClass} space-y-4`}>
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-black text-black">Register model</h3>
+              <Plus className="h-5 w-5 text-[#FF5252]" />
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Display name</label>
+                <input
+                  value={modelForm.displayName}
+                  onChange={(event) =>
+                    setModelForm((prev) => ({ ...prev, displayName: event.target.value }))
+                  }
+                  className={`mt-2 ${neoInputClass}`}
+                  placeholder="Stable Diffusion XL"
+                  disabled={isMutating}
+                />
+              </div>
+              <div>
+                <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">System name</label>
+                <input
+                  value={modelForm.name}
+                  onChange={(event) =>
+                    setModelForm((prev) => ({ ...prev, name: normalizeSlug(event.target.value) }))
+                  }
+                  className={`mt-2 ${neoInputClass}`}
+                  placeholder="stable-diffusion-xl"
+                  disabled={isMutating}
+                />
+              </div>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Provider</label>
+                <input
+                  value={modelForm.provider}
+                  onChange={(event) =>
+                    setModelForm((prev) => ({ ...prev, provider: event.target.value }))
+                  }
+                  className={`mt-2 ${neoInputClass}`}
+                  placeholder="Stability AI"
+                  disabled={isMutating}
+                />
+                <p className="mt-2 text-xs text-black/60">Name the vendor or API powering this model.</p>
+              </div>
+              <div>
+                <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Family</label>
+                <input
+                  value={modelForm.family}
+                  onChange={(event) =>
+                    setModelForm((prev) => ({ ...prev, family: event.target.value }))
+                  }
+                  className={`mt-2 ${neoInputClass}`}
+                  placeholder="diffusion"
+                  disabled={isMutating}
+                />
+                <p className="mt-2 text-xs text-black/60">Group related deployments (LLM, diffusion, audio, etc.).</p>
+              </div>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Version</label>
+                <input
+                  value={modelForm.version}
+                  onChange={(event) =>
+                    setModelForm((prev) => ({ ...prev, version: event.target.value }))
+                  }
+                  className={`mt-2 ${neoInputClass}`}
+                  placeholder="1.0"
+                  disabled={isMutating}
+                />
+              </div>
+              <div>
+                <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Category</label>
+                <select
+                  value={modelForm.categoryId}
+                  onChange={(event) =>
+                    setModelForm((prev) => ({ ...prev, categoryId: event.target.value }))
+                  }
+                  className={`mt-2 ${neoSelectClass}`}
+                  disabled={isMutating}
+                >
+                  <option value="">Uncategorized</option>
+                  {sortedCategories.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                    </option>
+                  ))}
+                </select>
+                {sortedCategories.length === 0 ? (
+                  <p className="mt-2 text-xs text-black/60">
+                    Create a category on the left to group similar providers; new models stay uncategorized until then.
+                  </p>
+                ) : null}
+              </div>
+            </div>
+            <div>
+              <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Description</label>
+              <textarea
+                value={modelForm.description}
+                onChange={(event) =>
+                  setModelForm((prev) => ({ ...prev, description: event.target.value }))
+                }
+                className={`mt-2 ${neoTextareaClass} min-h-[120px]`}
+                placeholder="Where does this model shine? Include typical prompts or guidance."
+                disabled={isMutating}
+              />
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Icon URL</label>
+                <input
+                  value={modelForm.iconUrl}
+                  onChange={(event) =>
+                    setModelForm((prev) => ({ ...prev, iconUrl: event.target.value }))
+                  }
+                  className={`mt-2 ${neoInputClass}`}
+                  placeholder="https://..."
+                  disabled={isMutating}
+                />
+              </div>
+              <div className="flex items-end justify-between">
+                <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Active</label>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setModelForm((prev) => ({ ...prev, isActive: !prev.isActive }))
+                  }
+                  className={cn(
+                    'inline-flex items-center gap-2 rounded-full border-2 border-black px-4 py-2 text-xs font-black uppercase tracking-[0.2em] shadow-[5px_5px_0_rgba(0,0,0,0.15)] transition-transform hover:-translate-y-0.5 hover:shadow-[7px_7px_0_rgba(0,0,0,0.2)]',
+                    modelForm.isActive ? 'bg-[#B9FBC0] text-black' : 'bg-[#FFADAD] text-black',
+                  )}
+                  disabled={isMutating}
+                >
+                  <Power className="h-4 w-4" /> {modelForm.isActive ? 'Enabled' : 'Paused'}
+                </button>
+              </div>
+            </div>
+            <div>
+              <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Parameters schema (JSON)</label>
+              <textarea
+                value={modelForm.parametersSchema}
+                onChange={(event) => setModelForm((prev) => ({ ...prev, parametersSchema: event.target.value }))}
+                className={`mt-2 ${neoTextareaClass} min-h-[140px] font-mono`}
+                placeholder='{ "cfg_scale": 7 }'
+                disabled={isMutating}
+              />
+            </div>
+            {createParametersError ? (
+              <p className="text-sm font-semibold text-[#FF5252]">{createParametersError}</p>
+            ) : null}
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center gap-2 rounded-full border-2 border-black bg-[#6C63FF] px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-white shadow-[5px_5px_0_rgba(0,0,0,0.2)] transition-transform hover:-translate-y-0.5 hover:shadow-[7px_7px_0_rgba(0,0,0,0.25)] disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={isMutating || !modelForm.displayName.trim()}
+            >
+              <Plus className="h-4 w-4" /> Publish model
+            </button>
+          </form>
+
+          <div className="space-y-5">
+            {sortedModels.length === 0 ? (
+              <div className={`${neoCardClass} text-sm font-semibold text-black/70`}>
+                No models registered. Add your first provider above to unlock the prompt submission wizard.
+              </div>
+            ) : (
+              sortedModels.map((model) => {
+                const draft = modelDrafts[model.id]
+                const isEditing = editingModelId === model.id
+
+                return (
+                  <div key={model.id} className={`${neoCardClass} space-y-4`}>
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="space-y-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h4 className="text-xl font-black text-black">{model.displayName}</h4>
+                          <span
+                            className={cn(
+                              neoBadgeClass,
+                              model.isActive ? 'bg-[#B9FBC0]' : 'bg-[#FFADAD]',
+                              'text-black',
+                            )}
+                          >
+                            {model.isActive ? 'Active' : 'Inactive'}
+                          </span>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-black/60">
+                          {model.provider ? <span>{model.provider}</span> : null}
+                          {model.family ? <span>{model.family}</span> : null}
+                          {model.version ? <span>v{model.version}</span> : null}
+                          {model.categoryName ? <span>#{model.categoryName}</span> : null}
+                        </div>
+                        {model.description ? (
+                          <p className="text-sm text-black/70">{model.description}</p>
+                        ) : null}
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            void onToggleModelStatus(model.id, !model.isActive)
+                          }}
+                          className="inline-flex items-center justify-center rounded-full border-2 border-black bg-white px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-black shadow-[4px_4px_0_rgba(0,0,0,0.12)] transition-transform hover:-translate-y-0.5 hover:shadow-[6px_6px_0_rgba(0,0,0,0.18)] disabled:cursor-not-allowed disabled:opacity-50"
+                          disabled={isMutating}
+                        >
+                          <Power className="mr-1 h-4 w-4" /> {model.isActive ? 'Disable' : 'Enable'}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => (isEditing ? handleSaveModel(model.id) : handleStartEditModel(model))}
+                          className="inline-flex items-center justify-center rounded-full border-2 border-black bg-white px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-black shadow-[4px_4px_0_rgba(0,0,0,0.12)] transition-transform hover:-translate-y-0.5 hover:shadow-[6px_6px_0_rgba(0,0,0,0.18)] disabled:cursor-not-allowed disabled:opacity-50"
+                          disabled={isMutating}
+                        >
+                          {isEditing ? (
+                            <>
+                              <Save className="mr-1 h-4 w-4" /> Save
+                            </>
+                          ) : (
+                            <>
+                              <Pencil className="mr-1 h-4 w-4" /> Edit
+                            </>
+                          )}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            void onDeleteModel(model.id)
+                          }}
+                          className="inline-flex items-center justify-center rounded-full border-2 border-black bg-[#FFADAD] px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-black shadow-[4px_4px_0_rgba(0,0,0,0.12)] transition-transform hover:-translate-y-0.5 hover:shadow-[6px_6px_0_rgba(0,0,0,0.18)] disabled:cursor-not-allowed disabled:opacity-50"
+                          disabled={isMutating}
+                        >
+                          <Trash2 className="mr-1 h-4 w-4" /> Delete
+                        </button>
+                      </div>
+                    </div>
+
+                    {isEditing ? (
+                      <div className="grid gap-4">
+                        <div className="grid gap-4 sm:grid-cols-2">
+                          <div>
+                            <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Display name</label>
+                            <input
+                              value={draft?.displayName ?? ''}
+                              onChange={(event) =>
+                                handleModelDraftChange(model.id, 'displayName', event.target.value)
+                              }
+                              className={`mt-2 ${neoInputClass}`}
+                              disabled={isMutating}
+                            />
+                          </div>
+                          <div>
+                            <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">System name</label>
+                            <input
+                              value={draft?.name ?? ''}
+                              onChange={(event) =>
+                                handleModelDraftChange(model.id, 'name', normalizeSlug(event.target.value))
+                              }
+                              className={`mt-2 ${neoInputClass}`}
+                              disabled={isMutating}
+                            />
+                          </div>
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                          <div>
+                            <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Provider</label>
+                            <input
+                              value={draft?.provider ?? ''}
+                              onChange={(event) =>
+                                handleModelDraftChange(model.id, 'provider', event.target.value)
+                              }
+                              className={`mt-2 ${neoInputClass}`}
+                              disabled={isMutating}
+                            />
+                          </div>
+                          <div>
+                            <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Family</label>
+                            <input
+                              value={draft?.family ?? ''}
+                              onChange={(event) =>
+                                handleModelDraftChange(model.id, 'family', event.target.value)
+                              }
+                              className={`mt-2 ${neoInputClass}`}
+                              disabled={isMutating}
+                            />
+                          </div>
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                          <div>
+                            <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Version</label>
+                            <input
+                              value={draft?.version ?? ''}
+                              onChange={(event) =>
+                                handleModelDraftChange(model.id, 'version', event.target.value)
+                              }
+                              className={`mt-2 ${neoInputClass}`}
+                              disabled={isMutating}
+                            />
+                          </div>
+                          <div>
+                            <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Category</label>
+                            <select
+                              value={draft?.categoryId ?? ''}
+                              onChange={(event) =>
+                                handleModelDraftChange(model.id, 'categoryId', event.target.value)
+                              }
+                              className={`mt-2 ${neoSelectClass}`}
+                              disabled={isMutating}
+                            >
+                              <option value="">Uncategorized</option>
+                              {sortedCategories.map((category) => (
+                                <option key={category.id} value={category.id}>
+                                  {category.name}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                        </div>
+                        <div>
+                          <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Description</label>
+                          <textarea
+                            value={draft?.description ?? ''}
+                            onChange={(event) =>
+                              handleModelDraftChange(model.id, 'description', event.target.value)
+                            }
+                            className={`mt-2 ${neoTextareaClass} min-h-[120px]`}
+                            disabled={isMutating}
+                          />
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                          <div>
+                            <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Icon URL</label>
+                            <input
+                              value={draft?.iconUrl ?? ''}
+                              onChange={(event) =>
+                                handleModelDraftChange(model.id, 'iconUrl', event.target.value)
+                              }
+                              className={`mt-2 ${neoInputClass}`}
+                              disabled={isMutating}
+                            />
+                          </div>
+                          <div className="flex items-end justify-between">
+                            <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Active</label>
+                            <button
+                              type="button"
+                              onClick={() =>
+                                handleModelDraftChange(model.id, 'isActive', !(draft?.isActive ?? false))
+                              }
+                              className={cn(
+                                'inline-flex items-center gap-2 rounded-full border-2 border-black px-4 py-2 text-xs font-black uppercase tracking-[0.2em] shadow-[5px_5px_0_rgba(0,0,0,0.15)] transition-transform hover:-translate-y-0.5 hover:shadow-[7px_7px_0_rgba(0,0,0,0.2)]',
+                                draft?.isActive ? 'bg-[#B9FBC0] text-black' : 'bg-[#FFADAD] text-black',
+                              )}
+                              disabled={isMutating}
+                            >
+                              <Power className="h-4 w-4" /> {draft?.isActive ? 'Enabled' : 'Paused'}
+                            </button>
+                          </div>
+                        </div>
+                        <div>
+                          <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Parameters schema (JSON)</label>
+                          <textarea
+                            value={draft?.parametersSchema ?? ''}
+                            onChange={(event) =>
+                              handleModelDraftChange(model.id, 'parametersSchema', event.target.value)
+                            }
+                            className={`mt-2 ${neoTextareaClass} min-h-[140px] font-mono`}
+                            disabled={isMutating}
+                          />
+                        </div>
+                        {editParameterErrors[model.id] ? (
+                          <p className="text-sm font-semibold text-[#FF5252]">{editParameterErrors[model.id]}</p>
+                        ) : null}
+                      </div>
+                    ) : null}
+                  </div>
+                )
+              })
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/Sidebar.tsx
+++ b/src/components/admin/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Tag,
   Users,
   X,
+  Cpu,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
@@ -122,6 +123,14 @@ export const Sidebar = ({
                 label="Taxonomy"
                 isActive={currentView === 'taxonomy'}
                 onClick={() => onNavigate('taxonomy')}
+              />
+            )}
+            {isAdmin && (
+              <SidebarLink
+                icon={<Cpu />}
+                label="Models"
+                isActive={currentView === 'models'}
+                onClick={() => onNavigate('models')}
               />
             )}
             {isAdmin && (

--- a/src/components/prompt-gallery/PromptUploadWizard.tsx
+++ b/src/components/prompt-gallery/PromptUploadWizard.tsx
@@ -3,6 +3,13 @@
 import { useMemo, useState, useTransition } from 'react'
 import { PromptModel } from '@/lib/prompt-gallery/types'
 import { CreatePromptInput } from '@/lib/prompt-gallery/validation'
+import {
+  neoInputClass,
+  neoSelectClass,
+  neoTextareaClass,
+  neoCardClass,
+  neoBadgeClass,
+} from '@/components/ui/neobrutalistFieldStyles'
 
 interface PromptUploadWizardProps {
   models: PromptModel[]
@@ -163,7 +170,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
                 value={formData.title}
                 onChange={(event) => updateField('title', event.target.value)}
                 placeholder="Give your prompt a name"
-                className="mt-2 w-full rounded-2xl border-2 border-black bg-white px-4 py-3 text-sm shadow-[4px_4px_0_rgba(0,0,0,0.12)] focus:outline-none"
+                className={`mt-2 ${neoInputClass}`}
               />
             </div>
             <div>
@@ -172,7 +179,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
                 value={formData.description ?? ''}
                 onChange={(event) => updateField('description', event.target.value)}
                 placeholder="Describe what makes this prompt special"
-                className="mt-2 w-full rounded-2xl border-2 border-black bg-white px-4 py-3 text-sm shadow-[4px_4px_0_rgba(0,0,0,0.12)] focus:outline-none"
+                className={`mt-2 ${neoTextareaClass} min-h-[120px]`}
               />
             </div>
             <div className="grid gap-4 sm:grid-cols-2">
@@ -181,7 +188,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
                 <select
                   value={formData.mediaType}
                   onChange={(event) => updateField('mediaType', event.target.value as CreatePromptInput['mediaType'])}
-                  className="mt-2 w-full rounded-2xl border-2 border-black bg-white px-4 py-3 text-sm shadow-[4px_4px_0_rgba(0,0,0,0.12)] focus:outline-none"
+                  className={`mt-2 ${neoSelectClass}`}
                 >
                   {mediaOptions.map((option) => (
                     <option key={option} value={option}>
@@ -195,7 +202,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
                 <select
                   value={formData.difficulty}
                   onChange={(event) => updateField('difficulty', event.target.value as CreatePromptInput['difficulty'])}
-                  className="mt-2 w-full rounded-2xl border-2 border-black bg-white px-4 py-3 text-sm shadow-[4px_4px_0_rgba(0,0,0,0.12)] focus:outline-none"
+                  className={`mt-2 ${neoSelectClass}`}
                 >
                   {difficultyOptions.map((option) => (
                     <option key={option} value={option}>
@@ -211,7 +218,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
                 <input
                   value={formData.language}
                   onChange={(event) => updateField('language', event.target.value)}
-                  className="mt-2 w-full rounded-2xl border-2 border-black bg-white px-4 py-3 text-sm shadow-[4px_4px_0_rgba(0,0,0,0.12)] focus:outline-none"
+                  className={`mt-2 ${neoInputClass}`}
                 />
               </div>
               <div>
@@ -219,7 +226,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
                 <select
                   value={formData.monetizationType}
                   disabled
-                  className="mt-2 w-full cursor-not-allowed rounded-2xl border-2 border-dashed border-black/40 bg-[#F5F3FF] px-4 py-3 text-sm font-semibold uppercase text-black/50 shadow-[4px_4px_0_rgba(0,0,0,0.12)]"
+                  className={`mt-2 ${neoSelectClass} uppercase tracking-[0.2em] text-black/60`}
                 >
                   {monetizationOptions.map((option) => (
                     <option key={option} value={option}>
@@ -236,7 +243,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
                 <select
                   value={formData.visibility}
                   onChange={(event) => updateField('visibility', event.target.value as CreatePromptInput['visibility'])}
-                  className="mt-2 w-full rounded-2xl border-2 border-black bg-white px-4 py-3 text-sm shadow-[4px_4px_0_rgba(0,0,0,0.12)] focus:outline-none"
+                  className={`mt-2 ${neoSelectClass}`}
                 >
                   {visibilityOptions.map((option) => (
                     <option key={option} value={option}>
@@ -250,7 +257,8 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
                 <input
                   value="Coming soon"
                   readOnly
-                  className="mt-2 w-full cursor-not-allowed rounded-2xl border-2 border-dashed border-black/40 bg-[#F5F3FF] px-4 py-3 text-sm font-semibold uppercase text-black/50 shadow-[4px_4px_0_rgba(0,0,0,0.12)]"
+                  className={`mt-2 ${neoInputClass} uppercase tracking-[0.2em] text-black/60`}
+                  disabled
                 />
               </div>
             </div>
@@ -264,7 +272,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
               <textarea
                 value={formData.promptText}
                 onChange={(event) => updateField('promptText', event.target.value)}
-                className="mt-2 w-full min-h-[160px] rounded-2xl border-2 border-black bg-white px-4 py-3 text-sm shadow-[4px_4px_0_rgba(0,0,0,0.12)] focus:outline-none"
+                className={`mt-2 ${neoTextareaClass} min-h-[180px]`}
               />
             </div>
             <div>
@@ -272,7 +280,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
               <textarea
                 value={formData.negativePrompt ?? ''}
                 onChange={(event) => updateField('negativePrompt', event.target.value)}
-                className="mt-2 w-full min-h-[120px] rounded-2xl border-2 border-black bg-white px-4 py-3 text-sm shadow-[4px_4px_0_rgba(0,0,0,0.12)] focus:outline-none"
+                className={`mt-2 ${neoTextareaClass} min-h-[140px]`}
               />
             </div>
             <div>
@@ -288,7 +296,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
                     setErrorMessage('Parameters must be valid JSON.')
                   }
                 }}
-                className="mt-2 w-full min-h-[140px] rounded-2xl border-2 border-black bg-white px-4 py-3 text-sm shadow-[4px_4px_0_rgba(0,0,0,0.12)] focus:outline-none"
+                className={`mt-2 ${neoTextareaClass} min-h-[160px] font-mono`}
               />
             </div>
           </div>
@@ -301,20 +309,23 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
               <button
                 type="button"
                 onClick={addAsset}
-                className="rounded-full border-2 border-black bg-[#FFCA3A] px-3 py-1 text-xs font-black uppercase tracking-[0.2em] text-black shadow-[3px_3px_0_rgba(0,0,0,0.15)]"
+                className="rounded-full border-2 border-black bg-[#FFCA3A] px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-black shadow-[5px_5px_0_rgba(0,0,0,0.18)] transition-transform hover:-translate-y-0.5 hover:shadow-[7px_7px_0_rgba(0,0,0,0.2)]"
               >
                 Add asset
               </button>
             </div>
             {(formData.assets ?? []).map((asset, index) => (
-              <div key={index} className="rounded-2xl border-2 border-black bg-white p-4 shadow-[4px_4px_0_rgba(0,0,0,0.12)]">
+              <div
+                key={index}
+                className="rounded-[30px] border-[3px] border-black bg-white/90 p-4 shadow-[8px_8px_0_rgba(0,0,0,0.14)] backdrop-blur-sm"
+              >
                 <div className="grid gap-3 sm:grid-cols-2">
                   <div>
                     <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">File URL</label>
                     <input
                       value={asset.file_url}
                       onChange={(event) => updateAsset(index, 'file_url', event.target.value)}
-                      className="mt-2 w-full rounded-2xl border-2 border-black bg-white px-3 py-2 text-sm focus:outline-none"
+                      className={`mt-2 ${neoInputClass} px-4 py-2`}
                     />
                   </div>
                   <div>
@@ -322,7 +333,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
                     <input
                       value={asset.thumbnail_url ?? ''}
                       onChange={(event) => updateAsset(index, 'thumbnail_url', event.target.value)}
-                      className="mt-2 w-full rounded-2xl border-2 border-black bg-white px-3 py-2 text-sm focus:outline-none"
+                      className={`mt-2 ${neoInputClass} px-4 py-2`}
                     />
                   </div>
                 </div>
@@ -330,7 +341,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
                   <button
                     type="button"
                     onClick={() => removeAsset(index)}
-                    className="rounded-full border-2 border-black bg-white px-3 py-1 text-xs font-black uppercase tracking-[0.2em] text-black"
+                    className="rounded-full border-2 border-black bg-white px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-black shadow-[4px_4px_0_rgba(0,0,0,0.12)] transition-transform hover:-translate-y-0.5 hover:shadow-[6px_6px_0_rgba(0,0,0,0.18)]"
                   >
                     Remove
                   </button>
@@ -350,27 +361,41 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
               <select
                 value={formData.primaryModelId}
                 onChange={(event) => updateField('primaryModelId', event.target.value)}
-                className="mt-2 w-full rounded-2xl border-2 border-black bg-white px-4 py-3 text-sm shadow-[4px_4px_0_rgba(0,0,0,0.12)] focus:outline-none"
+                className={`mt-2 ${neoSelectClass}`}
               >
-                {models.map((model) => (
-                  <option key={model.id} value={model.id}>
-                    {model.display_name} ({model.category})
-                  </option>
-                ))}
+                {models.map((model) => {
+                  const provider = model.provider ? ` • ${model.provider}` : ''
+                  const family = model.family ? ` — ${model.family}` : ''
+                  return (
+                    <option key={model.id} value={model.id}>
+                      {model.display_name}
+                      {provider}
+                      {family}
+                    </option>
+                  )
+                })}
               </select>
             </div>
             <div>
               <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Secondary models</label>
-              <div className="mt-2 grid gap-2 sm:grid-cols-2">
+              <div className="mt-2 grid gap-3 sm:grid-cols-2">
                 {models.map((model) => (
-                  <label key={model.id} className="flex items-center gap-2 rounded-2xl border-2 border-black bg-white px-3 py-2 text-sm shadow-[3px_3px_0_rgba(0,0,0,0.12)]">
+                  <label
+                    key={model.id}
+                    className="flex items-center justify-between gap-3 rounded-[30px] border-[3px] border-black bg-white/95 px-4 py-3 text-sm font-semibold text-black shadow-[8px_8px_0_rgba(0,0,0,0.14)] transition-transform hover:-translate-y-0.5 hover:shadow-[11px_11px_0_rgba(0,0,0,0.2)]"
+                  >
                     <input
                       type="checkbox"
                       checked={formData.secondaryModelIds?.includes(model.id) ?? false}
                       onChange={() => toggleSecondaryModel(model.id)}
-                      className="h-4 w-4"
+                      className="h-4 w-4 accent-[#6C63FF]"
                     />
-                    <span>{model.display_name}</span>
+                    <div className="flex flex-1 flex-col text-left">
+                      <span className="font-black uppercase tracking-[0.1em]">{model.display_name}</span>
+                      <span className="text-xs text-black/60">
+                        {[model.provider, model.family, model.category].filter(Boolean).join(' • ')}
+                      </span>
+                    </div>
                   </label>
                 ))}
               </div>
@@ -379,9 +404,17 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
               <label className="text-xs font-black uppercase tracking-[0.2em] text-black/60">Tags</label>
               <input
                 value={(formData.tags ?? []).join(', ')}
-                onChange={(event) => updateField('tags', event.target.value.split(',').map((tag) => tag.trim()).filter(Boolean))}
+                onChange={(event) =>
+                  updateField(
+                    'tags',
+                    event.target.value
+                      .split(',')
+                      .map((tag) => tag.trim())
+                      .filter(Boolean),
+                  )
+                }
                 placeholder="marketing, cinematic, launch, ..."
-                className="mt-2 w-full rounded-2xl border-2 border-black bg-white px-4 py-3 text-sm shadow-[4px_4px_0_rgba(0,0,0,0.12)] focus:outline-none"
+                className={`mt-2 ${neoInputClass}`}
               />
               <p className="mt-2 text-xs text-black/60">Separate tags with commas. Max 12 tags.</p>
             </div>
@@ -391,16 +424,25 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
         return (
           <div className="space-y-4">
             <h3 className="text-sm font-black uppercase tracking-[0.2em] text-black/70">Review</h3>
-            <div className="rounded-2xl border-2 border-black bg-white p-4 shadow-[4px_4px_0_rgba(0,0,0,0.12)]">
+            <div className={`${neoCardClass} bg-white`}>
               <p className="text-base font-black text-black">{formData.title}</p>
               <p className="mt-1 text-sm text-black/70">{formData.description}</p>
-              <ul className="mt-3 space-y-1 text-sm text-black/80">
-                <li>Primary model: {models.find((model) => model.id === formData.primaryModelId)?.display_name ?? 'Not selected'}</li>
-                <li>Secondary models: {(formData.secondaryModelIds ?? []).length || 'None'}</li>
-                <li>Tags: {(formData.tags ?? []).join(', ') || 'None'}</li>
-                <li>Visibility: {formData.visibility}</li>
-                <li>Monetization: {formData.monetizationType}</li>
-              </ul>
+              {(() => {
+                const primaryModel = models.find((model) => model.id === formData.primaryModelId)
+                return (
+                  <ul className="mt-3 space-y-1 text-sm text-black/80">
+                    <li>
+                      Primary model: {primaryModel?.display_name ?? 'Not selected'}
+                    </li>
+                    <li>Provider: {primaryModel?.provider ?? 'Not specified'}</li>
+                    <li>Family: {primaryModel?.family ?? 'Not specified'}</li>
+                    <li>Secondary models: {(formData.secondaryModelIds ?? []).length || 'None'}</li>
+                    <li>Tags: {(formData.tags ?? []).join(', ') || 'None'}</li>
+                    <li>Visibility: {formData.visibility}</li>
+                    <li>Monetization: {formData.monetizationType}</li>
+                  </ul>
+                )
+              })()}
             </div>
           </div>
         )
@@ -410,7 +452,9 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
   }
 
   return (
-    <div className="space-y-6 rounded-3xl border-4 border-black bg-[#F9F7FF] p-6 shadow-[12px_12px_0_rgba(0,0,0,0.08)]">
+    <div
+      className={`${neoCardClass} space-y-6 bg-[radial-gradient(circle_at_top_left,#F9F7FF,white_55%,#E8E2FF)]`}
+    >
       <header className="flex flex-col gap-2">
         <p className="text-xs font-black uppercase tracking-[0.3em] text-black/60">Upload wizard</p>
         <h2 className="text-2xl font-black text-black">Share a new prompt</h2>
@@ -420,21 +464,17 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
       </header>
 
       {!models.length ? (
-        <div className="rounded-2xl border-2 border-black bg-[#FFADAD] px-4 py-3 text-sm font-semibold text-black">
-          No active AI models are configured yet. Ask an admin to add models before submitting prompts.
+        <div className={`${neoBadgeClass} w-full justify-center bg-[#FFADAD] text-black`}> 
+          No active AI models are configured yet. Ask an admin to add model families and providers in the dashboard.
         </div>
       ) : null}
 
       {statusMessage ? (
-        <div className="rounded-2xl border-2 border-black bg-[#B9FBC0] px-4 py-3 text-sm font-semibold text-black">
-          {statusMessage}
-        </div>
+        <div className={`${neoBadgeClass} w-full justify-center bg-[#B9FBC0] text-black`}>{statusMessage}</div>
       ) : null}
 
       {errorMessage ? (
-        <div className="rounded-2xl border-2 border-black bg-[#FFADAD] px-4 py-3 text-sm font-semibold text-black">
-          {errorMessage}
-        </div>
+        <div className={`${neoBadgeClass} w-full justify-center bg-[#FFADAD] text-black`}>{errorMessage}</div>
       ) : null}
 
       <div className="flex items-center gap-2 text-xs font-black uppercase tracking-[0.3em] text-black/60">
@@ -453,7 +493,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
           type="button"
           onClick={() => setStep((current) => Math.max(1, current - 1))}
           disabled={step === 1 || isSubmitting}
-          className="rounded-2xl border-2 border-black bg-white px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-black shadow-[4px_4px_0_rgba(0,0,0,0.12)] disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded-[28px] border-[3px] border-black bg-white px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-black shadow-[6px_6px_0_rgba(0,0,0,0.14)] transition-transform hover:-translate-y-0.5 hover:shadow-[9px_9px_0_rgba(0,0,0,0.2)] disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none"
         >
           Back
         </button>
@@ -462,7 +502,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
             type="button"
             onClick={() => setStep((current) => Math.min(5, current + 1))}
             disabled={!canContinue}
-            className="rounded-2xl border-2 border-black bg-[#6C63FF] px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-white shadow-[4px_4px_0_rgba(0,0,0,0.2)] disabled:cursor-not-allowed disabled:opacity-40"
+            className="rounded-[28px] border-[3px] border-black bg-[#6C63FF] px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-white shadow-[6px_6px_0_rgba(0,0,0,0.2)] transition-transform hover:-translate-y-0.5 hover:shadow-[9px_9px_0_rgba(0,0,0,0.26)] disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none"
           >
             Continue
           </button>
@@ -471,7 +511,7 @@ export function PromptUploadWizard({ models }: PromptUploadWizardProps) {
             type="button"
             onClick={submitPrompt}
             disabled={isSubmitting}
-            className="rounded-2xl border-2 border-black bg-[#6C63FF] px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-white shadow-[4px_4px_0_rgba(0,0,0,0.2)] disabled:cursor-not-allowed disabled:opacity-40"
+            className="rounded-[28px] border-[3px] border-black bg-[#6C63FF] px-4 py-2 text-xs font-black uppercase tracking-[0.2em] text-white shadow-[6px_6px_0_rgba(0,0,0,0.2)] transition-transform hover:-translate-y-0.5 hover:shadow-[9px_9px_0_rgba(0,0,0,0.26)] disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none"
           >
             {isSubmitting ? 'Publishing…' : 'Submit for review'}
           </button>

--- a/src/components/ui/neobrutalistFieldStyles.ts
+++ b/src/components/ui/neobrutalistFieldStyles.ts
@@ -1,0 +1,44 @@
+const baseShadow = 'shadow-[8px_8px_0_rgba(0,0,0,0.14)]'
+const focusShadow = 'focus:shadow-[11px_11px_0_rgba(0,0,0,0.2)]'
+const disabledStyles =
+  'disabled:cursor-not-allowed disabled:border-dashed disabled:border-black/40 disabled:bg-[#F5F3FF] disabled:text-black/60 disabled:shadow-[4px_4px_0_rgba(0,0,0,0.1)] disabled:translate-y-0'
+
+const fieldBase = [
+  'w-full',
+  'rounded-[32px]',
+  'border-2',
+  'border-black',
+  'bg-[radial-gradient(circle_at_top_left,#FFFFFF,#F6F1FF_58%,#E8E1FF_100%)]',
+  'px-5',
+  'py-3',
+  'text-sm',
+  'font-semibold',
+  'text-black',
+  baseShadow,
+  'transition-all',
+  'duration-200',
+  'hover:-translate-y-0.5',
+  'hover:shadow-[10px_10px_0_rgba(0,0,0,0.22)]',
+  'focus:-translate-y-0.5',
+  'focus:outline-none',
+  'focus:ring-4',
+  'focus:ring-black/10',
+  focusShadow,
+  disabledStyles,
+].join(' ')
+
+export const neoInputClass = fieldBase
+
+export const neoTextareaClass = [fieldBase, 'min-h-[160px]', 'resize-vertical', 'leading-relaxed'].join(' ')
+
+export const neoSelectClass = [
+  fieldBase,
+  'appearance-none',
+  'pr-14',
+  'bg-[radial-gradient(circle_at_top_right,#FFFFFF,#F1ECFF_55%,#E1D7FF_95%)]',
+  'neo-select-arrow',
+].join(' ')
+
+export const neoBadgeClass = 'inline-flex items-center gap-2 rounded-full border-2 border-black bg-white px-4 py-1 text-xs font-black uppercase tracking-[0.2em] text-black shadow-[4px_4px_0_rgba(0,0,0,0.12)]'
+export const neoCardClass =
+  'relative rounded-[36px] border-[3px] border-black bg-white/92 p-6 shadow-[14px_14px_0_rgba(0,0,0,0.08)] backdrop-blur-sm'

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { ChevronRight } from "lucide-react"
+import { ChevronRight as ChevronRightIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
@@ -99,7 +99,7 @@ const SidebarTrigger = React.forwardRef<HTMLButtonElement, React.ComponentPropsW
         {...props}
       >
         <span className="sr-only">Toggle sidebar</span>
-        <ChevronRight className="h-5 w-5" aria-hidden="true" />
+        <ChevronRightIcon className="h-5 w-5" aria-hidden="true" />
       </button>
     )
   },
@@ -275,7 +275,7 @@ const SidebarRail = ({ className, ...props }: React.ComponentPropsWithoutRef<"di
           !isOpen && !isMobile && "rotate-180",
         )}
       >
-        <ChevronRight className="h-5 w-5" aria-hidden="true" />
+        <ChevronRightIcon className="h-5 w-5" aria-hidden="true" />
         <span className="sr-only">Collapse sidebar</span>
       </button>
     </div>

--- a/src/lib/prompt-gallery/queries.ts
+++ b/src/lib/prompt-gallery/queries.ts
@@ -72,7 +72,10 @@ const formatPromptSummary = (row: PromptQueryRow): PromptSummary => {
       id: model.id,
       display_name: model.display_name,
       category: model.category,
-      version: model.version ?? null,
+      category_id: model.category_id,
+      version: model.version,
+      family: model.family,
+      provider: model.provider,
     }))
 
   const tags = (row.tags ?? [])

--- a/src/lib/prompt-gallery/types.ts
+++ b/src/lib/prompt-gallery/types.ts
@@ -19,7 +19,12 @@ export interface PromptSummary {
   monetizationType: PromptRow['monetization_type']
   isFeatured: boolean
   preview: string
-  models: Array<Pick<Database['public']['Tables']['ai_models']['Row'], 'id' | 'display_name' | 'category' | 'version'>>
+  models: Array<
+    Pick<
+      Database['public']['Tables']['ai_models']['Row'],
+      'id' | 'display_name' | 'category' | 'category_id' | 'version' | 'family' | 'provider'
+    >
+  >
   tags: Array<Pick<Database['public']['Tables']['prompt_tags']['Row'], 'id' | 'name' | 'category'>>
   stats: {
     upvotes: number

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -117,10 +117,13 @@ export interface Database {
           name: string
           display_name: string
           category: string
+          category_id: string | null
           version: string | null
           description: string | null
           icon_url: string | null
           parameters_schema: Record<string, unknown> | null
+          family: string | null
+          provider: string | null
           is_active: boolean
           created_at: string
           updated_at: string
@@ -130,15 +133,39 @@ export interface Database {
           name: string
           display_name: string
           category: string
+          category_id?: string | null
           version?: string | null
           description?: string | null
           icon_url?: string | null
           parameters_schema?: Record<string, unknown> | null
+          family?: string | null
+          provider?: string | null
           is_active?: boolean
           created_at?: string
           updated_at?: string
         }
         Update: Partial<Database['public']['Tables']['ai_models']['Insert']>
+      }
+      ai_model_categories: {
+        Row: {
+          id: string
+          name: string
+          slug: string
+          description: string | null
+          accent_color: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          name: string
+          slug: string
+          description?: string | null
+          accent_color?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: Partial<Database['public']['Tables']['ai_model_categories']['Insert']>
       }
       prompt_collections: {
         Row: {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -16,6 +16,60 @@ export interface TagOption {
   slug: string
 }
 
+export interface AdminModelCategory {
+  id: string
+  name: string
+  slug: string
+  description: string | null
+  accentColor: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateModelCategoryPayload {
+  name: string
+  slug: string
+  description?: string | null
+  accentColor?: string | null
+}
+
+export type UpdateModelCategoryPayload = Partial<CreateModelCategoryPayload>
+
+export interface AdminModelSummary {
+  id: string
+  name: string
+  displayName: string
+  categoryId: string | null
+  categoryName: string | null
+  categorySlug: string | null
+  family: string | null
+  provider: string | null
+  version: string | null
+  description: string | null
+  iconUrl: string | null
+  parametersSchema: Record<string, unknown> | null
+  isActive: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateAdminModelPayload {
+  name: string
+  displayName: string
+  categoryId?: string | null
+  family?: string | null
+  provider?: string | null
+  version?: string | null
+  description?: string | null
+  iconUrl?: string | null
+  parametersSchema?: Record<string, unknown> | null
+  isActive?: boolean
+}
+
+export interface UpdateAdminModelPayload extends Partial<CreateAdminModelPayload> {
+  isActive?: boolean
+}
+
 export interface AdminPost {
   id: string
   title: string

--- a/supabase/migrations/0015_add_ai_model_catalog.sql
+++ b/supabase/migrations/0015_add_ai_model_catalog.sql
@@ -1,0 +1,36 @@
+-- Adds a dedicated catalog for AI model categories along with
+-- richer metadata for individual models so the admin console
+-- can manage families and providers.
+
+create table if not exists public.ai_model_categories (
+  id uuid primary key default gen_random_uuid(),
+  name text not null unique,
+  slug text not null unique,
+  description text,
+  accent_color text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_trigger
+    where tgname = 'update_ai_model_categories_updated_at'
+  ) then
+    create trigger update_ai_model_categories_updated_at
+    before update on public.ai_model_categories
+    for each row execute function trigger_update_timestamp();
+  end if;
+end
+$$;
+
+create index if not exists ai_model_categories_slug_idx on public.ai_model_categories (slug);
+
+alter table public.ai_models
+  add column if not exists family text,
+  add column if not exists provider text,
+  add column if not exists category_id uuid references public.ai_model_categories (id) on delete set null;
+
+create index if not exists ai_models_category_id_idx on public.ai_models (category_id);


### PR DESCRIPTION
## Summary
- deepen the neo-brutalist field system with curved gradients and refreshed shadows, and apply the new treatment to the prompt upload wizard inputs/buttons
- surface provider and family guidance within the admin model manager and add an overview call-to-action for building the AI model catalog
- tighten the custom select arrow positioning to match the updated rounded inputs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e78cc8914c832dbeeff16c12c4a90f