### PR TITLE
feat: redesign topics hub with neo-brutalist layout

### DIFF
--- a/src/app/topics/RandomTopicButton.tsx
+++ b/src/app/topics/RandomTopicButton.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback, useMemo } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Sparkles } from 'lucide-react';
+
+interface RandomTopicButtonProps {
+  topics: { slug: string; label: string }[];
+}
+
+export const RandomTopicButton = ({ topics }: RandomTopicButtonProps) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const topicPool = useMemo(() => {
+    if (topics.length === 0) {
+      return [];
+    }
+
+    return topics;
+  }, [topics]);
+
+  const handleClick = useCallback(() => {
+    if (topicPool.length === 0) {
+      return;
+    }
+
+    const currentTopic = searchParams.get('topic');
+    const pool = topicPool.filter((topic) => topic.slug !== currentTopic);
+    const selectionPool = pool.length > 0 ? pool : topicPool;
+    const randomIndex = Math.floor(Math.random() * selectionPool.length);
+    const nextTopic = selectionPool[randomIndex];
+
+    router.push(`/topics?topic=${encodeURIComponent(nextTopic.slug)}`);
+  }, [router, searchParams, topicPool]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-gradient-to-r from-[#FF8A00] via-[#FF3D81] to-[#7048FF] px-5 py-2.5 text-sm font-black uppercase tracking-[0.18em] text-white shadow-[6px_6px_0px_0px_rgba(0,0,0,0.25)] transition-transform hover:-translate-y-1 focus:outline-none focus-visible:ring-4 focus-visible:ring-black/60"
+      aria-label="Pick a random topic"
+    >
+      <Sparkles className="h-4 w-4" aria-hidden="true" />
+      Superime me
+    </button>
+  );
+};

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -1,145 +1,414 @@
-import { Metadata } from 'next';
-import { Globe2, Layers, PlugZap, Sparkles } from 'lucide-react';
-import { PageShell, PageHero, ContentSection, CtaButton } from '@/components/ui/PageLayout';
-
-const topics = [
-  {
-    title: 'Frontend & UI',
-    description: 'Design systems, animation, accessibility, and the craft of building delightful interfaces.',
-    icon: Layers,
-    spotlight: ['Design tokens', 'Accessibility audits', 'Framer Motion', 'CSS architecture'],
-  },
-  {
-    title: 'Full-stack & APIs',
-    description: 'Server components, edge computing, GraphQL, and resilient backend patterns.',
-    icon: PlugZap,
-    spotlight: ['Edge functions', 'Supabase workflows', 'tRPC', 'Caching strategies'],
-  },
-  {
-    title: 'Tooling & DX',
-    description: 'Developer experience, testing, observability, and workflows that keep teams shipping happily.',
-    icon: Sparkles,
-    spotlight: ['Playwright testing', 'CI/CD pipelines', 'Telemetry', 'Dev productivity'],
-  },
-  {
-    title: 'Culture & careers',
-    description: 'Leadership, collaboration, growth frameworks, and stories from the people behind the products.',
-    icon: Globe2,
-    spotlight: ['Engineering management', 'Career ladders', 'Async collaboration', 'Team rituals'],
-  },
-];
-
-const curatedCollections = [
-  {
-    title: 'Launch Playbook',
-    description: 'Everything you need to go from concept to shipped product with real-world constraints in mind.',
-    href: '/resources',
-  },
-  {
-    title: 'Accessibility Toolkit',
-    description: 'Guides, checklists, and code labs to make inclusive experiences the default.',
-    href: '/blogs',
-  },
-  {
-    title: 'Career Growth Series',
-    description: 'Stories and frameworks for leveling up as an individual contributor or manager.',
-    href: '/blogs',
-  },
-];
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { ArrowRight, Compass, Search } from 'lucide-react';
+import { getPublishedPosts } from '@/lib/posts';
+import {
+  allTopicLeaves,
+  getDescendantTopicSlugs,
+  getFallbackMessage,
+  navigationLinks,
+  recommendedTopics,
+  topicIndex,
+  topicSections,
+} from '@/data/topic-catalog';
+import { RandomTopicButton } from './RandomTopicButton';
 
 export const metadata: Metadata = {
-  title: 'Topics | Syntax & Sips',
-  description: 'Browse the topics we cover across blogs, podcasts, and tutorials to find what you want to learn next.',
+  title: 'Explore Topics | Syntax & Sips',
+  description:
+    'Browse every Syntax & Sips topic from software craft and AI breakthroughs to culture and self-improvement. Pick a lane, search, or let us Superime you.',
 };
 
-export default function TopicsPage() {
+type SearchParamsShape = Record<string, string | string[] | undefined>;
+
+type TopicsPageProps = {
+  searchParams?: SearchParamsShape | Promise<SearchParamsShape>;
+};
+
+const footerLinks = [
+  'Help',
+  'Status',
+  'About',
+  'Careers',
+  'Press',
+  'Blog',
+  'Privacy',
+  'Rules',
+  'Terms',
+  'Text to speech',
+];
+
+const findSectionSlug = (slug: string | null): string | null => {
+  if (!slug) {
+    return null;
+  }
+
+  let current = topicIndex.get(slug) ?? null;
+
+  while (current) {
+    if (current.type === 'section') {
+      return current.slug;
+    }
+
+    if (!current.parentSlug) {
+      return null;
+    }
+
+    current = topicIndex.get(current.parentSlug) ?? null;
+  }
+
+  return null;
+};
+
+const defaultRandomTopics = allTopicLeaves.map((topic) => ({ slug: topic.slug, label: topic.label }));
+
+const groupPostsBySlug = (posts: Awaited<ReturnType<typeof getPublishedPosts>>) => {
+  const map = new Map<string, typeof posts>();
+
+  for (const post of posts) {
+    const slug = post.category?.slug;
+
+    if (!slug) {
+      continue;
+    }
+
+    const entry = map.get(slug) ?? [];
+    entry.push(post);
+    map.set(slug, entry);
+  }
+
+  return map;
+};
+
+const ActiveTopicPanel = ({
+  activeSlug,
+  posts,
+}: {
+  activeSlug: string | null;
+  posts: Awaited<ReturnType<typeof getPublishedPosts>>;
+}) => {
+  if (!activeSlug) {
+    return (
+      <section className="mt-12">
+        <div className="rounded-3xl border-2 border-black bg-white p-8 shadow-[10px_10px_0px_0px_rgba(0,0,0,0.15)]">
+          <div className="flex flex-col gap-3 text-center">
+            <span className="inline-flex items-center justify-center gap-2 self-center rounded-full border-2 border-black bg-[#F1F5F9] px-4 py-1 text-xs font-bold uppercase tracking-[0.2em] text-[#0F172A]">
+              <Compass className="h-4 w-4" aria-hidden="true" />
+              Topic spotlight
+            </span>
+            <h2 className="text-2xl font-black">Choose a topic to start exploring</h2>
+            <p className="text-sm text-black/70">
+              Use the filters below or smash the Superime button to let fate pick your next deep dive.
+            </p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  const entry = topicIndex.get(activeSlug);
+  const label = entry?.label ?? activeSlug.replace(/-/g, ' ');
+  const fallback = getFallbackMessage(activeSlug);
+
   return (
-    <PageShell
-      hero={
-        <PageHero
-          eyebrow="Topics"
-          title="Follow the subjects that keep you curious"
-          description="Pick a lane—or mix a few. Syntax & Sips covers the full spectrum of building delightful, resilient products."
-          actions={
-            <>
-              <CtaButton href="/newsletter">Subscribe for highlights</CtaButton>
-              <CtaButton href="/blogs" variant="secondary">
-                Read the latest
-              </CtaButton>
-            </>
-          }
-        />
-      }
-    >
-      <ContentSection
-        eyebrow="Categories"
-        title="A little something for every builder"
-        description="Dive deep into a single topic or explore cross-disciplinary insights that make teams unstoppable."
-      >
-        <div className="grid gap-8 md:grid-cols-2">
-          {topics.map((topic) => (
-            <article
-              key={topic.title}
-              className="flex h-full flex-col gap-4 rounded-2xl border-2 border-black bg-white/80 p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.08)]"
-            >
-              <div className="flex items-center gap-3">
-                <topic.icon className="h-10 w-10 text-[#6C63FF]" aria-hidden="true" />
-                <h3 className="text-xl font-black">{topic.title}</h3>
-              </div>
-              <p className="text-sm text-black/70 leading-relaxed">{topic.description}</p>
-              <div className="flex flex-wrap gap-2">
-                {topic.spotlight.map((item) => (
+    <section className="mt-12" aria-live="polite">
+      <div className="rounded-3xl border-2 border-black bg-[#FFF7ED] p-8 shadow-[10px_10px_0px_0px_rgba(0,0,0,0.15)]">
+        <div className="mb-6 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <span className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-white px-4 py-1 text-xs font-black uppercase tracking-[0.2em] text-[#9A3412]">
+              <Compass className="h-4 w-4" aria-hidden="true" />
+              Spotlight
+            </span>
+            <h2 className="mt-4 text-3xl font-black text-[#9A3412]">{label}</h2>
+            <p className="mt-2 max-w-2xl text-sm text-black/70">
+              Handpicked Syntax &amp; Sips pieces tagged under <strong>{label}</strong>.
+            </p>
+          </div>
+          <Link
+            href={`/topics?topic=${encodeURIComponent(activeSlug)}`}
+            className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-white px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-black shadow-[6px_6px_0px_0px_rgba(0,0,0,0.25)] transition-transform hover:-translate-y-1 focus:outline-none focus-visible:ring-4 focus-visible:ring-black/60"
+          >
+            View all
+            <ArrowRight className="h-4 w-4" aria-hidden="true" />
+          </Link>
+        </div>
+        {posts.length === 0 ? (
+          <div className="rounded-2xl border-2 border-dashed border-[#9A3412] bg-white/60 p-8 text-center text-sm font-medium text-[#9A3412]">
+            {fallback}
+          </div>
+        ) : (
+          <div className="grid gap-6 md:grid-cols-2">
+            {posts.slice(0, 4).map((post) => (
+              <article
+                key={post.id}
+                className="flex h-full flex-col justify-between gap-4 rounded-2xl border-2 border-black bg-white p-6 shadow-[6px_6px_0px_0px_rgba(0,0,0,0.2)]"
+              >
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-black/60">
+                    {post.category?.name ?? 'Uncategorised'}
+                  </p>
+                  <h3 className="mt-2 text-xl font-black text-black">
+                    <Link
+                      href={`/blogs/${post.slug}`}
+                      className="hover:underline focus:outline-none focus-visible:ring-4 focus-visible:ring-black/60"
+                    >
+                      {post.title}
+                    </Link>
+                  </h3>
+                </div>
+                <div className="text-sm text-black/70">
+                  {post.excerpt ?? 'Tap in to read the full story.'}
+                </div>
+                <div className="flex items-center justify-between">
                   <span
-                    key={item}
-                    className="rounded-full border-2 border-black bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em]"
+                    className="inline-flex items-center rounded-full border-2 border-black px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em]"
+                    style={{
+                      backgroundColor: post.accentColor ?? '#FCD34D',
+                      color: '#111827',
+                    }}
                   >
-                    {item}
+                    {post.publishedAt ? new Date(post.publishedAt).toLocaleDateString() : 'Unscheduled'}
                   </span>
-                ))}
+                  <Link
+                    href={`/blogs/${post.slug}`}
+                    className="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-[0.2em] text-[#9A3412] hover:underline"
+                  >
+                    Read
+                    <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Link>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+const normalizeParam = (value: string | string[] | undefined) =>
+  (Array.isArray(value) ? value[0] : value) ?? null;
+
+export default async function TopicsPage({ searchParams }: TopicsPageProps) {
+  const resolvedSearchParams: SearchParamsShape =
+    searchParams && typeof (searchParams as Promise<unknown>).then === 'function'
+      ? await (searchParams as Promise<SearchParamsShape>)
+      : (searchParams ?? {});
+
+  const rawTopic = normalizeParam(resolvedSearchParams.topic);
+  const rawQuery = normalizeParam(resolvedSearchParams.q);
+
+  const activeTopicSlug = rawTopic?.toLowerCase() ?? null;
+  const searchQuery = rawQuery?.trim() ?? '';
+  const normalizedQuery = searchQuery.toLowerCase();
+
+  const posts = await getPublishedPosts();
+  const postsBySlug = groupPostsBySlug(posts);
+
+  const descendantSlugs = activeTopicSlug ? getDescendantTopicSlugs(activeTopicSlug) : [];
+  const activePosts = descendantSlugs.flatMap((slug) => postsBySlug.get(slug) ?? []);
+
+  const searchMatches = normalizedQuery
+    ? defaultRandomTopics.filter((topic) => topic.label.toLowerCase().includes(normalizedQuery)).slice(0, 12)
+    : [];
+
+  const activeSectionSlug = findSectionSlug(activeTopicSlug);
+
+  return (
+    <div className="bg-[#FAFAFA] pb-24">
+      <section id="top" className="border-b-4 border-black bg-[#F5F3FF] pb-12 pt-8 shadow-[0px_8px_0px_0px_rgba(0,0,0,0.08)]">
+        <div className="container mx-auto flex flex-col gap-8 px-4">
+          <nav className="flex flex-wrap gap-3">
+            {navigationLinks.map((link) => {
+              const isActive = link.topicSlug
+                ? activeTopicSlug === link.topicSlug
+                : activeSectionSlug
+                  ? link.anchor === `#${activeSectionSlug}`
+                  : false;
+
+              const href = link.topicSlug ? `/topics?topic=${encodeURIComponent(link.topicSlug)}` : link.anchor ?? '#top';
+
+              return (
+                <Link
+                  key={link.label}
+                  href={href}
+                  className={`inline-flex items-center rounded-full border-2 border-black px-4 py-2 text-xs font-black uppercase tracking-[0.2em] shadow-[4px_4px_0px_0px_rgba(0,0,0,0.2)] transition-transform hover:-translate-y-1 focus:outline-none focus-visible:ring-4 focus-visible:ring-black/60 ${
+                    isActive
+                      ? 'bg-black text-white'
+                      : 'bg-white text-black'
+                  }`}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
+          </nav>
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div className="max-w-2xl space-y-3">
+              <span className="inline-block rounded-full border-2 border-black bg-white px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-[#4338CA]">
+                Explore topics
+              </span>
+              <h1 className="text-4xl font-black text-[#1E1E2F] md:text-5xl">
+                Every theme we obsess over — now in one ultra-neobrutalist index
+              </h1>
+              <p className="text-base text-black/70">
+                Browse by category, search for something oddly specific, or let the Superime button deliver a serendipitous rabbit hole.
+              </p>
+            </div>
+            <RandomTopicButton topics={defaultRandomTopics} />
+          </div>
+          <form className="relative" action="/topics" method="get">
+            {activeTopicSlug ? (
+              <input type="hidden" name="topic" value={activeTopicSlug} />
+            ) : null}
+            <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-black/60" />
+            <input
+              type="search"
+              name="q"
+              placeholder="Search all topics"
+              defaultValue={searchQuery}
+              className="w-full rounded-full border-2 border-black bg-white px-12 py-3 text-base font-medium text-black shadow-[6px_6px_0px_0px_rgba(0,0,0,0.2)] focus:outline-none focus-visible:ring-4 focus-visible:ring-black/60"
+            />
+          </form>
+          {normalizedQuery ? (
+            <div className="rounded-3xl border-2 border-black bg-white/80 p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.1)]">
+              <h2 className="text-sm font-black uppercase tracking-[0.2em] text-black/70">Search results</h2>
+              {searchMatches.length > 0 ? (
+                <div className="mt-4 flex flex-wrap gap-3">
+                  {searchMatches.map((topic) => (
+                    <Link
+                      key={`${topic.slug}-search`}
+                      href={`/topics?topic=${encodeURIComponent(topic.slug)}`}
+                      className="inline-flex items-center rounded-full border-2 border-black bg-[#F5F3FF] px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[#1E1E2F] shadow-[4px_4px_0px_0px_rgba(0,0,0,0.15)] hover:-translate-y-1 focus:outline-none focus-visible:ring-4 focus-visible:ring-black/60"
+                    >
+                      {topic.label}
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <p className="mt-3 text-sm text-black/70">
+                  Nothing matched that vibe. Try another keyword or let Superime spin up a surprise.
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="text-sm font-semibold uppercase tracking-[0.2em] text-black/60">Recommended:</span>
+              {recommendedTopics.map((topic) => (
+                <Link
+                  key={topic.slug}
+                  href={`/topics?topic=${encodeURIComponent(topic.slug)}`}
+                  className={`inline-flex items-center rounded-full border-2 border-black px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] shadow-[4px_4px_0px_0px_rgba(0,0,0,0.15)] transition-transform hover:-translate-y-1 focus:outline-none focus-visible:ring-4 focus-visible:ring-black/60 ${
+                    activeTopicSlug === topic.slug ? 'bg-black text-white' : 'bg-white text-black'
+                  }`}
+                >
+                  {topic.label}
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <div className="container mx-auto px-4">
+        <ActiveTopicPanel activeSlug={activeTopicSlug} posts={activePosts} />
+
+        {topicSections.map((section) => (
+          <section key={section.slug} id={section.slug} className="pt-16">
+            <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+              <div className="max-w-2xl space-y-3">
+                <span
+                  className="inline-flex items-center gap-2 rounded-full border-2 border-black px-4 py-1 text-xs font-bold uppercase tracking-[0.2em]"
+                  style={{
+                    backgroundColor: section.accentColor,
+                    color: section.textColor,
+                  }}
+                >
+                  {section.title}
+                </span>
+                <p className="text-lg font-semibold text-[#111827]">{section.description}</p>
               </div>
-            </article>
-          ))}
-        </div>
-      </ContentSection>
+              <Link
+                href={`/topics?topic=${encodeURIComponent(section.slug)}`}
+                className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-black shadow-[6px_6px_0px_0px_rgba(0,0,0,0.2)] transition-transform hover:-translate-y-1 focus:outline-none focus-visible:ring-4 focus-visible:ring-black/60"
+              >
+                {section.showAllLabel}
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
+            </div>
+            <div className="mt-10 grid gap-6 md:grid-cols-3">
+              {section.clusters.map((cluster) => (
+                <article
+                  key={cluster.slug}
+                  className="flex h-full flex-col gap-4 rounded-3xl border-2 border-black bg-white p-6 shadow-[8px_8px_0px_0px_rgba(0,0,0,0.15)]"
+                >
+                  <div
+                    className="inline-flex w-fit items-center gap-2 rounded-full border-2 border-black px-4 py-1 text-xs font-bold uppercase tracking-[0.18em]"
+                    style={{
+                      backgroundColor: cluster.accentColor,
+                      color: '#0F172A',
+                    }}
+                  >
+                    {cluster.label}
+                  </div>
+                  <ul className="flex flex-wrap gap-2">
+                    {cluster.topics.map((topic) => {
+                      const isActive = activeTopicSlug === topic.slug;
 
-      <ContentSection
-        eyebrow="Curated collections"
-        title="Not sure where to start?"
-        description="These playlists bundle our best content so you can binge with purpose."
-        tone="lavender"
-      >
-        <div className="grid gap-6 md:grid-cols-3">
-          {curatedCollections.map((collection) => (
-            <article
-              key={collection.title}
-              className="flex h-full flex-col gap-3 rounded-2xl border-2 border-black bg-white/80 p-6"
+                      return (
+                        <li key={topic.slug}>
+                          <Link
+                            href={`/topics?topic=${encodeURIComponent(topic.slug)}`}
+                            className={`inline-flex items-center rounded-full border-2 border-black px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] transition-transform hover:-translate-y-1 focus:outline-none focus-visible:ring-4 focus-visible:ring-black/60 ${
+                              isActive
+                                ? 'bg-black text-white shadow-[4px_4px_0px_0px_rgba(0,0,0,0.3)]'
+                                : 'bg-white text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,0.15)]'
+                            }`}
+                          >
+                            {topic.label}
+                          </Link>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </article>
+              ))}
+            </div>
+          </section>
+        ))}
+
+        <section className="mt-20 rounded-3xl border-2 border-black bg-[#E0F2FE] p-8 shadow-[10px_10px_0px_0px_rgba(0,0,0,0.12)]">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-2xl font-black text-[#0C4A6E]">
+                See a topic you think should be added or removed here?
+              </h2>
+              <p className="mt-2 max-w-2xl text-sm text-[#075985]">
+                We iterate on this directory constantly. Flag a missing obsession or retire something past its prime.
+              </p>
+            </div>
+            <Link
+              href="/contact"
+              className="inline-flex items-center gap-2 rounded-full border-2 border-black bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-black shadow-[6px_6px_0px_0px_rgba(0,0,0,0.2)] transition-transform hover:-translate-y-1 focus:outline-none focus-visible:ring-4 focus-visible:ring-black/60"
             >
-              <h3 className="text-lg font-black">{collection.title}</h3>
-              <p className="text-sm text-black/70 leading-relaxed">{collection.description}</p>
-              <CtaButton href={collection.href} variant="secondary">
-                Explore
-              </CtaButton>
-            </article>
-          ))}
-        </div>
-      </ContentSection>
+              Suggest an edit
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </Link>
+          </div>
+        </section>
 
-      <ContentSection
-        eyebrow="Coming soon"
-        title="Help us plan the next series"
-        description="We regularly rotate topics based on what the community wants more of."
-        align="center"
-        tone="peach"
-      >
-        <div className="flex flex-col gap-4 rounded-2xl border-2 border-black bg-white/70 p-6 md:flex-row md:items-center md:justify-between">
-          <p className="text-sm text-black/80 max-w-2xl">
-            Vote on upcoming themes like performance budgets, design leadership, open-source sustainability, and more.
-          </p>
-          <CtaButton href="/roadmap" variant="secondary">
-            View roadmap
-          </CtaButton>
-        </div>
-      </ContentSection>
-    </PageShell>
+        <section className="mt-12 flex flex-wrap gap-4 border-t-4 border-dashed border-black/40 pt-8 text-xs font-semibold uppercase tracking-[0.18em] text-black/60">
+          {footerLinks.map((link) => (
+            <Link
+              key={link}
+              href={`/${link.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}
+              className="hover:text-black focus:outline-none focus-visible:ring-4 focus-visible:ring-black/60"
+            >
+              {link}
+            </Link>
+          ))}
+        </section>
+      </div>
+    </div>
   );
 }

--- a/src/components/ui/TopicsSection.tsx
+++ b/src/components/ui/TopicsSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from 'react';
+import Link from 'next/link';
 import {
   Brain,
   Database,
@@ -11,8 +12,23 @@ import {
   Youtube,
   Gamepad2,
 } from 'lucide-react';
+import { homeSpotlightTopics } from '@/data/topic-catalog';
 
 export const TopicsSection = () => {
+  const icons = [
+    <Brain key="brain" />,
+    <Database key="database" />,
+    <Atom key="atom" />,
+    <Code key="code" />,
+    <FileText key="file" />,
+    <Star key="star" />,
+    <Youtube key="youtube" />,
+    <Gamepad2 key="game" />,
+  ];
+
+  const colors = ['#FF5252', '#06D6A0', '#FFD166', '#6C63FF', '#118AB2', '#FF5252', '#06D6A0', '#FFD166'];
+  const rotations = ['-rotate-2', 'rotate-1', '-rotate-1', 'rotate-2', 'rotate-1', '-rotate-2', 'rotate-2', '-rotate-1'];
+
   return (
     <section className="py-16 bg-[#118AB2] text-white">
       <div className="container mx-auto px-4">
@@ -23,59 +39,20 @@ export const TopicsSection = () => {
             </span>
           </h2>
           <p className="text-xl max-w-2xl mx-auto">
-            Dive into our diverse range of content spanning from cutting-edge
-            tech to casual entertainment
+            Dive into our diverse range of content spanning from cutting-edge tech to casual entertainment
           </p>
         </div>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8">
-          <TopicCard
-            icon={<Brain />}
-            title="Machine Learning"
-            color="#FF5252"
-            rotation="-rotate-2"
-          />
-          <TopicCard
-            icon={<Database />}
-            title="Data Science"
-            color="#06D6A0"
-            rotation="rotate-1"
-          />
-          <TopicCard
-            icon={<Atom />}
-            title="Quantum Computing"
-            color="#FFD166"
-            rotation="-rotate-1"
-          />
-          <TopicCard
-            icon={<Code />}
-            title="Coding Tutorials"
-            color="#6C63FF"
-            rotation="rotate-2"
-          />
-          <TopicCard
-            icon={<FileText />}
-            title="Tech Articles"
-            color="#118AB2"
-            rotation="rotate-1"
-          />
-          <TopicCard
-            icon={<Star />}
-            title="Reviews"
-            color="#FF5252"
-            rotation="-rotate-2"
-          />
-          <TopicCard
-            icon={<Youtube />}
-            title="Video Content"
-            color="#06D6A0"
-            rotation="rotate-2"
-          />
-          <TopicCard
-            icon={<Gamepad2 />}
-            title="Gaming"
-            color="#FFD166"
-            rotation="-rotate-1"
-          />
+          {homeSpotlightTopics.map((topic, index) => (
+            <TopicCard
+              key={topic.slug}
+              icon={icons[index % icons.length]}
+              title={topic.label}
+              color={colors[index % colors.length]}
+              rotation={rotations[index % rotations.length]}
+              href={`/topics?topic=${encodeURIComponent(topic.slug)}`}
+            />
+          ))}
         </div>
       </div>
     </section>
@@ -87,22 +64,25 @@ interface TopicCardProps {
   title: string;
   color: string;
   rotation: string;
+  href: string;
 }
 
-const TopicCard = ({ icon, title, color, rotation }: TopicCardProps) => {
+const TopicCard = ({ icon, title, color, rotation, href }: TopicCardProps) => {
   return (
-    <div
-      className={`bg-white text-black border-4 border-black p-4 rounded-lg transform ${rotation} transition-all hover:scale-105 hover:shadow-[4px_4px_0px_0px_rgba(0,0,0)] cursor-pointer`}
-    >
+    <Link href={href} className="group block focus:outline-none focus-visible:ring-4 focus-visible:ring-black/60">
       <div
-        className="flex flex-col items-center text-center"
-        style={{
-          color: color,
-        }}
+        className={`bg-white text-black border-4 border-black p-4 rounded-lg transform ${rotation} transition-all group-hover:scale-105 group-hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,0.85)] group-focus:scale-105`}
       >
-        <div className="mb-3 text-3xl">{icon}</div>
-        <h3 className="font-bold text-lg text-black">{title}</h3>
+        <div
+          className="flex flex-col items-center text-center"
+          style={{
+            color,
+          }}
+        >
+          <div className="mb-3 text-3xl">{icon}</div>
+          <h3 className="font-bold text-lg text-black">{title}</h3>
+        </div>
       </div>
-    </div>
+    </Link>
   );
 };

--- a/src/data/topic-catalog.ts
+++ b/src/data/topic-catalog.ts
@@ -1,0 +1,665 @@
+export interface TopicLeafData {
+  label: string;
+  slug: string;
+  quip?: string;
+}
+
+export interface TopicClusterData {
+  label: string;
+  slug: string;
+  topics: TopicLeafData[];
+  accentColor: string;
+  quip?: string;
+}
+
+export interface TopicSectionData {
+  title: string;
+  slug: string;
+  description: string;
+  accentColor: string;
+  textColor: string;
+  clusters: TopicClusterData[];
+  showAllLabel?: string;
+  quip?: string;
+}
+
+export interface TopicNavigationLink {
+  label: string;
+  anchor?: string;
+  topicSlug?: string;
+}
+
+export interface StandaloneTopic {
+  label: string;
+  slug: string;
+  quip?: string;
+}
+
+const defaultQuip = (label: string) =>
+  `No ${label} stories yet — clearly everyone is still drafting in their head. Write some or swing back later.`;
+
+const leaf = (label: string, overrides: Partial<TopicLeafData> = {}): TopicLeafData => ({
+  label,
+  slug: overrides.slug ?? label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, ''),
+  quip: overrides.quip ?? defaultQuip(label),
+});
+
+const section = (
+  title: string,
+  description: string,
+  accentColor: string,
+  textColor: string,
+  clusters: TopicClusterData[],
+  overrides: Partial<TopicSectionData> = {},
+): TopicSectionData => ({
+  title,
+  slug: overrides.slug ?? title.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+  description,
+  accentColor,
+  textColor,
+  clusters,
+  showAllLabel: overrides.showAllLabel ?? `Show all in "${title}"`,
+  quip: overrides.quip ?? defaultQuip(title),
+});
+
+const withSlug = (label: string, slug: string, quip?: string) => leaf(label, { slug, quip });
+
+export const topicSections: TopicSectionData[] = [
+  section(
+    'Life',
+    'Whole-self stories that balance ambition with being human.',
+    '#FFD166',
+    '#18181B',
+    [
+      {
+        label: 'Family',
+        slug: 'family-life',
+        accentColor: '#F97316',
+        quip: defaultQuip('Family'),
+        topics: [
+          leaf('Adoption'),
+          leaf('Children'),
+          leaf('Elder Care'),
+          leaf('Fatherhood'),
+          leaf('Motherhood'),
+        ],
+      },
+      {
+        label: 'More',
+        slug: 'life-health',
+        accentColor: '#1D4ED8',
+        quip: defaultQuip('Life & health'),
+        topics: [
+          leaf('Health'),
+          leaf('Aging'),
+          withSlug('Coronavirus', 'coronavirus'),
+          withSlug('Covid-19', 'covid-19'),
+          leaf('Death And Dying'),
+          leaf('Disease'),
+        ],
+      },
+      {
+        label: 'Relationships',
+        slug: 'life-relationships',
+        accentColor: '#DB2777',
+        quip: defaultQuip('Relationships'),
+        topics: [
+          leaf('Dating'),
+          leaf('Divorce'),
+          leaf('Friendship'),
+          leaf('Love'),
+          leaf('Marriage'),
+        ],
+      },
+    ],
+    { slug: 'life' },
+  ),
+  section(
+    'Self Improvement',
+    'Growth-minded playbooks to get a little sharper every day.',
+    '#06D6A0',
+    '#052e1d',
+    [
+      {
+        label: 'Mental Health',
+        slug: 'self-mental-health',
+        accentColor: '#6C63FF',
+        topics: [
+          leaf('Anxiety'),
+          leaf('Counseling'),
+          leaf('Grief'),
+          leaf('Life Lessons'),
+          withSlug('Self-awareness', 'self-awareness'),
+        ],
+      },
+      {
+        label: 'Productivity',
+        slug: 'self-productivity',
+        accentColor: '#F59E0B',
+        topics: [
+          leaf('Career Advice'),
+          leaf('Coaching'),
+          leaf('Goal Setting'),
+          leaf('Morning Routines'),
+          withSlug('Pomodoro Technique', 'pomodoro-technique'),
+        ],
+      },
+      {
+        label: 'Mindfulness',
+        slug: 'self-mindfulness',
+        accentColor: '#0EA5E9',
+        topics: [
+          withSlug('Guided Meditation', 'guided-meditation'),
+          leaf('Journaling'),
+          leaf('Meditation'),
+          withSlug('Transcendental Meditation', 'transcendental-meditation'),
+          leaf('Yoga'),
+        ],
+      },
+    ],
+    { slug: 'self-improvement' },
+  ),
+  section(
+    'Work',
+    'Operating manuals for ambitious teams, leaders, and independents.',
+    '#F87171',
+    '#1F2937',
+    [
+      {
+        label: 'Business',
+        slug: 'work-business',
+        accentColor: '#111827',
+        topics: [
+          leaf('Entrepreneurship'),
+          leaf('Freelancing'),
+          withSlug('Small Business', 'small-business'),
+          leaf('Startups'),
+          withSlug('Venture Capital', 'venture-capital'),
+        ],
+      },
+      {
+        label: 'Marketing',
+        slug: 'work-marketing',
+        accentColor: '#2563EB',
+        topics: [
+          leaf('Advertising'),
+          leaf('Branding'),
+          withSlug('Content Marketing', 'content-marketing'),
+          withSlug('Content Strategy', 'content-strategy'),
+          withSlug('Digital Marketing', 'digital-marketing'),
+        ],
+      },
+      {
+        label: 'Leadership',
+        slug: 'work-leadership',
+        accentColor: '#7C3AED',
+        topics: [
+          withSlug('Employee Engagement', 'employee-engagement'),
+          withSlug('Leadership Coaching', 'leadership-coaching'),
+          withSlug('Leadership Development', 'leadership-development'),
+          leaf('Management'),
+          leaf('Meetings'),
+        ],
+      },
+    ],
+    { slug: 'work' },
+  ),
+  section(
+    'Technology',
+    'Frontier tech, frameworks, and the systems powering tomorrow.',
+    '#94A3B8',
+    '#020617',
+    [
+      {
+        label: 'Artificial Intelligence',
+        slug: 'tech-ai',
+        accentColor: '#4338CA',
+        topics: [
+          withSlug('ChatGPT', 'chatgpt'),
+          withSlug('Conversational AI', 'conversational-ai'),
+          withSlug('Deep Learning', 'deep-learning'),
+          withSlug('Large Language Models', 'large-language-models'),
+          withSlug('Machine Learning', 'machine-learning'),
+        ],
+      },
+      {
+        label: 'Blockchain',
+        slug: 'tech-blockchain',
+        accentColor: '#059669',
+        topics: [
+          leaf('Bitcoin'),
+          leaf('Cryptocurrency'),
+          withSlug('Decentralized Finance', 'defi'),
+          withSlug('Ethereum', 'ethereum'),
+          withSlug('Nft', 'nft'),
+        ],
+      },
+      {
+        label: 'Data Science',
+        slug: 'tech-data',
+        accentColor: '#F97316',
+        topics: [
+          leaf('Analytics'),
+          withSlug('Data Engineering', 'data-engineering'),
+          withSlug('Data Visualization', 'data-visualization'),
+          withSlug('Database Design', 'database-design'),
+          withSlug('Sql', 'sql'),
+        ],
+      },
+    ],
+    { slug: 'technology' },
+  ),
+  section(
+    'Software Development',
+    'Ship-ready craft for builders shipping beautiful, resilient products.',
+    '#6C63FF',
+    '#0F172A',
+    [
+      {
+        label: 'Programming',
+        slug: 'dev-programming',
+        accentColor: '#F43F5E',
+        topics: [
+          withSlug('Android Development', 'android-development'),
+          leaf('Coding'),
+          leaf('Flutter'),
+          withSlug('Frontend Engineering', 'frontend-engineering'),
+          withSlug('iOS Development', 'ios-development'),
+        ],
+      },
+      {
+        label: 'Programming Languages',
+        slug: 'dev-languages',
+        accentColor: '#22C55E',
+        topics: [
+          leaf('Angular'),
+          withSlug('CSS', 'css'),
+          withSlug('HTML', 'html'),
+          leaf('Java'),
+          withSlug('JavaScript', 'javascript'),
+        ],
+      },
+      {
+        label: 'Dev Ops',
+        slug: 'dev-ops',
+        accentColor: '#0EA5E9',
+        topics: [
+          withSlug('AWS', 'aws'),
+          withSlug('Databricks', 'databricks'),
+          withSlug('Docker', 'docker'),
+          withSlug('Kubernetes', 'kubernetes'),
+          withSlug('Terraform', 'terraform'),
+        ],
+      },
+    ],
+    { slug: 'software-development' },
+  ),
+  section(
+    'Media',
+    'Storytellers, artists, and digital creators pushing imagination forward.',
+    '#F9A8D4',
+    '#3B0764',
+    [
+      {
+        label: 'Writing',
+        slug: 'media-writing',
+        accentColor: '#EA580C',
+        topics: [
+          withSlug('30 Day Challenge', '30-day-challenge'),
+          withSlug('Book Reviews', 'book-reviews'),
+          leaf('Books'),
+          withSlug('Creative Nonfiction', 'creative-nonfiction'),
+          leaf('Diary'),
+        ],
+      },
+      {
+        label: 'Art',
+        slug: 'media-art',
+        accentColor: '#2563EB',
+        topics: [
+          leaf('Comics'),
+          withSlug('Contemporary Art', 'contemporary-art'),
+          leaf('Drawing'),
+          withSlug('Fine Art', 'fine-art'),
+          withSlug('Generative Art', 'generative-art'),
+        ],
+      },
+      {
+        label: 'Gaming',
+        slug: 'media-gaming',
+        accentColor: '#16A34A',
+        topics: [
+          withSlug('Game Design', 'game-design'),
+          withSlug('Game Development', 'game-development'),
+          withSlug('Indie Game', 'indie-game'),
+          withSlug('Metaverse', 'metaverse'),
+          leaf('Nintendo'),
+        ],
+      },
+    ],
+    { slug: 'media' },
+  ),
+  section(
+    'Society',
+    'Civic pulse checks and cultural critiques grounded in lived experience.',
+    '#FDE047',
+    '#1C1917',
+    [
+      {
+        label: 'Economics',
+        slug: 'society-economics',
+        accentColor: '#B91C1C',
+        topics: [
+          withSlug('Basic Income', 'basic-income'),
+          leaf('Debt'),
+          leaf('Economy'),
+          leaf('Inflation'),
+          withSlug('Stock Market', 'stock-market'),
+        ],
+      },
+      {
+        label: 'Education',
+        slug: 'society-education',
+        accentColor: '#7C3AED',
+        topics: [
+          withSlug('Charter Schools', 'charter-schools'),
+          withSlug('Education Reform', 'education-reform'),
+          withSlug('Higher Education', 'higher-education'),
+          withSlug('PhD', 'phd'),
+          withSlug('Public Schools', 'public-schools'),
+        ],
+      },
+      {
+        label: 'Equality',
+        slug: 'society-equality',
+        accentColor: '#0F766E',
+        topics: [
+          leaf('Disability'),
+          leaf('Discrimination'),
+          withSlug('Diversity In Tech', 'diversity-in-tech'),
+          leaf('Feminism'),
+          leaf('Inclusion'),
+        ],
+      },
+    ],
+    { slug: 'society' },
+  ),
+  section(
+    'Culture',
+    'Big ideas, rituals, and meaning-making across the globe.',
+    '#BFDBFE',
+    '#111827',
+    [
+      {
+        label: 'Philosophy',
+        slug: 'culture-philosophy',
+        accentColor: '#9333EA',
+        topics: [
+          leaf('Atheism'),
+          withSlug('Epistemology', 'epistemology'),
+          leaf('Ethics'),
+          withSlug('Existentialism', 'existentialism'),
+          withSlug('Metaphysics', 'metaphysics'),
+        ],
+      },
+      {
+        label: 'Religion',
+        slug: 'culture-religion',
+        accentColor: '#2563EB',
+        topics: [
+          withSlug('Buddhism', 'buddhism'),
+          withSlug('Christianity', 'christianity'),
+          withSlug('Hinduism', 'hinduism'),
+          withSlug('Islam', 'islam'),
+          withSlug('Judaism', 'judaism'),
+        ],
+      },
+      {
+        label: 'Spirituality',
+        slug: 'culture-spirituality',
+        accentColor: '#0EA5E9',
+        topics: [
+          leaf('Astrology'),
+          withSlug('Energy Healing', 'energy-healing'),
+          withSlug('Horoscopes', 'horoscopes'),
+          withSlug('Mysticism', 'mysticism'),
+          leaf('Reiki'),
+        ],
+      },
+    ],
+    { slug: 'culture' },
+  ),
+  section(
+    'World',
+    'Dispatches from cities, wild places, and the people in motion.',
+    '#4ADE80',
+    '#064E3B',
+    [
+      {
+        label: 'Cities',
+        slug: 'world-cities',
+        accentColor: '#EF4444',
+        topics: [
+          withSlug('Abu Dhabi', 'abu-dhabi'),
+          withSlug('Amsterdam', 'amsterdam'),
+          withSlug('Athens', 'athens'),
+          withSlug('Bangkok', 'bangkok'),
+          withSlug('Barcelona', 'barcelona'),
+        ],
+      },
+      {
+        label: 'Nature',
+        slug: 'world-nature',
+        accentColor: '#2563EB',
+        topics: [
+          leaf('Birding'),
+          leaf('Camping'),
+          withSlug('Climate Change', 'climate-change'),
+          leaf('Conservation'),
+          leaf('Hiking'),
+        ],
+      },
+      {
+        label: 'Travel',
+        slug: 'world-travel',
+        accentColor: '#EAB308',
+        topics: [
+          leaf('Tourism'),
+          withSlug('Travel Tips', 'travel-tips'),
+          withSlug('Travel Writing', 'travel-writing'),
+          leaf('Vacation'),
+          leaf('Vanlife'),
+        ],
+      },
+    ],
+    { slug: 'world' },
+  ),
+];
+
+export const standaloneTopics: StandaloneTopic[] = [
+  {
+    label: 'Politics',
+    slug: 'politics',
+    quip: 'No politics think pieces yet — the debate prep team clearly hit the snooze button. Draft something or check back soon.',
+  },
+  {
+    label: 'Writing',
+    slug: 'writing',
+    quip: 'Writing about writing? The meta moment is coming. Bring your best draft or swing back when the muse cooperates.',
+  },
+  {
+    label: 'Data Science',
+    slug: 'data-science',
+    quip: 'No data science debriefs yet — the analysts are still calibrating their coffee. Crunch numbers later?',
+  },
+  {
+    label: 'Quantum Computing',
+    slug: 'quantum-computing',
+    quip: 'Quantum insights pending — the qubits are still untangling themselves. Check back once reality collapses properly.',
+  },
+  {
+    label: 'Coding Tutorials',
+    slug: 'coding-tutorials',
+    quip: 'No coding tutorials yet — apparently the keyboard is still stretching. Tap back later for keystroke wisdom.',
+  },
+  {
+    label: 'Tech Articles',
+    slug: 'tech-articles',
+    quip: 'No tech articles yet — the editors are probably lost in a gadget unboxing tunnel. Rescue them later.',
+  },
+  {
+    label: 'Reviews',
+    slug: 'reviews',
+    quip: 'No reviews yet — our critics are still sharpening their snark. Check back when the tea is piping hot.',
+  },
+  {
+    label: 'Video Content',
+    slug: 'video-content',
+    quip: 'No video content yet — the camera is insisting on another costume change. Return after the makeover.',
+  },
+  {
+    label: 'Gaming',
+    slug: 'gaming',
+    quip: 'No gaming recaps yet — the controllers are stuck in a dramatic loading screen. Reload again later.',
+  },
+];
+
+export const navigationLinks: TopicNavigationLink[] = [
+  { label: 'Explore topics', anchor: '#top' },
+  { label: 'Software Development', anchor: '#software-development' },
+  { label: 'Self Improvement', anchor: '#self-improvement' },
+  { label: 'Culture', anchor: '#culture' },
+  { label: 'World', anchor: '#world' },
+  { label: 'Media', anchor: '#media' },
+  { label: 'Technology', anchor: '#technology' },
+  { label: 'Society', anchor: '#society' },
+  { label: 'Work', anchor: '#work' },
+  { label: 'Life', anchor: '#life' },
+  { label: 'Politics', topicSlug: 'politics' },
+  { label: 'Writing', topicSlug: 'writing' },
+];
+
+export const recommendedTopics = [
+  { label: 'Self Improvement', slug: 'self-improvement' },
+  { label: 'Politics', slug: 'politics' },
+  { label: 'Writing', slug: 'writing' },
+];
+
+export const homeSpotlightTopics = [
+  { label: 'Machine Learning', slug: 'machine-learning' },
+  { label: 'Data Science', slug: 'data-science' },
+  { label: 'Quantum Computing', slug: 'quantum-computing' },
+  { label: 'Coding Tutorials', slug: 'coding-tutorials' },
+  { label: 'Tech Articles', slug: 'tech-articles' },
+  { label: 'Reviews', slug: 'reviews' },
+  { label: 'Video Content', slug: 'video-content' },
+  { label: 'Gaming', slug: 'gaming' },
+];
+
+export interface TopicIndexEntry {
+  label: string;
+  slug: string;
+  type: 'section' | 'cluster' | 'topic' | 'standalone';
+  descendantSlugs: string[];
+  quip: string;
+  parentSlug: string | null;
+}
+
+const buildIndexFromSection = (sectionData: TopicSectionData): TopicIndexEntry[] => {
+  const entries: TopicIndexEntry[] = [];
+  const descendantSlugs = new Set<string>();
+
+  for (const clusterData of sectionData.clusters) {
+    const clusterDescendants = new Set<string>();
+
+    for (const topic of clusterData.topics) {
+      entries.push({
+        label: topic.label,
+        slug: topic.slug,
+        type: 'topic',
+        descendantSlugs: [topic.slug],
+        quip: topic.quip ?? defaultQuip(topic.label),
+        parentSlug: clusterData.slug,
+      });
+      clusterDescendants.add(topic.slug);
+      descendantSlugs.add(topic.slug);
+    }
+
+    entries.push({
+      label: clusterData.label,
+      slug: clusterData.slug,
+      type: 'cluster',
+      descendantSlugs: Array.from(clusterDescendants),
+      quip: clusterData.quip ?? defaultQuip(clusterData.label),
+      parentSlug: sectionData.slug,
+    });
+  }
+
+  entries.push({
+    label: sectionData.title,
+    slug: sectionData.slug,
+    type: 'section',
+    descendantSlugs: Array.from(descendantSlugs),
+    quip: sectionData.quip ?? defaultQuip(sectionData.title),
+    parentSlug: null,
+  });
+
+  return entries;
+};
+
+export const topicIndex: Map<string, TopicIndexEntry> = (() => {
+  const entries = new Map<string, TopicIndexEntry>();
+
+  for (const sectionEntry of topicSections) {
+    for (const entry of buildIndexFromSection(sectionEntry)) {
+      entries.set(entry.slug, entry);
+    }
+  }
+
+  for (const solo of standaloneTopics) {
+    entries.set(solo.slug, {
+      label: solo.label,
+      slug: solo.slug,
+      type: 'standalone',
+      descendantSlugs: [solo.slug],
+      quip: solo.quip ?? defaultQuip(solo.label),
+      parentSlug: null,
+    });
+  }
+
+  return entries;
+})();
+
+export const allTopicLeaves: TopicLeafData[] = (() => {
+  const leaves: TopicLeafData[] = [];
+
+  for (const sectionEntry of topicSections) {
+    for (const clusterData of sectionEntry.clusters) {
+      leaves.push(...clusterData.topics);
+    }
+  }
+
+  leaves.push(...standaloneTopics);
+
+  return leaves;
+})();
+
+export const getFallbackMessage = (slug: string) => {
+  const entry = topicIndex.get(slug);
+
+  if (!entry) {
+    return defaultQuip(slug.replace(/-/g, ' '));
+  }
+
+  return entry.quip;
+};
+
+export const getDescendantTopicSlugs = (slug: string): string[] => {
+  const entry = topicIndex.get(slug);
+
+  if (!entry) {
+    return [];
+  }
+
+  return entry.descendantSlugs.length > 0 ? entry.descendantSlugs : [entry.slug];
+};


### PR DESCRIPTION
## Summary
- rebuild the /topics route with a neo-brutalist hero, topic navigation, search, and dynamic spotlight sections backed by Supabase posts
- add a shared topic catalog plus a gradient "Superime me" button for quick random exploration
- update the home topics carousel to link into the new topic slugs using the catalog metadata

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e791374af4832dadbaa5c03425ea5f