### PR TITLE
feat: integrate Vercel Speed Insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@supabase/supabase-js": "^2.48.0",
         "@tanstack/react-table": "^8.21.3",
         "@vercel/analytics": "^1.5.0",
+        "@vercel/speed-insights": "^1.1.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.8.0",
@@ -5829,6 +5830,41 @@
         "@remix-run/react": {
           "optional": true
         },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+      "integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
         "@sveltejs/kit": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@supabase/supabase-js": "^2.48.0",
     "@tanstack/react-table": "^8.21.3",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.1.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.8.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { NextWebVitalsMetric } from "next/app";
 import { headers } from "next/headers";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import "./globals.css";
 import "@/styles/neo-brutalism.css";
 import ConditionalNavbar from "@/components/ConditionalNavbar";
@@ -110,6 +111,7 @@ export default async function RootLayout({
           <Toaster theme="light" position="bottom-right" richColors closeButton />
           {children}
           <Analytics />
+          <SpeedInsights />
         </LoaderProvider>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- add the @vercel/speed-insights package to the project dependencies
- render the SpeedInsights component in the app layout so production visits emit performance metrics

## Testing
- `npm run lint` *(fails: pre-existing errors in src/components/ui/sidebar.tsx for undefined ChevronRight and unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_68e79a68f050832da2f54b93e19c657d