### PR TITLE
feat: wire library overview stats fetching

### DIFF
--- a/docs/library/library-implementation-guide.md
+++ b/docs/library/library-implementation-guide.md
@@ -183,6 +183,18 @@ touch src/components/library/HighlightSelector.tsx
    - Record reading time
    - Update history on page unload
 
+#### Blog Post Experience Wiring
+
+- File: `src/app/blogs/[slug]/NewBlogPostClient.tsx`
+- Wrap the markdown renderer with `HighlightSelector` when the reader is authenticated to enable inline saves.
+- Render the `BookmarkButton` beside the summarize action and hydrate it with the user's existing bookmark state.
+- Initialise the reading tracker by
+  - Fetching the latest bookmark and reading history entry via `/api/library/bookmarks` and `/api/library/history`.
+  - Tracking scroll percentage and time-on-page with debounced flushes to `/api/library/history`.
+  - Using `navigator.sendBeacon` as a fallback during `beforeunload` to guarantee persistence.
+- Display call-to-action banners for unauthenticated readers prompting a sign in flow using the neo-brutalist design tokens (border-4, bold fills, hard shadows).
+- Handle error feedback with accessible alerts (`aria-live="polite"`) so assistive tech announces sync issues.
+
 ### Step 7: Testing
 
 1. **Create test files**:

--- a/src/app/api/library/bookmarks/[id]/route.ts
+++ b/src/app/api/library/bookmarks/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server'
+import { buildLibraryErrorResponse, getLibraryRequestContext } from '@/lib/library/server'
+import { bookmarkIdentifierSchema } from '@/lib/library/validation'
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const parsed = bookmarkIdentifierSchema.safeParse({ bookmarkId: id })
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid bookmark identifier', details: parsed.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { bookmarkId } = parsed.data
+
+  const { error } = await auth.supabase
+    .from('bookmarks')
+    .delete()
+    .eq('id', bookmarkId)
+    .eq('profile_id', auth.profileId)
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to delete bookmark.')
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/library/bookmarks/route.ts
+++ b/src/app/api/library/bookmarks/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { mapBookmark } from '@/lib/library/mappers'
+import { buildLibraryErrorResponse, getLibraryRequestContext } from '@/lib/library/server'
+import {
+  createBookmarkSchema,
+  paginationQuerySchema,
+  validateWithSchema,
+} from '@/lib/library/validation'
+
+const BOOKMARK_COLUMNS = `
+  id,
+  profile_id,
+  post_id,
+  created_at,
+  posts (
+    title,
+    slug,
+    excerpt,
+    featured_image_url
+  )
+`
+
+const bookmarkQuerySchema = paginationQuerySchema.extend({
+  postId: z.string().uuid().optional(),
+})
+
+export async function GET(request: Request) {
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const url = new URL(request.url)
+  const queryParams = Object.fromEntries(url.searchParams.entries())
+  const parsedQuery = bookmarkQuerySchema.safeParse(queryParams)
+
+  if (!parsedQuery.success) {
+    return NextResponse.json(
+      { error: 'Invalid query parameters', details: parsedQuery.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { limit, cursor, postId } = parsedQuery.data
+
+  let builder = auth.supabase
+    .from('bookmarks')
+    .select(BOOKMARK_COLUMNS)
+    .eq('profile_id', auth.profileId)
+    .order('created_at', { ascending: false })
+    .limit(limit ?? 20)
+
+  if (cursor) {
+    builder = builder.lt('created_at', cursor)
+  }
+
+  if (postId) {
+    builder = builder.eq('post_id', postId)
+  }
+
+  const { data, error } = await builder
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to load bookmarks.')
+  }
+
+  const items = (data ?? []).map((record) => mapBookmark(record as Parameters<typeof mapBookmark>[0]))
+  const nextCursor = items.length === (limit ?? 20) ? items[items.length - 1]?.createdAt ?? null : null
+
+  return NextResponse.json({ items, nextCursor })
+}
+
+export async function POST(request: Request) {
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const raw = await request.json()
+  const validation = await validateWithSchema(createBookmarkSchema, raw)
+
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: validation.error },
+      { status: 422 },
+    )
+  }
+
+  const payload = validation.data
+
+  const { data, error } = await auth.supabase
+    .from('bookmarks')
+    .insert({
+      profile_id: auth.profileId,
+      post_id: payload.postId,
+    })
+    .select(BOOKMARK_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    if ((error as { code?: string }).code === '23505') {
+      return NextResponse.json(
+        { error: 'Bookmark already exists.' },
+        { status: 409 },
+      )
+    }
+
+    return buildLibraryErrorResponse(error, 'Unable to create bookmark.')
+  }
+
+  if (!data) {
+    return NextResponse.json(
+      { error: 'Unable to create bookmark.' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ bookmark: mapBookmark(data as Parameters<typeof mapBookmark>[0]) }, { status: 201 })
+}

--- a/src/app/api/library/highlights/[id]/route.ts
+++ b/src/app/api/library/highlights/[id]/route.ts
@@ -1,0 +1,137 @@
+import { NextResponse } from 'next/server'
+import { mapHighlight } from '@/lib/library/mappers'
+import { buildLibraryErrorResponse, getLibraryRequestContext } from '@/lib/library/server'
+import {
+  highlightIdentifierSchema,
+  updateHighlightSchema,
+  validateWithSchema,
+} from '@/lib/library/validation'
+
+const HIGHLIGHT_COLUMNS = `
+  id,
+  profile_id,
+  post_id,
+  highlighted_text,
+  note,
+  color,
+  position_start,
+  position_end,
+  is_public,
+  created_at,
+  updated_at,
+  posts (
+    title,
+    slug
+  )
+`
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const parsedParams = highlightIdentifierSchema.safeParse({ highlightId: id })
+
+  if (!parsedParams.success) {
+    return NextResponse.json(
+      { error: 'Invalid highlight identifier', details: parsedParams.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const raw = await request.json()
+  const validation = await validateWithSchema(updateHighlightSchema, raw)
+
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: validation.error },
+      { status: 422 },
+    )
+  }
+
+  const update = validation.data
+  const updatePayload: Record<string, unknown> = {}
+
+  if (update.postId) {
+    updatePayload.post_id = update.postId
+  }
+
+  if (update.highlightedText !== undefined) {
+    updatePayload.highlighted_text = update.highlightedText
+  }
+
+  if (update.note !== undefined) {
+    updatePayload.note = update.note?.trim() ?? null
+  }
+
+  if (update.color !== undefined) {
+    updatePayload.color = update.color
+  }
+
+  if (update.positionStart !== undefined) {
+    updatePayload.position_start = update.positionStart
+  }
+
+  if (update.positionEnd !== undefined) {
+    updatePayload.position_end = update.positionEnd
+  }
+
+  if (update.isPublic !== undefined) {
+    updatePayload.is_public = update.isPublic
+  }
+
+  const { data, error } = await auth.supabase
+    .from('highlights')
+    .update(updatePayload)
+    .eq('id', parsedParams.data.highlightId)
+    .eq('profile_id', auth.profileId)
+    .select(HIGHLIGHT_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to update highlight.')
+  }
+
+  if (!data) {
+    return NextResponse.json({ error: 'Highlight not found.' }, { status: 404 })
+  }
+
+  return NextResponse.json({ highlight: mapHighlight(data as Parameters<typeof mapHighlight>[0]) })
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const parsedParams = highlightIdentifierSchema.safeParse({ highlightId: id })
+
+  if (!parsedParams.success) {
+    return NextResponse.json(
+      { error: 'Invalid highlight identifier', details: parsedParams.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { error } = await auth.supabase
+    .from('highlights')
+    .delete()
+    .eq('id', parsedParams.data.highlightId)
+    .eq('profile_id', auth.profileId)
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to delete highlight.')
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/library/highlights/route.ts
+++ b/src/app/api/library/highlights/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { mapHighlight } from '@/lib/library/mappers'
+import { buildLibraryErrorResponse, getLibraryRequestContext } from '@/lib/library/server'
+import {
+  createHighlightSchema,
+  paginationQuerySchema,
+  validateWithSchema,
+} from '@/lib/library/validation'
+
+const HIGHLIGHT_COLUMNS = `
+  id,
+  profile_id,
+  post_id,
+  highlighted_text,
+  note,
+  color,
+  position_start,
+  position_end,
+  is_public,
+  created_at,
+  updated_at,
+  posts (
+    title,
+    slug
+  )
+`
+
+const highlightQuerySchema = paginationQuerySchema.extend({
+  postId: z.string().uuid().optional(),
+  color: z
+    .string()
+    .regex(/^#[0-9A-Fa-f]{6}$/)
+    .optional(),
+})
+
+export async function GET(request: Request) {
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const url = new URL(request.url)
+  const queryParams = Object.fromEntries(url.searchParams.entries())
+  const parsedQuery = highlightQuerySchema.safeParse(queryParams)
+
+  if (!parsedQuery.success) {
+    return NextResponse.json(
+      { error: 'Invalid query parameters', details: parsedQuery.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { limit, cursor, postId, color } = parsedQuery.data
+
+  let builder = auth.supabase
+    .from('highlights')
+    .select(HIGHLIGHT_COLUMNS)
+    .eq('profile_id', auth.profileId)
+    .order('created_at', { ascending: false })
+    .limit(limit ?? 20)
+
+  if (cursor) {
+    builder = builder.lt('created_at', cursor)
+  }
+
+  if (postId) {
+    builder = builder.eq('post_id', postId)
+  }
+
+  if (color) {
+    builder = builder.eq('color', color)
+  }
+
+  const { data, error } = await builder
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to load highlights.')
+  }
+
+  const items = (data ?? []).map((record) => mapHighlight(record as Parameters<typeof mapHighlight>[0]))
+  const nextCursor = items.length === (limit ?? 20) ? items[items.length - 1]?.createdAt ?? null : null
+
+  return NextResponse.json({ items, nextCursor })
+}
+
+export async function POST(request: Request) {
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const raw = await request.json()
+  const validation = await validateWithSchema(createHighlightSchema, raw)
+
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: validation.error },
+      { status: 422 },
+    )
+  }
+
+  const payload = validation.data
+
+  const insertPayload = {
+    profile_id: auth.profileId,
+    post_id: payload.postId,
+    highlighted_text: payload.highlightedText,
+    note: payload.note?.trim() ?? null,
+    color: payload.color,
+    position_start: payload.positionStart,
+    position_end: payload.positionEnd,
+    is_public: payload.isPublic ?? false,
+  }
+
+  const { data, error } = await auth.supabase
+    .from('highlights')
+    .insert(insertPayload)
+    .select(HIGHLIGHT_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to create highlight.')
+  }
+
+  if (!data) {
+    return NextResponse.json(
+      { error: 'Unable to create highlight.' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ highlight: mapHighlight(data as Parameters<typeof mapHighlight>[0]) }, { status: 201 })
+}

--- a/src/app/api/library/history/[id]/route.ts
+++ b/src/app/api/library/history/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server'
+import { buildLibraryErrorResponse, getLibraryRequestContext } from '@/lib/library/server'
+import { readingHistoryIdentifierSchema } from '@/lib/library/validation'
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const parsed = readingHistoryIdentifierSchema.safeParse({ historyId: id })
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid history identifier', details: parsed.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { historyId } = parsed.data
+
+  const { error } = await auth.supabase
+    .from('reading_history')
+    .delete()
+    .eq('id', historyId)
+    .eq('profile_id', auth.profileId)
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to delete history entry.')
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/library/history/route.ts
+++ b/src/app/api/library/history/route.ts
@@ -1,0 +1,203 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { mapReadingHistory } from '@/lib/library/mappers'
+import { buildLibraryErrorResponse, getLibraryRequestContext } from '@/lib/library/server'
+import {
+  paginationQuerySchema,
+  recordReadingSchema,
+  validateWithSchema,
+} from '@/lib/library/validation'
+
+const HISTORY_COLUMNS = `
+  id,
+  profile_id,
+  post_id,
+  read_at,
+  read_duration_seconds,
+  scroll_percentage,
+  completed,
+  last_position,
+  created_at,
+  updated_at,
+  posts (
+    title,
+    slug,
+    excerpt,
+    featured_image_url
+  )
+`
+
+const historyQuerySchema = paginationQuerySchema.extend({
+  postId: z.string().uuid().optional(),
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+  completed: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform((value) => (value === undefined ? undefined : value === 'true')),
+})
+
+export async function GET(request: Request) {
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const url = new URL(request.url)
+  const queryParams = Object.fromEntries(url.searchParams.entries())
+  const parsedQuery = historyQuerySchema.safeParse(queryParams)
+
+  if (!parsedQuery.success) {
+    return NextResponse.json(
+      { error: 'Invalid query parameters', details: parsedQuery.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { limit, cursor, postId, from, to, completed } = parsedQuery.data
+
+  let builder = auth.supabase
+    .from('reading_history')
+    .select(HISTORY_COLUMNS)
+    .eq('profile_id', auth.profileId)
+    .order('read_at', { ascending: false })
+    .limit(limit ?? 20)
+
+  if (cursor) {
+    builder = builder.lt('read_at', cursor)
+  }
+
+  if (postId) {
+    builder = builder.eq('post_id', postId)
+  }
+
+  if (typeof completed === 'boolean') {
+    builder = builder.eq('completed', completed)
+  }
+
+  if (from) {
+    builder = builder.gte('read_at', from)
+  }
+
+  if (to) {
+    builder = builder.lte('read_at', to)
+  }
+
+  const { data, error } = await builder
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to load reading history.')
+  }
+
+  const items = (data ?? []).map((record) => mapReadingHistory(record as Parameters<typeof mapReadingHistory>[0]))
+  const nextCursor = items.length === (limit ?? 20) ? items[items.length - 1]?.readAt ?? null : null
+
+  return NextResponse.json({ items, nextCursor })
+}
+
+export async function POST(request: Request) {
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const raw = await request.json()
+  const validation = await validateWithSchema(recordReadingSchema, raw)
+
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: validation.error },
+      { status: 422 },
+    )
+  }
+
+  const payload = validation.data
+  const commonFields = {
+    read_duration_seconds: payload.readDurationSeconds ?? null,
+    scroll_percentage: payload.scrollPercentage ?? null,
+    completed: payload.completed ?? false,
+    last_position: payload.lastPosition ?? 0,
+  }
+
+  if (payload.historyId) {
+    const { data, error } = await auth.supabase
+      .from('reading_history')
+      .update({
+        ...commonFields,
+        read_at: payload.readAt ?? new Date().toISOString(),
+      })
+      .eq('id', payload.historyId)
+      .eq('profile_id', auth.profileId)
+      .select(HISTORY_COLUMNS)
+      .maybeSingle()
+
+    if (error) {
+      return buildLibraryErrorResponse(error, 'Unable to update reading history entry.')
+    }
+
+    if (!data) {
+      return NextResponse.json({ error: 'Reading history entry not found.' }, { status: 404 })
+    }
+
+    return NextResponse.json({ history: mapReadingHistory(data as Parameters<typeof mapReadingHistory>[0]) })
+  }
+
+  const { data: existing, error: existingError } = await auth.supabase
+    .from('reading_history')
+    .select('id, completed')
+    .eq('profile_id', auth.profileId)
+    .eq('post_id', payload.postId)
+    .order('read_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (existingError) {
+    return buildLibraryErrorResponse(existingError, 'Unable to record reading history.')
+  }
+
+  if (existing && !existing.completed) {
+    const { data, error } = await auth.supabase
+      .from('reading_history')
+      .update({
+        ...commonFields,
+        read_at: payload.readAt ?? new Date().toISOString(),
+      })
+      .eq('id', existing.id)
+      .select(HISTORY_COLUMNS)
+      .maybeSingle()
+
+    if (error) {
+      return buildLibraryErrorResponse(error, 'Unable to update reading history entry.')
+    }
+
+    if (!data) {
+      return NextResponse.json({ error: 'Reading history entry not found.' }, { status: 404 })
+    }
+
+    return NextResponse.json({ history: mapReadingHistory(data as Parameters<typeof mapReadingHistory>[0]) })
+  }
+
+  const { data, error } = await auth.supabase
+    .from('reading_history')
+    .insert({
+      profile_id: auth.profileId,
+      post_id: payload.postId,
+      read_at: payload.readAt ?? new Date().toISOString(),
+      ...commonFields,
+    })
+    .select(HISTORY_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to record reading history.')
+  }
+
+  if (!data) {
+    return NextResponse.json(
+      { error: 'Unable to record reading history.' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ history: mapReadingHistory(data as Parameters<typeof mapReadingHistory>[0]) }, { status: 201 })
+}

--- a/src/app/api/library/lists/[id]/items/[itemId]/route.ts
+++ b/src/app/api/library/lists/[id]/items/[itemId]/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from 'next/server'
+import { mapListItem } from '@/lib/library/mappers'
+import { buildLibraryErrorResponse, getLibraryRequestContext } from '@/lib/library/server'
+import {
+  listIdentifierSchema,
+  listItemIdentifierSchema,
+  updateListItemSchema,
+  validateWithSchema,
+} from '@/lib/library/validation'
+
+const ITEM_COLUMNS = `
+  id,
+  list_id,
+  post_id,
+  note,
+  position,
+  added_at,
+  posts (
+    id,
+    title,
+    slug,
+    excerpt,
+    featured_image_url
+  )
+`
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string; itemId: string }> },
+) {
+  const { id, itemId } = await params
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const parsedList = listIdentifierSchema.safeParse({ listId: id })
+  if (!parsedList.success) {
+    return NextResponse.json(
+      { error: 'Invalid identifiers', details: parsedList.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const parsedItem = listItemIdentifierSchema.safeParse({
+    listId: id,
+    itemId,
+  })
+
+  if (!parsedItem.success) {
+    return NextResponse.json(
+      { error: 'Invalid identifiers', details: parsedItem.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const body = await request.json()
+  const validation = await validateWithSchema(updateListItemSchema, body)
+
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: validation.error },
+      { status: 422 },
+    )
+  }
+
+  const update = validation.data
+  const updatePayload: Record<string, unknown> = {}
+
+  if (update.note !== undefined) {
+    updatePayload.note = update.note?.trim() ?? null
+  }
+
+  if (update.position !== undefined) {
+    updatePayload.position = update.position
+  }
+
+  const { data, error } = await auth.supabase
+    .from('list_items')
+    .update(updatePayload)
+    .eq('id', parsedItem.data.itemId)
+    .eq('list_id', parsedList.data.listId)
+    .select(ITEM_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to update list item.')
+  }
+
+  if (!data) {
+    return NextResponse.json({ error: 'List item not found.' }, { status: 404 })
+  }
+
+  return NextResponse.json({ item: mapListItem(data as Parameters<typeof mapListItem>[0]) })
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; itemId: string }> },
+) {
+  const { id, itemId } = await params
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const parsedItem = listItemIdentifierSchema.safeParse({
+    listId: id,
+    itemId,
+  })
+
+  if (!parsedItem.success) {
+    return NextResponse.json(
+      { error: 'Invalid identifiers', details: parsedItem.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { error } = await auth.supabase
+    .from('list_items')
+    .delete()
+    .eq('id', parsedItem.data.itemId)
+    .eq('list_id', parsedItem.data.listId)
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to remove list item.')
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/library/lists/[id]/items/route.ts
+++ b/src/app/api/library/lists/[id]/items/route.ts
@@ -1,0 +1,163 @@
+import { NextResponse } from 'next/server'
+import { mapListItem } from '@/lib/library/mappers'
+import { buildLibraryErrorResponse, getLibraryRequestContext } from '@/lib/library/server'
+import {
+  createListItemSchema,
+  listIdentifierSchema,
+  paginationQuerySchema,
+  validateWithSchema,
+} from '@/lib/library/validation'
+
+const ITEM_COLUMNS = `
+  id,
+  list_id,
+  post_id,
+  note,
+  position,
+  added_at,
+  posts (
+    id,
+    title,
+    slug,
+    excerpt,
+    featured_image_url
+  )
+`
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const parsedParams = listIdentifierSchema.safeParse({ listId: id })
+  if (!parsedParams.success) {
+    return NextResponse.json(
+      { error: 'Invalid list identifier', details: parsedParams.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const url = new URL(request.url)
+  const queryParams = Object.fromEntries(url.searchParams.entries())
+  const parsedQuery = paginationQuerySchema.safeParse(queryParams)
+
+  if (!parsedQuery.success) {
+    return NextResponse.json(
+      { error: 'Invalid query parameters', details: parsedQuery.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { listId } = parsedParams.data
+  const { limit, cursor } = parsedQuery.data
+
+  let builder = auth.supabase
+    .from('list_items')
+    .select(ITEM_COLUMNS)
+    .eq('list_id', listId)
+    .order('position', { ascending: true })
+    .limit(limit ?? 20)
+
+  if (cursor) {
+    builder = builder.gt('position', Number.parseInt(cursor, 10))
+  }
+
+  const { data, error } = await builder
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to load list items.')
+  }
+
+  const items = (data ?? []).map((record) => mapListItem(record as Parameters<typeof mapListItem>[0]))
+  const nextCursor =
+    items.length === (limit ?? 20) ? String(items[items.length - 1]?.position ?? '') : null
+
+  return NextResponse.json({ items, nextCursor })
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const parsedParams = listIdentifierSchema.safeParse({ listId: id })
+  if (!parsedParams.success) {
+    return NextResponse.json(
+      { error: 'Invalid list identifier', details: parsedParams.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const body = await request.json()
+  const validation = await validateWithSchema(createListItemSchema, body)
+
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: validation.error },
+      { status: 422 },
+    )
+  }
+
+  const { listId } = parsedParams.data
+  const payload = validation.data
+
+  let position = payload.position ?? 0
+  if (payload.position === undefined) {
+    const { data: lastItem, error: lastError } = await auth.supabase
+      .from('list_items')
+      .select('position')
+      .eq('list_id', listId)
+      .order('position', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (lastError) {
+      return buildLibraryErrorResponse(lastError, 'Unable to resolve list position.')
+    }
+
+    position = lastItem ? (lastItem.position as number) + 1 : 0
+  }
+
+  const insertPayload = {
+    list_id: listId,
+    post_id: payload.postId,
+    note: payload.note?.trim() ?? null,
+    position,
+  }
+
+  const { data, error } = await auth.supabase
+    .from('list_items')
+    .insert(insertPayload)
+    .select(ITEM_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    if ((error as { code?: string }).code === '23505') {
+      return NextResponse.json(
+        { error: 'This post is already saved to the list.' },
+        { status: 409 },
+      )
+    }
+
+    return buildLibraryErrorResponse(error, 'Unable to add post to list.')
+  }
+
+  if (!data) {
+    return NextResponse.json(
+      { error: 'Unable to add item to list.' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ item: mapListItem(data as Parameters<typeof mapListItem>[0]) }, { status: 201 })
+}

--- a/src/app/api/library/lists/[id]/route.ts
+++ b/src/app/api/library/lists/[id]/route.ts
@@ -1,0 +1,204 @@
+import { NextResponse } from 'next/server'
+import { mapListItem, mapUserList } from '@/lib/library/mappers'
+import { buildLibraryErrorResponse, getLibraryRequestContext } from '@/lib/library/server'
+import {
+  listIdentifierSchema,
+  updateListSchema,
+  validateWithSchema,
+} from '@/lib/library/validation'
+
+const LIST_WITH_ITEMS_COLUMNS = `
+  id,
+  profile_id,
+  title,
+  description,
+  slug,
+  is_public,
+  cover_image_url,
+  item_count,
+  created_at,
+  updated_at,
+  list_items (
+    id,
+    list_id,
+    post_id,
+    note,
+    position,
+    added_at,
+    posts (
+      id,
+      title,
+      slug,
+      excerpt,
+      featured_image_url
+    )
+  )
+`
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const parsedParams = listIdentifierSchema.safeParse({ listId: id })
+  if (!parsedParams.success) {
+    return NextResponse.json(
+      { error: 'Invalid list identifier', details: parsedParams.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { listId } = parsedParams.data
+
+  const { data, error } = await auth.supabase
+    .from('user_lists')
+    .select(LIST_WITH_ITEMS_COLUMNS)
+    .eq('id', listId)
+    .maybeSingle()
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to load list.')
+  }
+
+  if (!data) {
+    return NextResponse.json({ error: 'List not found.' }, { status: 404 })
+  }
+
+  const list = mapUserList(data)
+  const items = ((data as unknown as { list_items?: Array<Record<string, unknown>> }).list_items ?? []).map((item) =>
+    mapListItem(item as Parameters<typeof mapListItem>[0]),
+  )
+
+  return NextResponse.json({ list: { ...list, items } })
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const parsedParams = listIdentifierSchema.safeParse({ listId: id })
+  if (!parsedParams.success) {
+    return NextResponse.json(
+      { error: 'Invalid list identifier', details: parsedParams.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const payload = await request.json()
+  const validation = await validateWithSchema(updateListSchema, payload)
+
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: validation.error },
+      { status: 422 },
+    )
+  }
+
+  const { listId } = parsedParams.data
+  const update = validation.data
+  const updatePayload: Record<string, unknown> = {}
+
+  if (update.title !== undefined) {
+    updatePayload.title = update.title.trim()
+  }
+
+  if (update.description !== undefined) {
+    updatePayload.description = update.description?.trim() ?? null
+  }
+
+  if (update.slug !== undefined) {
+    const normalizedSlug = update.slug.trim().toLowerCase()
+
+    const { data: existing, error: existingError } = await auth.supabase
+      .from('user_lists')
+      .select('id')
+      .eq('profile_id', auth.profileId)
+      .eq('slug', normalizedSlug)
+      .neq('id', listId)
+      .maybeSingle()
+
+    if (existingError) {
+      return buildLibraryErrorResponse(existingError, 'Unable to verify slug uniqueness.')
+    }
+
+    if (existing) {
+      return NextResponse.json(
+        { error: 'Another list with this slug already exists.' },
+        { status: 409 },
+      )
+    }
+
+    updatePayload.slug = normalizedSlug
+  }
+
+  if (update.isPublic !== undefined) {
+    updatePayload.is_public = update.isPublic
+  }
+
+  if (update.coverImageUrl !== undefined) {
+    updatePayload.cover_image_url = update.coverImageUrl ?? null
+  }
+
+  const { data, error } = await auth.supabase
+    .from('user_lists')
+    .update(updatePayload)
+    .eq('id', listId)
+    .select(LIST_WITH_ITEMS_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to update list.')
+  }
+
+  if (!data) {
+    return NextResponse.json({ error: 'List not found.' }, { status: 404 })
+  }
+
+  const list = mapUserList(data)
+  const items = ((data as unknown as { list_items?: Array<Record<string, unknown>> }).list_items ?? []).map((item) =>
+    mapListItem(item as Parameters<typeof mapListItem>[0]),
+  )
+
+  return NextResponse.json({ list: { ...list, items } })
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const parsedParams = listIdentifierSchema.safeParse({ listId: id })
+
+  if (!parsedParams.success) {
+    return NextResponse.json(
+      { error: 'Invalid list identifier', details: parsedParams.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { listId } = parsedParams.data
+
+  const { error } = await auth.supabase.from('user_lists').delete().eq('id', listId)
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to delete list.')
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/library/lists/route.ts
+++ b/src/app/api/library/lists/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from 'next/server'
+import { mapUserList } from '@/lib/library/mappers'
+import { buildLibraryErrorResponse, getLibraryRequestContext } from '@/lib/library/server'
+import {
+  createListSchema,
+  paginationQuerySchema,
+  validateWithSchema,
+} from '@/lib/library/validation'
+
+export const dynamic = 'force-dynamic'
+
+const LIST_COLUMNS =
+  'id, profile_id, title, description, slug, is_public, cover_image_url, item_count, created_at, updated_at'
+
+export async function GET(request: Request) {
+  const context = await getLibraryRequestContext()
+  if ('response' in context) {
+    return context.response
+  }
+
+  const url = new URL(request.url)
+  const queryParams = Object.fromEntries(url.searchParams.entries())
+  const parsedQuery = paginationQuerySchema.safeParse(queryParams)
+
+  if (!parsedQuery.success) {
+    return NextResponse.json(
+      { error: 'Invalid query parameters', details: parsedQuery.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { limit, cursor } = parsedQuery.data
+
+  let builder = context.supabase
+    .from('user_lists')
+    .select(LIST_COLUMNS)
+    .eq('profile_id', context.profileId)
+    .order('created_at', { ascending: false })
+    .limit(limit ?? 20)
+
+  if (cursor) {
+    builder = builder.lt('created_at', cursor)
+  }
+
+  const { data, error } = await builder
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to load lists.')
+  }
+
+  const lists = (data ?? []).map(mapUserList)
+  const nextCursor = lists.length === (limit ?? 20) ? lists[lists.length - 1]?.createdAt ?? null : null
+
+  return NextResponse.json({ items: lists, nextCursor })
+}
+
+export async function POST(request: Request) {
+  const context = await getLibraryRequestContext()
+  if ('response' in context) {
+    return context.response
+  }
+
+  const raw = await request.json()
+  const validation = await validateWithSchema(createListSchema, raw)
+
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: validation.error },
+      { status: 422 },
+    )
+  }
+
+  const payload = validation.data
+
+  const { data: existing, error: existingError } = await context.supabase
+    .from('user_lists')
+    .select('id')
+    .eq('profile_id', context.profileId)
+    .eq('slug', payload.slug)
+    .maybeSingle()
+
+  if (existingError) {
+    return buildLibraryErrorResponse(existingError, 'Unable to verify list slug uniqueness.')
+  }
+
+  if (existing) {
+    return NextResponse.json(
+      { error: 'A list with this slug already exists.' },
+      { status: 409 },
+    )
+  }
+
+  const insertPayload = {
+    profile_id: context.profileId,
+    title: payload.title.trim(),
+    description: payload.description?.trim() ?? null,
+    slug: payload.slug.trim().toLowerCase(),
+    is_public: payload.isPublic ?? false,
+    cover_image_url: payload.coverImageUrl ?? null,
+  }
+
+  const { data, error } = await context.supabase
+    .from('user_lists')
+    .insert(insertPayload)
+    .select(LIST_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to create list.')
+  }
+
+  if (!data) {
+    return NextResponse.json(
+      { error: 'List could not be created.' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ list: mapUserList(data) }, { status: 201 })
+}

--- a/src/app/api/library/saved-lists/[id]/route.ts
+++ b/src/app/api/library/saved-lists/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server'
+import { buildLibraryErrorResponse, getLibraryRequestContext } from '@/lib/library/server'
+import { savedListIdentifierSchema } from '@/lib/library/validation'
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const parsed = savedListIdentifierSchema.safeParse({ savedListId: id })
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid saved list identifier', details: parsed.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { savedListId } = parsed.data
+
+  const { error } = await auth.supabase
+    .from('saved_lists')
+    .delete()
+    .eq('id', savedListId)
+    .eq('profile_id', auth.profileId)
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to remove saved list.')
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/library/saved-lists/route.ts
+++ b/src/app/api/library/saved-lists/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from 'next/server'
+import { mapSavedList } from '@/lib/library/mappers'
+import { buildLibraryErrorResponse, getLibraryRequestContext } from '@/lib/library/server'
+import {
+  paginationQuerySchema,
+  saveListSchema,
+  validateWithSchema,
+} from '@/lib/library/validation'
+
+const SAVED_LIST_COLUMNS = `
+  id,
+  profile_id,
+  list_id,
+  saved_at,
+  user_lists (
+    title,
+    description,
+    item_count,
+    profiles (
+      display_name
+    )
+  )
+`
+
+export async function GET(request: Request) {
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const url = new URL(request.url)
+  const queryParams = Object.fromEntries(url.searchParams.entries())
+  const parsedQuery = paginationQuerySchema.safeParse(queryParams)
+
+  if (!parsedQuery.success) {
+    return NextResponse.json(
+      { error: 'Invalid query parameters', details: parsedQuery.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { limit, cursor } = parsedQuery.data
+
+  let builder = auth.supabase
+    .from('saved_lists')
+    .select(SAVED_LIST_COLUMNS)
+    .eq('profile_id', auth.profileId)
+    .order('saved_at', { ascending: false })
+    .limit(limit ?? 20)
+
+  if (cursor) {
+    builder = builder.lt('saved_at', cursor)
+  }
+
+  const { data, error } = await builder
+
+  if (error) {
+    return buildLibraryErrorResponse(error, 'Unable to load saved lists.')
+  }
+
+  const items = (data ?? []).map((record) => mapSavedList(record as Parameters<typeof mapSavedList>[0]))
+  const nextCursor = items.length === (limit ?? 20) ? items[items.length - 1]?.savedAt ?? null : null
+
+  return NextResponse.json({ items, nextCursor })
+}
+
+export async function POST(request: Request) {
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const body = await request.json()
+  const validation = await validateWithSchema(saveListSchema, body)
+
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: validation.error },
+      { status: 422 },
+    )
+  }
+
+  const { listId } = validation.data
+
+  const { data, error } = await auth.supabase
+    .from('saved_lists')
+    .insert({
+      profile_id: auth.profileId,
+      list_id: listId,
+    })
+    .select(SAVED_LIST_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    if ((error as { code?: string }).code === '23505') {
+      return NextResponse.json(
+        { error: 'List already saved.' },
+        { status: 409 },
+      )
+    }
+
+    return buildLibraryErrorResponse(error, 'Unable to save list.')
+  }
+
+  if (!data) {
+    return NextResponse.json(
+      { error: 'Unable to save list.' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ savedList: mapSavedList(data as Parameters<typeof mapSavedList>[0]) }, { status: 201 })
+}

--- a/src/app/api/library/stats/route.ts
+++ b/src/app/api/library/stats/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server'
+import { buildLibraryErrorResponse, getLibraryRequestContext } from '@/lib/library/server'
+import { statsQuerySchema } from '@/lib/library/validation'
+import { loadLibraryStats } from '@/lib/library/stats-service'
+
+export async function GET(request: Request) {
+  const auth = await getLibraryRequestContext()
+  if ('response' in auth) {
+    return auth.response
+  }
+
+  const url = new URL(request.url)
+  const parsedQuery = statsQuerySchema.safeParse(Object.fromEntries(url.searchParams.entries()))
+
+  if (!parsedQuery.success) {
+    return NextResponse.json(
+      { error: 'Invalid query parameters', details: parsedQuery.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const payload = await loadLibraryStats(auth.profileId, auth.supabase, parsedQuery.data.range)
+    return NextResponse.json(payload)
+  } catch (error) {
+    return buildLibraryErrorResponse(error, 'Unable to load library stats.')
+  }
+}

--- a/src/app/me/accounts/page.tsx
+++ b/src/app/me/accounts/page.tsx
@@ -1,0 +1,1 @@
+export { default, dynamic } from '@/app/account/page'

--- a/src/app/me/error.tsx
+++ b/src/app/me/error.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useEffect } from 'react'
+
+interface MeErrorProps {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function MeError({ error, reset }: MeErrorProps) {
+  useEffect(() => {
+    console.error('Library dashboard error', error)
+  }, [error])
+
+  return (
+    <div className="rounded-[32px] border-4 border-black bg-[#FFB347] p-6 text-black shadow-[16px_16px_0px_0px_rgba(0,0,0,0.2)]">
+      <h2 className="text-2xl font-black">Something went wrong</h2>
+      <p className="mt-2 text-lg">{error.message}</p>
+      <button
+        type="button"
+        onClick={reset}
+        className="mt-4 inline-flex rounded-[24px] border-4 border-black bg-white px-5 py-2 font-bold transition-transform hover:-translate-y-1 hover:shadow-[8px_8px_0px_0px_rgba(0,0,0,0.2)]"
+      >
+        Try again
+      </button>
+    </div>
+  )
+}

--- a/src/app/me/highlights/page.tsx
+++ b/src/app/me/highlights/page.tsx
@@ -1,0 +1,49 @@
+import { redirect } from 'next/navigation'
+import { createServerComponentClient } from '@/lib/supabase/server-client'
+import type { Database } from '@/lib/supabase/types'
+import { mapHighlight } from '@/lib/library/mappers'
+import { HighlightsViewer } from '@/components/library/HighlightsViewer'
+
+export const dynamic = 'force-dynamic'
+
+const HIGHLIGHT_COLUMNS =
+  'id, profile_id, post_id, highlighted_text, note, color, position_start, position_end, is_public, created_at, updated_at, posts(title, slug)'
+
+export default async function HighlightsPage() {
+  const supabase = createServerComponentClient<Database>()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login?redirect=/me/highlights')
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    throw new Error(`Unable to load profile: ${profileError.message}`)
+  }
+
+  if (!profile) {
+    redirect('/signup')
+  }
+
+  const { data, error } = await supabase
+    .from('highlights')
+    .select(HIGHLIGHT_COLUMNS)
+    .eq('profile_id', profile.id)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    throw new Error(`Unable to load highlights: ${error.message}`)
+  }
+
+  const highlights = (data ?? []).map(mapHighlight)
+
+  return <HighlightsViewer initialHighlights={highlights} />
+}

--- a/src/app/me/history/page.tsx
+++ b/src/app/me/history/page.tsx
@@ -1,0 +1,49 @@
+import { redirect } from 'next/navigation'
+import { createServerComponentClient } from '@/lib/supabase/server-client'
+import type { Database } from '@/lib/supabase/types'
+import { mapReadingHistory } from '@/lib/library/mappers'
+import { ReadingHistory } from '@/components/library/ReadingHistory'
+
+export const dynamic = 'force-dynamic'
+
+const HISTORY_COLUMNS =
+  'id, profile_id, post_id, read_at, read_duration_seconds, scroll_percentage, completed, last_position, created_at, updated_at, posts(title, slug, excerpt, featured_image_url)'
+
+export default async function ReadingHistoryPage() {
+  const supabase = createServerComponentClient<Database>()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login?redirect=/me/history')
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    throw new Error(`Unable to load profile: ${profileError.message}`)
+  }
+
+  if (!profile) {
+    redirect('/signup')
+  }
+
+  const { data, error } = await supabase
+    .from('reading_history')
+    .select(HISTORY_COLUMNS)
+    .eq('profile_id', profile.id)
+    .order('read_at', { ascending: false })
+
+  if (error) {
+    throw new Error(`Unable to load reading history: ${error.message}`)
+  }
+
+  const history = (data ?? []).map(mapReadingHistory)
+
+  return <ReadingHistory initialHistory={history} />
+}

--- a/src/app/me/layout.tsx
+++ b/src/app/me/layout.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react'
+import { redirect } from 'next/navigation'
+import { createServerComponentClient } from '@/lib/supabase/server-client'
+import type { Database } from '@/lib/supabase/types'
+import { LibraryNav } from '@/components/library/LibraryNav'
+
+export const dynamic = 'force-dynamic'
+
+interface MeLayoutProps {
+  children: ReactNode
+}
+
+export default async function MeLayout({ children }: MeLayoutProps) {
+  const supabase = createServerComponentClient<Database>()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login?redirect=/me')
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, display_name')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Unable to load profile: ${error.message}`)
+  }
+
+  if (!profile) {
+    redirect('/signup')
+  }
+
+  return (
+    <div className="min-h-screen bg-[#FDF7FF] py-10">
+      <div className="container mx-auto flex flex-col gap-10 px-4 lg:flex-row">
+        <LibraryNav profileName={profile.display_name ?? 'Reader'} />
+        <div className="flex-1">
+          <div className="rounded-[32px] border-4 border-black bg-white p-6 shadow-[16px_16px_0px_0px_rgba(0,0,0,0.2)]">
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/me/lists/[id]/page.tsx
+++ b/src/app/me/lists/[id]/page.tsx
@@ -1,0 +1,86 @@
+import { redirect } from 'next/navigation'
+import { createServerComponentClient } from '@/lib/supabase/server-client'
+import type { Database } from '@/lib/supabase/types'
+import { mapListItem, mapUserList } from '@/lib/library/mappers'
+import { ListDetailView } from '@/components/library/ListDetailView'
+
+export const dynamic = 'force-dynamic'
+
+const LIST_WITH_ITEMS_COLUMNS = `
+  id,
+  profile_id,
+  title,
+  description,
+  slug,
+  is_public,
+  cover_image_url,
+  item_count,
+  created_at,
+  updated_at,
+  list_items (
+    id,
+    list_id,
+    post_id,
+    note,
+    position,
+    added_at,
+    posts (
+      id,
+      title,
+      slug,
+      excerpt,
+      featured_image_url
+    )
+  )
+`
+
+interface ListDetailPageProps {
+  params: Promise<{ id: string }>
+}
+
+export default async function ListDetailPage({ params }: ListDetailPageProps) {
+  const { id } = await params
+  const supabase = createServerComponentClient<Database>()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect(`/login?redirect=/me/lists/${id}`)
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    throw new Error(`Unable to load profile: ${profileError.message}`)
+  }
+
+  if (!profile) {
+    redirect('/signup')
+  }
+
+  const { data, error } = await supabase
+    .from('user_lists')
+    .select(LIST_WITH_ITEMS_COLUMNS)
+    .eq('id', id)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Unable to load list: ${error.message}`)
+  }
+
+  if (!data) {
+    redirect('/me/lists')
+  }
+
+  const list = mapUserList(data)
+  const items = ((data as unknown as { list_items?: Array<Record<string, unknown>> }).list_items ?? []).map((item) =>
+    mapListItem(item as Parameters<typeof mapListItem>[0]),
+  )
+
+  return <ListDetailView list={list} items={items} />
+}

--- a/src/app/me/lists/page.tsx
+++ b/src/app/me/lists/page.tsx
@@ -1,0 +1,49 @@
+import { redirect } from 'next/navigation'
+import { createServerComponentClient } from '@/lib/supabase/server-client'
+import type { Database } from '@/lib/supabase/types'
+import { mapUserList } from '@/lib/library/mappers'
+import { ListsManager } from '@/components/library/ListsManager'
+
+export const dynamic = 'force-dynamic'
+
+const LIST_COLUMNS =
+  'id, profile_id, title, description, slug, is_public, cover_image_url, item_count, created_at, updated_at'
+
+export default async function ListsPage() {
+  const supabase = createServerComponentClient<Database>()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login?redirect=/me/lists')
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    throw new Error(`Unable to load profile: ${profileError.message}`)
+  }
+
+  if (!profile) {
+    redirect('/signup')
+  }
+
+  const { data, error } = await supabase
+    .from('user_lists')
+    .select(LIST_COLUMNS)
+    .eq('profile_id', profile.id)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    throw new Error(`Unable to load lists: ${error.message}`)
+  }
+
+  const lists = (data ?? []).map(mapUserList)
+
+  return <ListsManager initialLists={lists} />
+}

--- a/src/app/me/loading.tsx
+++ b/src/app/me/loading.tsx
@@ -1,0 +1,16 @@
+export default function MeLoading() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="h-12 rounded-[32px] border-4 border-black bg-[#FF69B4]/40 shadow-[16px_16px_0px_0px_rgba(0,0,0,0.1)]"></div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {['overview', 'lists', 'highlights', 'history'].map((placeholder) => (
+          <div
+            key={placeholder}
+            className="h-32 rounded-[32px] border-4 border-black bg-[#87CEEB]/40 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.1)]"
+            aria-hidden="true"
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,5 +1,41 @@
 import { redirect } from 'next/navigation';
+import { createServerComponentClient } from '@/lib/supabase/server-client';
+import type { Database } from '@/lib/supabase/types';
+import { loadLibraryStats } from '@/lib/library/stats-service';
+import { LibraryDashboard } from '@/components/library/LibraryDashboard';
 
-export default function LegacyAdminLoginRedirect() {
-  redirect('/admin/login');
+export const dynamic = 'force-dynamic';
+
+export default async function LibraryOverviewPage() {
+  const supabase = createServerComponentClient<Database>();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login?redirect=/me');
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, display_name')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Unable to load profile: ${error.message}`);
+  }
+
+  if (!profile) {
+    redirect('/signup');
+  }
+
+  const stats = await loadLibraryStats(profile.id, supabase, '30d');
+
+  return (
+    <LibraryDashboard
+      initialStats={stats}
+      profileName={profile.display_name ?? 'Reader'}
+    />
+  );
 }

--- a/src/app/me/responses/page.tsx
+++ b/src/app/me/responses/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from 'next/navigation'
+import { createServerComponentClient } from '@/lib/supabase/server-client'
+import type { Database } from '@/lib/supabase/types'
+import { ResponsesPanel } from '@/components/library/ResponsesPanel'
+
+export const dynamic = 'force-dynamic'
+
+export default async function ResponsesPage() {
+  const supabase = createServerComponentClient<Database>()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login?redirect=/me/responses')
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Unable to load profile: ${error.message}`)
+  }
+
+  if (!profile) {
+    redirect('/signup')
+  }
+
+  // TODO: integrate comment analytics once available.
+  return <ResponsesPanel responsesCount={0} />
+}

--- a/src/app/me/saved-lists/page.tsx
+++ b/src/app/me/saved-lists/page.tsx
@@ -1,0 +1,61 @@
+import { redirect } from 'next/navigation'
+import { createServerComponentClient } from '@/lib/supabase/server-client'
+import type { Database } from '@/lib/supabase/types'
+import { mapSavedList } from '@/lib/library/mappers'
+import { SavedListsPanel } from '@/components/library/SavedListsPanel'
+
+export const dynamic = 'force-dynamic'
+
+const SAVED_COLUMNS = `
+  id,
+  profile_id,
+  list_id,
+  saved_at,
+  user_lists (
+    title,
+    description,
+    item_count,
+    profiles (
+      display_name
+    )
+  )
+`
+
+export default async function SavedListsPage() {
+  const supabase = createServerComponentClient<Database>()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login?redirect=/me/saved-lists')
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    throw new Error(`Unable to load profile: ${profileError.message}`)
+  }
+
+  if (!profile) {
+    redirect('/signup')
+  }
+
+  const { data, error } = await supabase
+    .from('saved_lists')
+    .select(SAVED_COLUMNS)
+    .eq('profile_id', profile.id)
+    .order('saved_at', { ascending: false })
+
+  if (error) {
+    throw new Error(`Unable to load saved lists: ${error.message}`)
+  }
+
+  const savedLists = (data ?? []).map(mapSavedList)
+
+  return <SavedListsPanel savedLists={savedLists} />
+}

--- a/src/components/library/BookmarkButton.tsx
+++ b/src/components/library/BookmarkButton.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Bookmark, BookmarkCheck } from 'lucide-react'
+
+interface BookmarkButtonProps {
+  postId: string
+  initialBookmarkId?: string | null
+  className?: string
+}
+
+export function BookmarkButton({ postId, initialBookmarkId = null, className }: BookmarkButtonProps) {
+  const [bookmarkId, setBookmarkId] = useState<string | null>(initialBookmarkId ?? null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    setBookmarkId(initialBookmarkId ?? null)
+  }, [initialBookmarkId])
+
+  const isBookmarked = Boolean(bookmarkId)
+
+  const toggleBookmark = async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      if (isBookmarked && bookmarkId) {
+        const response = await fetch(`/api/library/bookmarks/${bookmarkId}`, {
+          method: 'DELETE',
+          credentials: 'include',
+        })
+
+        if (!response.ok) {
+          const payload = (await response.json()) as { error?: string }
+          throw new Error(payload.error ?? 'Unable to remove bookmark')
+        }
+
+        setBookmarkId(null)
+        return
+      }
+
+      const response = await fetch('/api/library/bookmarks', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ postId }),
+      })
+
+      if (!response.ok) {
+        const payload = (await response.json()) as { error?: string }
+        throw new Error(payload.error ?? 'Unable to save bookmark')
+      }
+
+      const payload = (await response.json()) as { bookmark: { id: string } }
+      setBookmarkId(payload.bookmark.id)
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Unable to update bookmark')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={() => void toggleBookmark()}
+        disabled={loading}
+        className={`inline-flex items-center gap-2 rounded-[24px] border-4 border-black px-4 py-2 font-bold transition-transform hover:-translate-y-1 hover:shadow-[8px_8px_0px_0px_rgba(0,0,0,0.2)] ${isBookmarked ? 'bg-[#9723C9] text-white' : 'bg-white text-black'}`}
+        aria-pressed={isBookmarked}
+      >
+        {isBookmarked ? <BookmarkCheck className="h-5 w-5" aria-hidden="true" /> : <Bookmark className="h-5 w-5" aria-hidden="true" />}
+        {isBookmarked ? 'Bookmarked' : 'Save for later'}
+      </button>
+      {error ? <p className="mt-2 text-xs font-semibold text-[#B91C1C]">{error}</p> : null}
+    </div>
+  )
+}

--- a/src/components/library/HighlightSelector.tsx
+++ b/src/components/library/HighlightSelector.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import { Loader2 } from 'lucide-react'
+
+interface HighlightSelectorProps {
+  postId: string
+  children: ReactNode
+  onHighlightCreated?: () => void
+}
+
+const highlightColors = ['#FFEB3B', '#FF69B4', '#87CEEB', '#90EE90']
+
+interface DraftHighlight {
+  text: string
+  start: number
+  end: number
+  rect: DOMRect
+}
+
+export function HighlightSelector({ postId, children, onHighlightCreated }: HighlightSelectorProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [draft, setDraft] = useState<DraftHighlight | null>(null)
+  const [color, setColor] = useState<string>(highlightColors[0])
+  const [note, setNote] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSelectionChange = useCallback(() => {
+    const selection = window.getSelection()
+    if (!selection || selection.rangeCount === 0) {
+      setDraft(null)
+      return
+    }
+
+    const range = selection.getRangeAt(0)
+    if (!containerRef.current || !containerRef.current.contains(range.commonAncestorContainer)) {
+      setDraft(null)
+      return
+    }
+
+    const selectedText = range.toString()
+    if (selectedText.trim().length === 0) {
+      setDraft(null)
+      return
+    }
+
+    const preRange = range.cloneRange()
+    preRange.selectNodeContents(containerRef.current)
+    preRange.setEnd(range.startContainer, range.startOffset)
+    const start = preRange.toString().length
+    const end = start + selectedText.length
+    const rect = range.getBoundingClientRect()
+
+    setDraft({ text: selectedText, start, end, rect })
+  }, [])
+
+  useEffect(() => {
+    document.addEventListener('selectionchange', handleSelectionChange)
+    return () => document.removeEventListener('selectionchange', handleSelectionChange)
+  }, [handleSelectionChange])
+
+  const createHighlight = async () => {
+    if (!draft) return
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await fetch('/api/library/highlights', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          postId,
+          highlightedText: draft.text,
+          positionStart: draft.start,
+          positionEnd: draft.end,
+          color,
+          note: note.trim().length > 0 ? note.trim() : undefined,
+        }),
+      })
+
+      if (!response.ok) {
+        const payload = (await response.json()) as { error?: string }
+        throw new Error(payload.error ?? 'Unable to save highlight')
+      }
+
+      setDraft(null)
+      setNote('')
+      if (onHighlightCreated) onHighlightCreated()
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Unable to save highlight')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="relative" ref={containerRef}>
+      {children}
+      {draft ? (
+        <div
+          className="fixed z-50 flex flex-col gap-2 rounded-[24px] border-4 border-black bg-white p-3 text-sm font-semibold text-black shadow-[8px_8px_0px_0px_rgba(0,0,0,0.2)]"
+          style={{ top: draft.rect.bottom + window.scrollY + 12, left: draft.rect.left + window.scrollX }}
+          role="dialog"
+          aria-label="Create highlight"
+        >
+          <p className="max-w-xs text-xs text-black/70">“{draft.text.slice(0, 120)}{draft.text.length > 120 ? '…' : ''}”</p>
+          <div className="flex items-center gap-2">
+            {highlightColors.map((hex) => (
+              <button
+                key={hex}
+                type="button"
+                onClick={() => setColor(hex)}
+                className={`h-6 w-6 rounded-full border-2 border-black ${color === hex ? 'ring-4 ring-black/50' : ''}`}
+                style={{ backgroundColor: hex }}
+                aria-label={`Use color ${hex}`}
+              />
+            ))}
+          </div>
+          <textarea
+            rows={2}
+            value={note}
+            onChange={(event) => setNote(event.target.value)}
+            placeholder="Add a personal note"
+            className="w-60 rounded-[16px] border-4 border-black px-2 py-1 text-xs font-semibold text-black focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-black/50"
+          />
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void createHighlight()}
+              className="inline-flex items-center gap-2 rounded-[24px] border-4 border-black bg-[#FF69B4] px-3 py-1 text-xs font-bold text-black"
+              disabled={loading}
+            >
+              {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+              Save highlight
+            </button>
+            <button
+              type="button"
+              onClick={() => setDraft(null)}
+              className="inline-flex items-center rounded-[24px] border-4 border-black bg-white px-3 py-1 text-xs font-bold text-black"
+            >
+              Cancel
+            </button>
+          </div>
+          {error ? <p className="text-xs text-[#B91C1C]">{error}</p> : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/library/HighlightsViewer.tsx
+++ b/src/components/library/HighlightsViewer.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Loader2, Trash2, Palette, Copy } from 'lucide-react'
+import type { Highlight } from '@/utils/types'
+
+interface HighlightsViewerProps {
+  initialHighlights: Highlight[]
+}
+
+export function HighlightsViewer({ initialHighlights }: HighlightsViewerProps) {
+  const [highlights, setHighlights] = useState(initialHighlights)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [filterColor, setFilterColor] = useState<string>('all')
+  const [copiedId, setCopiedId] = useState<string | null>(null)
+
+  const colors = useMemo(() => {
+    const set = new Set(highlights.map((highlight) => highlight.color))
+    return Array.from(set)
+  }, [highlights])
+
+  const filteredHighlights = useMemo(
+    () =>
+      filterColor === 'all'
+        ? highlights
+        : highlights.filter((highlight) => highlight.color === filterColor),
+    [filterColor, highlights],
+  )
+
+  const loadHighlights = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch('/api/library/highlights?limit=100', {
+        credentials: 'include',
+        cache: 'no-store',
+      })
+
+      if (!response.ok) {
+        const body = (await response.json()) as { error?: string }
+        throw new Error(body.error ?? 'Unable to load highlights')
+      }
+
+      const body = (await response.json()) as { items: Highlight[] }
+      setHighlights(body.items ?? [])
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Unable to load highlights')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (initialHighlights.length === 0) {
+      void loadHighlights()
+    }
+  }, [initialHighlights.length, loadHighlights])
+
+  const handleDelete = async (id: string) => {
+    const confirmed = window.confirm('Delete this highlight?')
+    if (!confirmed) return
+
+    const response = await fetch(`/api/library/highlights/${id}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    })
+
+    if (!response.ok) {
+      setError('Unable to delete highlight.')
+      return
+    }
+
+    setHighlights((prev) => prev.filter((highlight) => highlight.id !== id))
+  }
+
+  const handleCopy = async (highlight: Highlight) => {
+    try {
+      await navigator.clipboard.writeText(`${highlight.highlightedText}\n\n— ${highlight.postTitle}`)
+      setCopiedId(highlight.id)
+      window.setTimeout(() => setCopiedId(null), 1500)
+    } catch {
+      setError('Unable to copy highlight to clipboard.')
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="border-b-4 border-black pb-4">
+        <h1 className="text-3xl font-black text-black">Highlights</h1>
+        <p className="text-sm text-black/70">
+          Everything you&apos;ve highlighted across Syntax &amp; Sips. Filter by color to review what resonates most.
+        </p>
+      </header>
+
+      {error ? (
+        <div className="rounded-[24px] border-4 border-black bg-[#FFB347] px-4 py-3 font-semibold text-black">{error}</div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => setFilterColor('all')}
+          className={`rounded-[24px] border-4 border-black px-4 py-2 text-sm font-bold ${filterColor === 'all' ? 'bg-[#87CEEB]' : 'bg-white text-black'}`}
+        >
+          All
+        </button>
+        {colors.map((color) => (
+          <button
+            key={color}
+            type="button"
+            onClick={() => setFilterColor(color)}
+            className={`inline-flex items-center gap-2 rounded-[24px] border-4 border-black px-4 py-2 text-sm font-bold ${filterColor === color ? 'bg-[#9723C9] text-white' : 'bg-white text-black'}`}
+          >
+            <span className="h-4 w-4 rounded-full border-2 border-black" style={{ backgroundColor: color }} />
+            {color}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={() => void loadHighlights()}
+          className="inline-flex items-center gap-2 rounded-[24px] border-4 border-black bg-white px-4 py-2 text-sm font-bold text-black"
+        >
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+          Refresh
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        {filteredHighlights.length === 0 && !loading ? (
+          <div className="rounded-[32px] border-4 border-dashed border-black/40 bg-[#FDF7FF] px-6 py-10 text-center font-semibold text-black/70">
+            No highlights found. Explore articles and select the passages that inspire you.
+          </div>
+        ) : null}
+        {filteredHighlights.map((highlight) => (
+          <article
+            key={highlight.id}
+            className="space-y-3 rounded-[32px] border-4 border-black bg-white p-6 text-black shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)]"
+          >
+            <header className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="text-lg font-black">{highlight.postTitle}</p>
+                <p className="text-xs uppercase text-black/60">{new Date(highlight.createdAt).toLocaleString()}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="inline-flex items-center gap-2 rounded-[24px] border-4 border-black bg-white px-3 py-1 text-sm font-bold text-black">
+                  <Palette className="h-4 w-4" aria-hidden="true" />
+                  {highlight.color}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => void handleCopy(highlight)}
+                  className="inline-flex items-center gap-2 rounded-[24px] border-4 border-black bg-[#87CEEB] px-3 py-1 text-sm font-bold text-black"
+                >
+                  <Copy className="h-4 w-4" aria-hidden="true" />
+                  {copiedId === highlight.id ? 'Copied!' : 'Copy'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleDelete(highlight.id)}
+                  className="inline-flex items-center gap-2 rounded-[24px] border-4 border-black bg-[#FF69B4] px-3 py-1 text-sm font-bold text-black"
+                >
+                  <Trash2 className="h-4 w-4" aria-hidden="true" /> Delete
+                </button>
+              </div>
+            </header>
+            <blockquote className="rounded-[24px] border-4 border-black bg-[#FFFFE0] p-4 text-base font-semibold italic text-black">
+              “{highlight.highlightedText}”
+            </blockquote>
+            {highlight.note ? (
+              <p className="text-sm text-black/70">Personal note: {highlight.note}</p>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/library/LibraryDashboard.tsx
+++ b/src/components/library/LibraryDashboard.tsx
@@ -1,0 +1,324 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { Loader2, ArrowRight, Sparkles } from 'lucide-react'
+import type { LibraryStatsResponse, LibraryActivityEntry } from '@/lib/library/types'
+import type { Bookmark, Highlight, ReadingHistoryEntry } from '@/utils/types'
+import { cn } from '@/lib/utils'
+
+interface LibraryDashboardProps {
+  initialStats: LibraryStatsResponse
+  profileName: string
+}
+
+type StatsRange = '7d' | '30d' | '90d' | '365d'
+
+const rangeOptions: Array<{ label: string; value: StatsRange }> = [
+  { label: '7 days', value: '7d' },
+  { label: '30 days', value: '30d' },
+  { label: '90 days', value: '90d' },
+  { label: '1 year', value: '365d' },
+]
+
+const quickLinks = [
+  { href: '/me/lists', label: 'Create a list', color: '#9723C9' },
+  { href: '/me/highlights', label: 'Review highlights', color: '#FF69B4' },
+  { href: '/me/history', label: 'Continue reading', color: '#87CEEB' },
+]
+
+export function LibraryDashboard({ initialStats, profileName }: LibraryDashboardProps) {
+  const [stats, setStats] = useState(initialStats)
+  const [range, setRange] = useState<StatsRange>('30d')
+  const [loadingStats, setLoadingStats] = useState(false)
+  const [statsError, setStatsError] = useState<string | null>(null)
+  const [activity, setActivity] = useState<LibraryActivityEntry[]>([])
+  const [loadingActivity, setLoadingActivity] = useState(true)
+  const [activityError, setActivityError] = useState<string | null>(null)
+
+  const fetchStats = useCallback(async (nextRange: StatsRange) => {
+    setLoadingStats(true)
+    setStatsError(null)
+    try {
+      const response = await fetch(`/api/library/stats?range=${nextRange}`, {
+        credentials: 'include',
+        cache: 'no-store',
+      })
+
+      if (!response.ok) {
+        const payload = (await response.json()) as { error?: string }
+        throw new Error(payload.error ?? 'Unable to load stats')
+      }
+
+      const payload = (await response.json()) as LibraryStatsResponse
+      setStats(payload)
+    } catch (error) {
+      setStatsError(error instanceof Error ? error.message : 'Unable to load stats')
+    } finally {
+      setLoadingStats(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    const loadActivity = async () => {
+      setLoadingActivity(true)
+      setActivityError(null)
+      try {
+        const [bookmarksRes, highlightsRes, historyRes] = await Promise.all([
+          fetch('/api/library/bookmarks?limit=5', { credentials: 'include', cache: 'no-store' }),
+          fetch('/api/library/highlights?limit=5', { credentials: 'include', cache: 'no-store' }),
+          fetch('/api/library/history?limit=5', { credentials: 'include', cache: 'no-store' }),
+        ])
+
+        if (!bookmarksRes.ok || !highlightsRes.ok || !historyRes.ok) {
+          throw new Error('Unable to load recent activity')
+        }
+
+        const bookmarksPayload = (await bookmarksRes.json()) as { items: Bookmark[] }
+        const highlightsPayload = (await highlightsRes.json()) as { items: Highlight[] }
+        const historyPayload = (await historyRes.json()) as { items: ReadingHistoryEntry[] }
+
+        const items: LibraryActivityEntry[] = []
+
+        for (const bookmark of bookmarksPayload.items ?? []) {
+          items.push({
+            id: `bookmark-${bookmark.id}`,
+            type: 'bookmark',
+            title: bookmark.postTitle,
+            subtitle: 'Saved for later',
+            occurredAt: bookmark.createdAt,
+            metadata: { slug: bookmark.postSlug },
+          })
+        }
+
+        for (const highlight of highlightsPayload.items ?? []) {
+          items.push({
+            id: `highlight-${highlight.id}`,
+            type: 'highlight',
+            title: highlight.postTitle,
+            subtitle: highlight.highlightedText.slice(0, 120),
+            occurredAt: highlight.createdAt,
+            metadata: { color: highlight.color },
+          })
+        }
+
+        for (const entry of historyPayload.items ?? []) {
+          items.push({
+            id: `history-${entry.id}`,
+            type: 'history',
+            title: entry.postTitle,
+            subtitle: entry.completed ? 'Completed reading' : 'Still reading',
+            occurredAt: entry.readAt,
+            metadata: { progress: entry.scrollPercentage ?? 0 },
+          })
+        }
+
+        items.sort((a, b) => (a.occurredAt > b.occurredAt ? -1 : 1))
+        setActivity(items.slice(0, 9))
+      } catch (error) {
+        setActivityError(error instanceof Error ? error.message : 'Unable to load activity')
+      } finally {
+        setLoadingActivity(false)
+      }
+    }
+
+    loadActivity()
+  }, [])
+
+  const statCards = useMemo(
+    () => [
+      {
+        label: 'Saved posts',
+        value: stats.stats.totalBookmarks,
+        color: '#9723C9',
+      },
+      {
+        label: 'Custom lists',
+        value: stats.stats.totalLists,
+        color: '#FF69B4',
+      },
+      {
+        label: 'Highlights',
+        value: stats.stats.totalHighlights,
+        color: '#87CEEB',
+      },
+      {
+        label: 'Reading streak',
+        value: stats.stats.readingStreak,
+        color: '#90EE90',
+      },
+    ],
+    [stats],
+  )
+
+  const formatDate = (iso: string) =>
+    new Date(iso).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-4 border-b-4 border-black pb-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p className="text-sm font-bold uppercase tracking-widest text-black/60">Your library</p>
+          <h1 className="text-4xl font-black text-black">Keep exploring, {profileName.split(' ')[0] ?? 'friend'}!</h1>
+          <p className="mt-2 max-w-2xl text-lg text-black/70">
+            Track everything you&apos;ve saved, highlighted, and read across Syntax &amp; Sips. Pick up right where you left off.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          {rangeOptions.map((option) => {
+            const isActive = option.value === range
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  setRange(option.value)
+                  void fetchStats(option.value)
+                }}
+                className={cn(
+                  'rounded-[24px] border-4 border-black px-4 py-2 text-sm font-bold uppercase transition-transform hover:-translate-y-1 hover:shadow-[6px_6px_0px_0px_rgba(0,0,0,0.2)] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-black/50',
+                  isActive ? 'bg-[#9723C9] text-white' : 'bg-white text-black',
+                )}
+              >
+                {option.label}
+              </button>
+            )
+          })}
+        </div>
+      </header>
+
+      {statsError ? (
+        <div className="rounded-[24px] border-4 border-black bg-[#FFB347] p-4 font-semibold text-black">
+          {statsError}
+        </div>
+      ) : null}
+
+      <section aria-labelledby="library-stats" className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {statCards.map((card) => (
+          <article
+            key={card.label}
+            className="rounded-[32px] border-4 border-black bg-white p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)]"
+            style={{ backgroundColor: `${card.color}20` }}
+          >
+            <p className="text-sm font-bold uppercase text-black/70">{card.label}</p>
+            <p className="mt-3 text-4xl font-black text-black">{card.value.toLocaleString()}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-3" aria-label="Library insights">
+        <article className="rounded-[32px] border-4 border-black bg-[#87CEEB]/40 p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)] lg:col-span-2">
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-black text-black">Reading timeline</h2>
+            {loadingStats ? <Loader2 className="h-5 w-5 animate-spin text-black" aria-hidden="true" /> : null}
+          </div>
+          <p className="mt-2 text-sm text-black/70">Minutes read per day</p>
+          <div className="mt-6 grid grid-cols-7 gap-2 text-xs">
+            {stats.readingTimeline.map((entry) => (
+              <div key={entry.date} className="flex flex-col items-center gap-1">
+                <div
+                  className="w-full rounded-full border-2 border-black bg-[#9723C9]/30"
+                  style={{ height: `${Math.min(entry.minutes * 3, 120)}px` }}
+                  aria-hidden="true"
+                />
+                <span className="font-semibold text-black/70">{new Date(entry.date).getDate()}</span>
+              </div>
+            ))}
+          </div>
+        </article>
+        <article className="rounded-[32px] border-4 border-black bg-[#90EE90]/40 p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)]">
+          <h2 className="text-2xl font-black text-black">Highlight colors</h2>
+          <ul className="mt-4 space-y-3">
+            {stats.highlightGroups.length === 0 ? (
+              <li className="rounded-[24px] border-4 border-dashed border-black/40 bg-white/70 px-4 py-3 text-sm font-semibold text-black/70">
+                No highlights yet. Start capturing what matters!
+              </li>
+            ) : (
+              stats.highlightGroups.map((group) => (
+                <li
+                  key={group.color}
+                  className="flex items-center justify-between rounded-[24px] border-4 border-black bg-white px-4 py-3 font-bold text-black"
+                >
+                  <span className="flex items-center gap-3">
+                    <span className="h-4 w-4 rounded-full border-2 border-black" style={{ backgroundColor: group.color }} />
+                    {group.color}
+                  </span>
+                  <span>{group.count}</span>
+                </li>
+              ))
+            )}
+          </ul>
+        </article>
+      </section>
+
+      <section aria-labelledby="quick-actions" className="grid gap-4 md:grid-cols-3">
+        {quickLinks.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className="flex items-center justify-between rounded-[32px] border-4 border-black px-6 py-5 font-black text-black shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)] transition-transform hover:-translate-y-1"
+            style={{ backgroundColor: link.color }}
+          >
+            <span>{link.label}</span>
+            <ArrowRight className="h-6 w-6" aria-hidden="true" />
+          </Link>
+        ))}
+      </section>
+
+      <section aria-labelledby="recent-activity" className="rounded-[32px] border-4 border-black bg-white p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)]">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 id="recent-activity" className="text-2xl font-black text-black">
+              Recent activity
+            </h2>
+            <p className="text-sm text-black/70">A snapshot of your latest saves, highlights, and reading sessions.</p>
+          </div>
+          <Sparkles className="h-6 w-6 text-[#9723C9]" aria-hidden="true" />
+        </div>
+        {activityError ? (
+          <div className="mt-4 rounded-[24px] border-4 border-black bg-[#FFB347] px-4 py-3 font-semibold text-black">
+            {activityError}
+          </div>
+        ) : null}
+        {loadingActivity ? (
+          <div className="mt-6 flex items-center gap-3 text-black">
+            <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" /> Loading activity…
+          </div>
+        ) : (
+          <ul className="mt-6 space-y-3">
+            {activity.length === 0 ? (
+              <li className="rounded-[24px] border-4 border-dashed border-black/40 bg-[#FDF7FF] px-4 py-4 text-sm font-semibold text-black/70">
+                No activity yet. Explore posts and start building your library.
+              </li>
+            ) : (
+              activity.map((item) => (
+                <li
+                  key={item.id}
+                  className="flex items-center justify-between rounded-[24px] border-4 border-black bg-[#FDF7FF] px-4 py-3 text-black"
+                >
+                  <div>
+                    <p className="text-lg font-bold">
+                      {item.type === 'bookmark'
+                        ? 'Saved: '
+                        : item.type === 'highlight'
+                          ? 'Highlighted: '
+                          : 'Reading: '}
+                      {item.title}
+                    </p>
+                    <p className="text-sm text-black/70">{item.subtitle}</p>
+                  </div>
+                  <span className="text-sm font-semibold text-black/80">{formatDate(item.occurredAt)}</span>
+                </li>
+              ))
+            )}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/components/library/LibraryNav.tsx
+++ b/src/components/library/LibraryNav.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Library, ListChecks, BookmarkPlus, Highlighter, History, MessageCircle, Settings } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface LibraryNavProps {
+  profileName: string
+}
+
+const links = [
+  { href: '/me', label: 'Overview', icon: Library },
+  { href: '/me/lists', label: 'Your Lists', icon: ListChecks },
+  { href: '/me/saved-lists', label: 'Saved Lists', icon: BookmarkPlus },
+  { href: '/me/highlights', label: 'Highlights', icon: Highlighter },
+  { href: '/me/history', label: 'Reading History', icon: History },
+  { href: '/me/responses', label: 'Responses', icon: MessageCircle },
+  { href: '/me/accounts', label: 'Account', icon: Settings },
+]
+
+export function LibraryNav({ profileName }: LibraryNavProps) {
+  const pathname = usePathname()
+
+  return (
+    <aside className="w-full max-w-xs rounded-[32px] border-4 border-black bg-[#FF69B4] p-6 text-black shadow-[16px_16px_0px_0px_rgba(0,0,0,0.2)]">
+      <div className="mb-6">
+        <p className="text-sm font-bold uppercase tracking-widest text-black/70">Welcome back</p>
+        <h2 className="text-2xl font-black leading-tight">{profileName}</h2>
+      </div>
+      <nav aria-label="Library navigation" className="space-y-2">
+        {links.map((link) => {
+          const Icon = link.icon
+          const isActive = pathname === link.href
+          return (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={cn(
+                'flex items-center gap-3 rounded-[24px] border-4 border-black bg-white px-4 py-3 text-lg font-bold transition-transform hover:-translate-y-1 hover:shadow-[8px_8px_0px_0px_rgba(0,0,0,0.2)] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-black/50',
+                isActive ? 'bg-[#87CEEB]' : 'bg-white',
+              )}
+            >
+              <Icon className="h-6 w-6" aria-hidden="true" />
+              <span>{link.label}</span>
+            </Link>
+          )
+        })}
+      </nav>
+    </aside>
+  )
+}

--- a/src/components/library/ListDetailView.tsx
+++ b/src/components/library/ListDetailView.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { useState } from 'react'
+import { Loader2, ArrowUp, ArrowDown, Trash2 } from 'lucide-react'
+import type { ListItem, UserList } from '@/utils/types'
+
+interface ListDetailViewProps {
+  list: UserList
+  items: ListItem[]
+}
+
+interface NewItemState {
+  postId: string
+  note: string
+}
+
+export function ListDetailView({ list, items: initialItems }: ListDetailViewProps) {
+  const [items, setItems] = useState(initialItems)
+  const [updating, setUpdating] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [newItem, setNewItem] = useState<NewItemState>({ postId: '', note: '' })
+
+  const refreshList = async () => {
+    const response = await fetch(`/api/library/lists/${list.id}/items?limit=100`, {
+      credentials: 'include',
+      cache: 'no-store',
+    })
+    if (!response.ok) return
+    const payload = (await response.json()) as { items: ListItem[] }
+    setItems(payload.items ?? [])
+  }
+
+  const handleRemove = async (itemId: string) => {
+    const confirmed = window.confirm('Remove this post from the list?')
+    if (!confirmed) return
+
+    const response = await fetch(`/api/library/lists/${list.id}/items/${itemId}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    })
+
+    if (!response.ok) {
+      setMessage('Unable to remove item. Please try again.')
+      return
+    }
+
+    setItems((prev) => prev.filter((item) => item.id !== itemId))
+  }
+
+  const handleReorder = async (itemId: string, direction: 'up' | 'down') => {
+    const currentIndex = items.findIndex((item) => item.id === itemId)
+    if (currentIndex === -1) return
+
+    const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1
+    if (targetIndex < 0 || targetIndex >= items.length) return
+
+    const updated = [...items]
+    const [moved] = updated.splice(currentIndex, 1)
+    updated.splice(targetIndex, 0, moved)
+
+    setItems(updated)
+
+    await fetch(`/api/library/lists/${list.id}/items/${itemId}`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ position: targetIndex }),
+    })
+  }
+
+  const handleNoteSave = async (itemId: string, note: string) => {
+    setUpdating(true)
+    const response = await fetch(`/api/library/lists/${list.id}/items/${itemId}`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ note }),
+    })
+
+    if (!response.ok) {
+      setMessage('Unable to update note.')
+    }
+    setUpdating(false)
+  }
+
+  const handleAddItem = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!newItem.postId) return
+    setUpdating(true)
+    setMessage(null)
+    const response = await fetch(`/api/library/lists/${list.id}/items`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ postId: newItem.postId, note: newItem.note }),
+    })
+
+    if (!response.ok) {
+      const body = (await response.json()) as { error?: string }
+      setMessage(body.error ?? 'Unable to add post to list.')
+      setUpdating(false)
+      return
+    }
+
+    setNewItem({ postId: '', note: '' })
+    await refreshList()
+    setUpdating(false)
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="border-b-4 border-black pb-4">
+        <h1 className="text-3xl font-black text-black">{list.title}</h1>
+        <p className="text-sm text-black/70">{list.description ?? 'No description yet.'}</p>
+        <p className="mt-1 text-xs uppercase text-black/60">{list.isPublic ? 'Public list' : 'Private list'}</p>
+      </header>
+
+      <section className="rounded-[32px] border-4 border-black bg-[#FF69B4]/30 p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)]">
+        <h2 className="text-xl font-black text-black">Add a post by ID</h2>
+        <p className="text-sm text-black/70">
+          Paste the post ID from the admin dashboard to add it to this list. We&apos;re shipping a friendlier picker soon!
+        </p>
+        <form className="mt-3 grid gap-3 md:grid-cols-2" onSubmit={handleAddItem}>
+          <input
+            value={newItem.postId}
+            onChange={(event) => setNewItem((prev) => ({ ...prev, postId: event.target.value }))}
+            placeholder="Post ID"
+            className="rounded-[16px] border-4 border-black px-3 py-2 font-semibold text-black focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-black/50"
+            required
+          />
+          <input
+            value={newItem.note}
+            onChange={(event) => setNewItem((prev) => ({ ...prev, note: event.target.value }))}
+            placeholder="Optional note"
+            className="rounded-[16px] border-4 border-black px-3 py-2 font-semibold text-black focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-black/50"
+          />
+          <button
+            type="submit"
+            className="md:col-span-2 inline-flex items-center justify-center gap-2 rounded-[24px] border-4 border-black bg-white px-4 py-2 font-bold text-black transition-transform hover:-translate-y-1 hover:shadow-[8px_8px_0px_0px_rgba(0,0,0,0.2)]"
+          >
+            {updating ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+            Add post
+          </button>
+        </form>
+      </section>
+
+      {message ? (
+        <div className="rounded-[24px] border-4 border-black bg-[#FFB347] px-4 py-3 font-semibold text-black">{message}</div>
+      ) : null}
+
+      <section aria-labelledby="list-items" className="space-y-4">
+        <h2 id="list-items" className="text-2xl font-black text-black">
+          Posts in this list ({items.length})
+        </h2>
+        {items.length === 0 ? (
+          <div className="rounded-[32px] border-4 border-dashed border-black/40 bg-[#FDF7FF] px-6 py-10 text-center font-semibold text-black/70">
+            No posts added yet. Use the form above to start curating!
+          </div>
+        ) : null}
+        <div className="space-y-4">
+          {items.map((item, index) => (
+            <article
+              key={item.id}
+              className="rounded-[32px] border-4 border-black bg-white p-5 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)]"
+            >
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <p className="text-lg font-black text-black">{item.postTitle}</p>
+                  <p className="text-sm text-black/70">{item.postExcerpt ?? 'No excerpt available.'}</p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void handleReorder(item.id, 'up')}
+                    className="inline-flex items-center gap-1 rounded-[24px] border-4 border-black bg-white px-3 py-1 text-sm font-bold text-black disabled:opacity-50"
+                    disabled={index === 0}
+                  >
+                    <ArrowUp className="h-4 w-4" aria-hidden="true" />
+                    Up
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleReorder(item.id, 'down')}
+                    className="inline-flex items-center gap-1 rounded-[24px] border-4 border-black bg-white px-3 py-1 text-sm font-bold text-black disabled:opacity-50"
+                    disabled={index === items.length - 1}
+                  >
+                    <ArrowDown className="h-4 w-4" aria-hidden="true" />
+                    Down
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleRemove(item.id)}
+                    className="inline-flex items-center gap-1 rounded-[24px] border-4 border-black bg-[#FF69B4] px-3 py-1 text-sm font-bold text-black"
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    Remove
+                  </button>
+                </div>
+              </div>
+              <div className="mt-3">
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-bold uppercase text-black/60">Personal note</span>
+                  <textarea
+                    defaultValue={item.note ?? ''}
+                    onBlur={(event) => void handleNoteSave(item.id, event.target.value)}
+                    rows={2}
+                    className="rounded-[16px] border-4 border-black px-3 py-2 font-semibold text-black focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-black/50"
+                  />
+                </label>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/library/ListsManager.tsx
+++ b/src/components/library/ListsManager.tsx
@@ -1,0 +1,288 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import slugify from '@sindresorhus/slugify'
+import { Loader2, Trash2, Eye, PlusCircle } from 'lucide-react'
+import type { UserList } from '@/utils/types'
+
+interface ListsManagerProps {
+  initialLists: UserList[]
+}
+
+interface FormState {
+  title: string
+  description: string
+  isPublic: boolean
+  slug: string
+  coverImageUrl: string
+}
+
+const defaultFormState: FormState = {
+  title: '',
+  description: '',
+  isPublic: false,
+  slug: '',
+  coverImageUrl: '',
+}
+
+export function ListsManager({ initialLists }: ListsManagerProps) {
+  const [lists, setLists] = useState<UserList[]>(initialLists)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [form, setForm] = useState<FormState>(defaultFormState)
+  const [submitting, setSubmitting] = useState(false)
+
+  const loadLists = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch('/api/library/lists?limit=50', {
+        credentials: 'include',
+        cache: 'no-store',
+      })
+
+      if (!response.ok) {
+        const payload = (await response.json()) as { error?: string }
+        throw new Error(payload.error ?? 'Unable to load lists')
+      }
+
+      const payload = (await response.json()) as { items: UserList[] }
+      setLists(payload.items ?? [])
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Unable to load lists')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (initialLists.length === 0) {
+      void loadLists()
+    }
+  }, [initialLists.length, loadLists])
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setSubmitting(true)
+    setError(null)
+
+    const payload = {
+      title: form.title.trim(),
+      description: form.description.trim().length > 0 ? form.description.trim() : undefined,
+      slug: (form.slug.trim() || slugify(form.title)).toLowerCase(),
+      isPublic: form.isPublic,
+      coverImageUrl: form.coverImageUrl.trim().length > 0 ? form.coverImageUrl.trim() : undefined,
+    }
+
+    try {
+      const response = await fetch('/api/library/lists', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+
+      if (!response.ok) {
+        const body = (await response.json()) as { error?: string }
+        throw new Error(body.error ?? 'Unable to create list')
+      }
+
+      const body = (await response.json()) as { list: UserList }
+      setLists((previous) => [body.list, ...previous])
+      setForm(defaultFormState)
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Unable to create list')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    const confirmed = window.confirm('Delete this list? This cannot be undone.')
+    if (!confirmed) return
+
+    try {
+      const response = await fetch(`/api/library/lists/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+
+      if (!response.ok) {
+        const body = (await response.json()) as { error?: string }
+        throw new Error(body.error ?? 'Unable to delete list')
+      }
+
+      setLists((previous) => previous.filter((list) => list.id !== id))
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Unable to delete list')
+    }
+  }
+
+  const totalItems = useMemo(
+    () => lists.reduce((sum, list) => sum + list.itemCount, 0),
+    [lists],
+  )
+
+  return (
+    <div className="space-y-6">
+      <header className="border-b-4 border-black pb-4">
+        <h1 className="text-3xl font-black text-black">Your custom lists</h1>
+        <p className="mt-2 text-sm text-black/70">
+          Organize saved posts into themed collections. Share public lists with the community or keep them private for your own learning path.
+        </p>
+      </header>
+
+      <section aria-labelledby="create-list" className="rounded-[32px] border-4 border-black bg-[#87CEEB]/40 p-6 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)]">
+        <div className="flex items-center gap-2">
+          <PlusCircle className="h-6 w-6 text-black" aria-hidden="true" />
+          <h2 id="create-list" className="text-2xl font-black text-black">
+            Create a new list
+          </h2>
+        </div>
+        <form className="mt-4 grid gap-4 md:grid-cols-2" onSubmit={handleSubmit}>
+          <label className="md:col-span-1">
+            <span className="text-sm font-bold uppercase text-black/70">Title</span>
+            <input
+              required
+              value={form.title}
+              onChange={(event) =>
+                setForm((prev) => ({ ...prev, title: event.target.value, slug: slugify(event.target.value) }))
+              }
+              className="mt-1 w-full rounded-[16px] border-4 border-black px-3 py-2 font-semibold text-black focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-black/50"
+              placeholder="React reading list"
+            />
+          </label>
+          <label className="md:col-span-1">
+            <span className="text-sm font-bold uppercase text-black/70">Slug</span>
+            <input
+              value={form.slug}
+              onChange={(event) => setForm((prev) => ({ ...prev, slug: event.target.value }))}
+              className="mt-1 w-full rounded-[16px] border-4 border-black px-3 py-2 font-semibold text-black focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-black/50"
+              placeholder="react-reading-list"
+            />
+          </label>
+          <label className="md:col-span-2">
+            <span className="text-sm font-bold uppercase text-black/70">Description</span>
+            <textarea
+              value={form.description}
+              onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+              rows={3}
+              className="mt-1 w-full rounded-[16px] border-4 border-black px-3 py-2 font-semibold text-black focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-black/50"
+              placeholder="Curated tutorials and guides for modern React developers."
+            />
+          </label>
+          <label className="md:col-span-1">
+            <span className="text-sm font-bold uppercase text-black/70">Cover image URL</span>
+            <input
+              value={form.coverImageUrl}
+              onChange={(event) => setForm((prev) => ({ ...prev, coverImageUrl: event.target.value }))}
+              className="mt-1 w-full rounded-[16px] border-4 border-black px-3 py-2 font-semibold text-black focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-black/50"
+              placeholder="https://..."
+            />
+          </label>
+          <label className="flex items-center gap-3 md:col-span-1">
+            <input
+              type="checkbox"
+              checked={form.isPublic}
+              onChange={(event) => setForm((prev) => ({ ...prev, isPublic: event.target.checked }))}
+              className="h-5 w-5 rounded border-4 border-black"
+            />
+            <span className="text-sm font-semibold text-black">Make this list public</span>
+          </label>
+          <div className="md:col-span-2">
+            <button
+              type="submit"
+              className="rounded-[24px] border-4 border-black bg-white px-5 py-2 font-bold text-black transition-transform hover:-translate-y-1 hover:shadow-[8px_8px_0px_0px_rgba(0,0,0,0.2)]"
+              disabled={submitting}
+            >
+              {submitting ? 'Saving…' : 'Save list'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      {error ? (
+        <div className="rounded-[24px] border-4 border-black bg-[#FFB347] px-4 py-3 font-semibold text-black">{error}</div>
+      ) : null}
+
+      <section aria-labelledby="your-lists" className="space-y-4">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 id="your-lists" className="text-2xl font-black text-black">
+              Your lists ({lists.length})
+            </h2>
+            <p className="text-sm text-black/70">{totalItems} posts organized so far.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void loadLists()}
+            className="inline-flex items-center gap-2 rounded-[24px] border-4 border-black bg-white px-4 py-2 font-bold text-black transition-transform hover:-translate-y-1 hover:shadow-[8px_8px_0px_0px_rgba(0,0,0,0.2)]"
+          >
+            {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+            Refresh
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center gap-3 text-black">
+            <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" /> Loading lists…
+          </div>
+        ) : null}
+
+        {lists.length === 0 && !loading ? (
+          <div className="rounded-[32px] border-4 border-dashed border-black/40 bg-[#FDF7FF] px-6 py-10 text-center font-semibold text-black/70">
+            No lists yet. Create your first collection to start organizing saved posts.
+          </div>
+        ) : null}
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {lists.map((list) => (
+            <article
+              key={list.id}
+              className="flex flex-col gap-4 rounded-[32px] border-4 border-black bg-white p-5 text-black shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)]"
+            >
+              <div>
+                <h3 className="text-xl font-black">{list.title}</h3>
+                <p className="text-sm text-black/70">{list.description ?? 'No description yet.'}</p>
+              </div>
+              <dl className="grid grid-cols-2 gap-2 text-sm font-semibold">
+                <div>
+                  <dt className="text-black/60">Items</dt>
+                  <dd>{list.itemCount}</dd>
+                </div>
+                <div>
+                  <dt className="text-black/60">Visibility</dt>
+                  <dd>{list.isPublic ? 'Public' : 'Private'}</dd>
+                </div>
+                <div>
+                  <dt className="text-black/60">Created</dt>
+                  <dd>{new Date(list.createdAt).toLocaleDateString()}</dd>
+                </div>
+                <div>
+                  <dt className="text-black/60">Updated</dt>
+                  <dd>{new Date(list.updatedAt).toLocaleDateString()}</dd>
+                </div>
+              </dl>
+              <div className="flex flex-wrap gap-3">
+                <Link
+                  href={`/me/lists/${list.id}`}
+                  className="inline-flex items-center gap-2 rounded-[24px] border-4 border-black bg-[#87CEEB] px-4 py-2 font-bold text-black transition-transform hover:-translate-y-1 hover:shadow-[8px_8px_0px_0px_rgba(0,0,0,0.2)]"
+                >
+                  <Eye className="h-4 w-4" aria-hidden="true" /> View list
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => void handleDelete(list.id)}
+                  className="inline-flex items-center gap-2 rounded-[24px] border-4 border-black bg-white px-4 py-2 font-bold text-black transition-transform hover:-translate-y-1 hover:shadow-[8px_8px_0px_0px_rgba(0,0,0,0.2)]"
+                >
+                  <Trash2 className="h-4 w-4" aria-hidden="true" /> Delete
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/library/ReadingHistory.tsx
+++ b/src/components/library/ReadingHistory.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Loader2, Trash2, Clock } from 'lucide-react'
+import type { ReadingHistoryEntry } from '@/utils/types'
+
+interface ReadingHistoryProps {
+  initialHistory: ReadingHistoryEntry[]
+}
+
+const formatDuration = (seconds: number | null) => {
+  if (!seconds) return '—'
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 1) return '<1 min'
+  return `${minutes} min`
+}
+
+export function ReadingHistory({ initialHistory }: ReadingHistoryProps) {
+  const [history, setHistory] = useState(initialHistory)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadHistory = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch('/api/library/history?limit=50', {
+        credentials: 'include',
+        cache: 'no-store',
+      })
+
+      if (!response.ok) {
+        const body = (await response.json()) as { error?: string }
+        throw new Error(body.error ?? 'Unable to load reading history')
+      }
+
+      const body = (await response.json()) as { items: ReadingHistoryEntry[] }
+      setHistory(body.items ?? [])
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Unable to load reading history')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (initialHistory.length === 0) {
+      void loadHistory()
+    }
+  }, [initialHistory.length, loadHistory])
+
+  const handleDelete = async (id: string) => {
+    const confirmed = window.confirm('Remove this entry from your history?')
+    if (!confirmed) return
+
+    const response = await fetch(`/api/library/history/${id}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    })
+
+    if (!response.ok) {
+      setError('Unable to delete history entry.')
+      return
+    }
+
+    setHistory((prev) => prev.filter((entry) => entry.id !== id))
+  }
+
+  const totals = useMemo(() => {
+    const time = history.reduce((sum, entry) => sum + (entry.readDurationSeconds ?? 0), 0)
+    const completed = history.filter((entry) => entry.completed).length
+    return {
+      totalMinutes: Math.round(time / 60),
+      completed,
+    }
+  }, [history])
+
+  return (
+    <div className="space-y-6">
+      <header className="border-b-4 border-black pb-4">
+        <h1 className="text-3xl font-black text-black">Reading history</h1>
+        <p className="text-sm text-black/70">Track your progress and jump back into stories you care about.</p>
+      </header>
+
+      {error ? (
+        <div className="rounded-[24px] border-4 border-black bg-[#FFB347] px-4 py-3 font-semibold text-black">{error}</div>
+      ) : null}
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <article className="rounded-[32px] border-4 border-black bg-[#9723C9]/30 p-4 text-black shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)]">
+          <p className="text-xs uppercase text-black/60">Total sessions</p>
+          <p className="text-3xl font-black">{history.length}</p>
+        </article>
+        <article className="rounded-[32px] border-4 border-black bg-[#87CEEB]/30 p-4 text-black shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)]">
+          <p className="text-xs uppercase text-black/60">Completed reads</p>
+          <p className="text-3xl font-black">{totals.completed}</p>
+        </article>
+        <article className="rounded-[32px] border-4 border-black bg-[#90EE90]/30 p-4 text-black shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)]">
+          <p className="text-xs uppercase text-black/60">Minutes logged</p>
+          <p className="text-3xl font-black">{totals.totalMinutes}</p>
+        </article>
+      </section>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void loadHistory()}
+          className="inline-flex items-center gap-2 rounded-[24px] border-4 border-black bg-white px-4 py-2 text-sm font-bold text-black"
+        >
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+          Refresh
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        {history.length === 0 && !loading ? (
+          <div className="rounded-[32px] border-4 border-dashed border-black/40 bg-[#FDF7FF] px-6 py-10 text-center font-semibold text-black/70">
+            No reading activity yet. Dive into an article and we&apos;ll track it here.
+          </div>
+        ) : null}
+        {history.map((entry) => (
+          <article
+            key={entry.id}
+            className="rounded-[32px] border-4 border-black bg-white p-6 text-black shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)]"
+          >
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-lg font-black">{entry.postTitle}</p>
+                <p className="text-sm text-black/70">
+                  {entry.completed ? 'Completed' : 'In progress'} · {formatDuration(entry.readDurationSeconds)} ·{' '}
+                  {entry.scrollPercentage ?? 0}% scrolled
+                </p>
+              </div>
+              <div className="flex items-center gap-2 text-sm font-semibold text-black/70">
+                <Clock className="h-4 w-4" aria-hidden="true" />
+                {new Date(entry.readAt).toLocaleString()}
+                <button
+                  type="button"
+                  onClick={() => void handleDelete(entry.id)}
+                  className="inline-flex items-center gap-2 rounded-[24px] border-4 border-black bg-[#FF69B4] px-3 py-1 text-sm font-bold text-black"
+                >
+                  <Trash2 className="h-4 w-4" aria-hidden="true" /> Remove
+                </button>
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/library/ResponsesPanel.tsx
+++ b/src/components/library/ResponsesPanel.tsx
@@ -1,0 +1,19 @@
+interface ResponsesPanelProps {
+  responsesCount: number
+}
+
+export function ResponsesPanel({ responsesCount }: ResponsesPanelProps) {
+  return (
+    <section className="space-y-4">
+      <header className="border-b-4 border-black pb-4">
+        <h1 className="text-3xl font-black text-black">Responses</h1>
+        <p className="text-sm text-black/70">
+          Comment management is coming soon. For now you can review your discussions directly on each article.
+        </p>
+      </header>
+      <div className="rounded-[32px] border-4 border-dashed border-black/40 bg-[#FDF7FF] px-6 py-10 text-center font-semibold text-black/70">
+        You&apos;ve shared {responsesCount} responses so far. We&apos;ll surface them here once the responses center is live.
+      </div>
+    </section>
+  )
+}

--- a/src/components/library/SavedListsPanel.tsx
+++ b/src/components/library/SavedListsPanel.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link'
+import type { SavedList } from '@/utils/types'
+
+interface SavedListsPanelProps {
+  savedLists: SavedList[]
+}
+
+export function SavedListsPanel({ savedLists }: SavedListsPanelProps) {
+  return (
+    <section className="space-y-4">
+      <header className="border-b-4 border-black pb-4">
+        <h1 className="text-3xl font-black text-black">Saved community lists</h1>
+        <p className="text-sm text-black/70">Inspiration curated by fellow readers. Visit their collections to explore new topics.</p>
+      </header>
+      {savedLists.length === 0 ? (
+        <div className="rounded-[32px] border-4 border-dashed border-black/40 bg-[#FDF7FF] px-6 py-10 text-center font-semibold text-black/70">
+          You haven&apos;t saved any community lists yet. Browse featured collections to discover new angles.
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          {savedLists.map((saved) => (
+            <article
+              key={saved.id}
+              className="space-y-3 rounded-[32px] border-4 border-black bg-white p-6 text-black shadow-[12px_12px_0px_0px_rgba(0,0,0,0.2)]"
+            >
+              <div>
+                <p className="text-lg font-black">{saved.listTitle}</p>
+                <p className="text-sm text-black/70">By {saved.listOwnerName}</p>
+              </div>
+              <p className="text-sm text-black/70">{saved.listDescription ?? 'No description provided.'}</p>
+              <div className="flex items-center justify-between text-sm font-semibold">
+                <span>{saved.listItemCount} items</span>
+                <span>Saved {new Date(saved.savedAt).toLocaleDateString()}</span>
+              </div>
+              <Link
+                href={`/me/lists/${saved.listId}`}
+                className="inline-flex items-center justify-center rounded-[24px] border-4 border-black bg-[#87CEEB] px-4 py-2 font-bold text-black transition-transform hover:-translate-y-1 hover:shadow-[8px_8px_0px_0px_rgba(0,0,0,0.2)]"
+              >
+                View list
+              </Link>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { PanelLeftClose, PanelLeftOpen } from "lucide-react"
+import { ChevronRight, PanelLeftClose, PanelLeftOpen } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
@@ -107,7 +107,7 @@ const SidebarTrigger = React.forwardRef<HTMLButtonElement, React.ComponentPropsW
 SidebarTrigger.displayName = "SidebarTrigger"
 
 const SidebarInset = ({ className, ...props }: React.ComponentPropsWithoutRef<"div">) => {
-  const { isOpen, isMobile } = useSidebar()
+  const { isMobile } = useSidebar()
   return (
     <div
       className={cn(
@@ -257,7 +257,7 @@ const SidebarMenuSubButton = React.forwardRef<HTMLAnchorElement, React.Component
 SidebarMenuSubButton.displayName = "SidebarMenuSubButton"
 
 const SidebarRail = ({ className, ...props }: React.ComponentPropsWithoutRef<"div">) => {
-  const { isOpen, isMobile, toggle } = useSidebar()
+  const { isOpen, toggle } = useSidebar()
   return (
     <div
       className={cn(

--- a/src/lib/library/mappers.ts
+++ b/src/lib/library/mappers.ts
@@ -1,0 +1,242 @@
+type Nullable<T> = T | null
+type Maybe<T> = T | null | undefined
+
+export const mapUserList = (record: {
+  id: string
+  profile_id: string
+  title: string
+  description: Nullable<string>
+  slug: string
+  is_public: boolean
+  cover_image_url: Nullable<string>
+  item_count: number
+  created_at: string
+  updated_at: string
+}) => ({
+  id: record.id,
+  profileId: record.profile_id,
+  title: record.title,
+  description: record.description ?? null,
+  slug: record.slug,
+  isPublic: record.is_public,
+  coverImageUrl: record.cover_image_url ?? null,
+  itemCount: record.item_count,
+  createdAt: record.created_at,
+  updatedAt: record.updated_at,
+})
+
+export const mapListItem = (record: {
+  id: string
+  list_id: string
+  post_id: string
+  note: Nullable<string>
+  position: number
+  added_at: string
+  posts?:
+    | {
+        id: Maybe<string>
+        title: Maybe<string>
+        slug: Maybe<string>
+        excerpt: Maybe<string>
+        featured_image_url: Maybe<string>
+      }
+    | {
+        id: Maybe<string>
+        title: Maybe<string>
+        slug: Maybe<string>
+        excerpt: Maybe<string>
+        featured_image_url: Maybe<string>
+      }[]
+    | null
+}) => ({
+  id: record.id,
+  listId: record.list_id,
+  postId: record.post_id,
+  ...(() => {
+    const post = Array.isArray(record.posts) ? record.posts[0] ?? null : record.posts ?? null
+    return {
+      postTitle: post?.title ?? 'Untitled',
+      postSlug: post?.slug ?? '',
+      postExcerpt: post?.excerpt ?? null,
+      postCoverImage: post?.featured_image_url ?? null,
+    }
+  })(),
+  note: record.note ?? null,
+  position: record.position,
+  addedAt: record.added_at,
+})
+
+export const mapSavedList = (record: {
+  id: string
+  profile_id: string
+  list_id: string
+  saved_at: string
+  user_lists?:
+    | {
+        title: Maybe<string>
+        description: Maybe<string>
+        item_count: Maybe<number>
+        profiles?:
+          | {
+              display_name: Maybe<string>
+            }
+          | {
+              display_name: Maybe<string>
+            }[]
+          | null
+      }
+    | {
+        title: Maybe<string>
+        description: Maybe<string>
+        item_count: Maybe<number>
+        profiles?:
+          | {
+              display_name: Maybe<string>
+            }
+          | {
+              display_name: Maybe<string>
+            }[]
+          | null
+      }[]
+    | null
+}) => ({
+  id: record.id,
+  profileId: record.profile_id,
+  listId: record.list_id,
+  ...(() => {
+    const list = Array.isArray(record.user_lists) ? record.user_lists[0] ?? null : record.user_lists ?? null
+    const profile = Array.isArray(list?.profiles) ? list?.profiles[0] ?? null : list?.profiles ?? null
+    return {
+      listTitle: list?.title ?? 'Untitled list',
+      listDescription: list?.description ?? null,
+      listOwnerName: profile?.display_name ?? 'Community curator',
+      listItemCount: list?.item_count ?? 0,
+    }
+  })(),
+  savedAt: record.saved_at,
+})
+
+export const mapHighlight = (record: {
+  id: string
+  profile_id: string
+  post_id: string
+  highlighted_text: string
+  note: Nullable<string>
+  color: string
+  position_start: number
+  position_end: number
+  is_public: boolean
+  created_at: string
+  updated_at: string
+  posts?:
+    | {
+        title: Maybe<string>
+        slug: Maybe<string>
+      }
+    | {
+        title: Maybe<string>
+        slug: Maybe<string>
+      }[]
+    | null
+}) => ({
+  id: record.id,
+  profileId: record.profile_id,
+  postId: record.post_id,
+  ...(() => {
+    const post = Array.isArray(record.posts) ? record.posts[0] ?? null : record.posts ?? null
+    return {
+      postTitle: post?.title ?? 'Untitled post',
+      postSlug: post?.slug ?? '',
+    }
+  })(),
+  highlightedText: record.highlighted_text,
+  note: record.note ?? null,
+  color: record.color,
+  positionStart: record.position_start,
+  positionEnd: record.position_end,
+  isPublic: record.is_public,
+  createdAt: record.created_at,
+  updatedAt: record.updated_at,
+})
+
+export const mapReadingHistory = (record: {
+  id: string
+  profile_id: string
+  post_id: string
+  read_at: string
+  read_duration_seconds: Nullable<number>
+  scroll_percentage: Nullable<number>
+  completed: boolean
+  last_position: number
+  created_at: string
+  updated_at: string
+  posts?:
+    | {
+        title: Maybe<string>
+        slug: Maybe<string>
+        excerpt: Maybe<string>
+        featured_image_url: Maybe<string>
+      }
+    | {
+        title: Maybe<string>
+        slug: Maybe<string>
+        excerpt: Maybe<string>
+        featured_image_url: Maybe<string>
+      }[]
+    | null
+}) => ({
+  id: record.id,
+  profileId: record.profile_id,
+  postId: record.post_id,
+  ...(() => {
+    const post = Array.isArray(record.posts) ? record.posts[0] ?? null : record.posts ?? null
+    return {
+      postTitle: post?.title ?? 'Untitled post',
+      postSlug: post?.slug ?? '',
+      postExcerpt: post?.excerpt ?? null,
+      postCoverImage: post?.featured_image_url ?? null,
+    }
+  })(),
+  readAt: record.read_at,
+  readDurationSeconds: record.read_duration_seconds ?? null,
+  scrollPercentage: record.scroll_percentage ?? null,
+  completed: record.completed,
+  lastPosition: record.last_position,
+  createdAt: record.created_at,
+  updatedAt: record.updated_at,
+})
+
+export const mapBookmark = (record: {
+  id: string
+  profile_id: string
+  post_id: string
+  created_at: string
+  posts?:
+    | {
+        title: Maybe<string>
+        slug: Maybe<string>
+        excerpt: Maybe<string>
+        featured_image_url: Maybe<string>
+      }
+    | {
+        title: Maybe<string>
+        slug: Maybe<string>
+        excerpt: Maybe<string>
+        featured_image_url: Maybe<string>
+      }[]
+    | null
+}) => ({
+  id: record.id,
+  profileId: record.profile_id,
+  postId: record.post_id,
+  ...(() => {
+    const post = Array.isArray(record.posts) ? record.posts[0] ?? null : record.posts ?? null
+    return {
+      postTitle: post?.title ?? 'Untitled post',
+      postSlug: post?.slug ?? '',
+      postExcerpt: post?.excerpt ?? null,
+      postCoverImage: post?.featured_image_url ?? null,
+    }
+  })(),
+  createdAt: record.created_at,
+})

--- a/src/lib/library/reading-utils.ts
+++ b/src/lib/library/reading-utils.ts
@@ -1,0 +1,82 @@
+export interface ReadingMetrics {
+  readDurationSeconds: number;
+  scrollPercentage: number;
+  lastPosition: number;
+}
+
+const clampNumber = (value: number, min: number, max: number) => {
+  if (Number.isNaN(value) || !Number.isFinite(value)) {
+    return min;
+  }
+
+  if (value < min) {
+    return min;
+  }
+
+  if (value > max) {
+    return max;
+  }
+
+  return value;
+};
+
+const round = (value: number) => Math.round(Number.isFinite(value) ? value : 0);
+
+export const computeScrollProgress = (
+  scrollTop: number,
+  scrollHeight: number,
+  clientHeight: number,
+): number => {
+  if (scrollHeight <= 0) {
+    return 0;
+  }
+
+  const adjustedScrollHeight = Math.max(scrollHeight - Math.max(clientHeight, 1), 1);
+  const ratio = clampNumber(scrollTop, 0, adjustedScrollHeight) / adjustedScrollHeight;
+  return clampNumber(Math.round(ratio * 100), 0, 100);
+};
+
+export const isReadingComplete = (scrollPercentage: number, threshold = 95) =>
+  clampNumber(scrollPercentage, 0, 100) >= threshold;
+
+export const shouldPersistReadingHistory = (
+  metrics: ReadingMetrics,
+  hasExistingEntry: boolean,
+) => {
+  const duration = round(metrics.readDurationSeconds);
+  const progress = clampNumber(round(metrics.scrollPercentage), 0, 100);
+
+  if (hasExistingEntry) {
+    return duration >= 5 || progress >= 5;
+  }
+
+  return duration >= 10 || progress >= 25;
+};
+
+interface BuildReadingHistoryPayloadOptions extends Partial<ReadingMetrics> {
+  historyId?: string | null;
+  postId: string;
+  completionThreshold?: number;
+}
+
+export const buildReadingHistoryPayload = ({
+  historyId,
+  postId,
+  readDurationSeconds = 0,
+  scrollPercentage = 0,
+  lastPosition = 0,
+  completionThreshold = 95,
+}: BuildReadingHistoryPayloadOptions) => {
+  const roundedDuration = Math.max(0, round(readDurationSeconds));
+  const roundedScroll = clampNumber(round(scrollPercentage), 0, 100);
+  const roundedPosition = Math.max(0, round(lastPosition));
+
+  return {
+    historyId: historyId ?? undefined,
+    postId,
+    readDurationSeconds: roundedDuration,
+    scrollPercentage: roundedScroll,
+    lastPosition: roundedPosition,
+    completed: isReadingComplete(roundedScroll, completionThreshold),
+  };
+};

--- a/src/lib/library/server.ts
+++ b/src/lib/library/server.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { createServerComponentClient } from '@/lib/supabase/server-client'
+import type { Database } from '@/lib/supabase/types'
+import type { AuthenticatedRequestContext } from './types'
+
+interface ProfileRecord {
+  id: string
+  display_name: string | null
+}
+
+export const getLibraryRequestContext = async (): Promise<
+  | ({ profile: ProfileRecord } & AuthenticatedRequestContext)
+  | { response: NextResponse }
+> => {
+  const supabase = createServerComponentClient<Database>()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return {
+      response: NextResponse.json(
+        { error: 'Authentication required.' },
+        { status: 401 },
+      ),
+    }
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, display_name')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (error) {
+    return {
+      response: NextResponse.json(
+        { error: `Unable to load profile: ${error.message}` },
+        { status: 500 },
+      ),
+    }
+  }
+
+  if (!profile) {
+    return {
+      response: NextResponse.json(
+        { error: 'Profile not found.' },
+        { status: 404 },
+      ),
+    }
+  }
+
+  return {
+    supabase: supabase as unknown as SupabaseClient<Database>,
+    profileId: profile.id,
+    userId: user.id,
+    profile,
+  }
+}
+
+export const buildLibraryErrorResponse = (
+  error: unknown,
+  fallback = 'An unexpected error occurred.',
+  status = 500,
+) => {
+  const message = error instanceof Error ? error.message : fallback
+  return NextResponse.json({ error: message }, { status })
+}

--- a/src/lib/library/stats-service.ts
+++ b/src/lib/library/stats-service.ts
@@ -1,0 +1,159 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { mapHighlight, mapReadingHistory } from '@/lib/library/mappers'
+import type { Database } from '@/lib/supabase/types'
+import type { LibraryStatsResponse } from '@/lib/library/types'
+
+const rangeLookup: Record<string, number> = {
+  '7d': 7,
+  '30d': 30,
+  '90d': 90,
+  '365d': 365,
+}
+
+export type StatsRange = keyof typeof rangeLookup
+
+export const loadLibraryStats = async (
+  profileId: string,
+  supabase: SupabaseClient<Database>,
+  range: StatsRange,
+): Promise<LibraryStatsResponse> => {
+  const days = rangeLookup[range] ?? rangeLookup['30d']
+  const now = new Date()
+  const rangeStart = new Date(now.getTime() - days * 24 * 60 * 60 * 1000)
+  const rangeStartIso = rangeStart.toISOString()
+  const streakWindow = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000)
+
+  const [
+    listsResult,
+    bookmarkCountResult,
+    highlightCountResult,
+    highlightsRangeResult,
+    historyCountResult,
+    historyEntriesResult,
+  ] = await Promise.all([
+    supabase.from('user_lists').select('item_count').eq('profile_id', profileId),
+    supabase
+      .from('bookmarks')
+      .select('id', { count: 'exact', head: true })
+      .eq('profile_id', profileId),
+    supabase
+      .from('highlights')
+      .select('id', { count: 'exact', head: true })
+      .eq('profile_id', profileId),
+    supabase
+      .from('highlights')
+      .select(
+        'color, created_at, profile_id, post_id, highlighted_text, note, position_start, position_end, is_public, updated_at, posts(title, slug)',
+      )
+      .eq('profile_id', profileId)
+      .gte('created_at', rangeStartIso),
+    supabase
+      .from('reading_history')
+      .select('id', { count: 'exact', head: true })
+      .eq('profile_id', profileId),
+    supabase
+      .from('reading_history')
+      .select(
+        'id, profile_id, post_id, read_at, read_duration_seconds, scroll_percentage, completed, last_position, created_at, updated_at, posts(title, slug, excerpt, featured_image_url)',
+      )
+      .eq('profile_id', profileId)
+      .gte('read_at', streakWindow.toISOString()),
+  ])
+
+  if (listsResult.error) {
+    throw new Error(`Unable to load lists for stats: ${listsResult.error.message}`)
+  }
+
+  if (bookmarkCountResult.error) {
+    throw new Error(`Unable to load bookmarks for stats: ${bookmarkCountResult.error.message}`)
+  }
+
+  if (highlightCountResult.error) {
+    throw new Error(`Unable to load highlights for stats: ${highlightCountResult.error.message}`)
+  }
+
+  if (highlightsRangeResult.error) {
+    throw new Error(`Unable to load highlight breakdown: ${highlightsRangeResult.error.message}`)
+  }
+
+  if (historyCountResult.error) {
+    throw new Error(`Unable to load reading history for stats: ${historyCountResult.error.message}`)
+  }
+
+  if (historyEntriesResult.error) {
+    throw new Error(`Unable to load reading history entries: ${historyEntriesResult.error.message}`)
+  }
+
+  const lists = (listsResult.data ?? []) as Array<{ item_count?: number | null }>
+  const totalLists = lists.length
+  const totalListItems = lists.reduce((acc, list) => acc + (list.item_count ?? 0), 0)
+  const totalBookmarks = bookmarkCountResult.count ?? 0
+  const totalHighlights = highlightCountResult.count ?? 0
+  const totalReadingHistory = historyCountResult.count ?? 0
+
+  const highlightGroupsMap = new Map<string, number>()
+  for (const record of highlightsRangeResult.data ?? []) {
+    const highlight = mapHighlight(record)
+    highlightGroupsMap.set(highlight.color, (highlightGroupsMap.get(highlight.color) ?? 0) + 1)
+  }
+
+  const highlightGroups = Array.from(highlightGroupsMap.entries()).map(([color, count]) => ({
+    color,
+    count,
+  }))
+
+  const historyEntries = (historyEntriesResult.data ?? []).map(mapReadingHistory)
+  const totalReadingTime = historyEntries.reduce(
+    (acc, entry) => acc + (entry.readDurationSeconds ?? 0),
+    0,
+  )
+
+  const readingDays = new Set<string>()
+  for (const entry of historyEntries) {
+    const day = entry.readAt.slice(0, 10)
+    readingDays.add(day)
+  }
+
+  let streak = 0
+  const currentDay = new Date(now)
+  while (true) {
+    const dayKey = currentDay.toISOString().slice(0, 10)
+    if (readingDays.has(dayKey)) {
+      streak += 1
+      currentDay.setUTCDate(currentDay.getUTCDate() - 1)
+    } else {
+      break
+    }
+  }
+
+  const timelineMap = new Map<string, number>()
+  for (const entry of historyEntries) {
+    if (entry.readAt < rangeStartIso) {
+      continue
+    }
+    const day = entry.readAt.slice(0, 10)
+    const minutes = Math.round(((entry.readDurationSeconds ?? 0) / 60) * 10) / 10
+    timelineMap.set(day, (timelineMap.get(day) ?? 0) + minutes)
+  }
+
+  const timeline: { date: string; minutes: number }[] = []
+  for (let i = days - 1; i >= 0; i -= 1) {
+    const date = new Date(now.getTime() - i * 24 * 60 * 60 * 1000)
+    const key = date.toISOString().slice(0, 10)
+    timeline.push({ date: key, minutes: timelineMap.get(key) ?? 0 })
+  }
+
+  return {
+    stats: {
+      totalBookmarks,
+      totalLists,
+      totalListItems,
+      totalHighlights,
+      totalReadingHistory,
+      readingStreak: streak,
+      totalReadingTime,
+    },
+    highlightGroups,
+    readingTimeline: timeline,
+  }
+}

--- a/src/lib/library/types.ts
+++ b/src/lib/library/types.ts
@@ -1,0 +1,90 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type {
+  Bookmark,
+  Highlight,
+  LibraryStats,
+  ListItem,
+  ReadingHistoryEntry,
+  SavedList,
+  UserList,
+} from '@/utils/types'
+import type {
+  CreateBookmarkInput,
+  CreateHighlightInput,
+  CreateListInput,
+  CreateListItemInput,
+  RecordReadingInput,
+  SaveListInput,
+  UpdateHighlightInput,
+  UpdateListInput,
+  UpdateListItemInput,
+} from './validation'
+
+export interface AuthenticatedRequestContext {
+  supabase: SupabaseClient
+  profileId: string
+  userId: string
+}
+
+export interface LibraryListWithItems extends UserList {
+  items: ListItem[]
+}
+
+export interface LibraryHighlightGroup {
+  color: string
+  count: number
+}
+
+export interface ReadingTimelinePoint {
+  date: string
+  minutes: number
+}
+
+export interface LibraryStatsResponse {
+  stats: LibraryStats
+  highlightGroups: LibraryHighlightGroup[]
+  readingTimeline: ReadingTimelinePoint[]
+}
+
+export type LibraryEntity =
+  | UserList
+  | ListItem
+  | SavedList
+  | Highlight
+  | ReadingHistoryEntry
+  | Bookmark
+
+export type LibraryMutationPayload =
+  | CreateListInput
+  | UpdateListInput
+  | CreateListItemInput
+  | UpdateListItemInput
+  | SaveListInput
+  | CreateHighlightInput
+  | UpdateHighlightInput
+  | RecordReadingInput
+  | CreateBookmarkInput
+
+export interface LibraryApiError {
+  error: string
+  details?: unknown
+  status?: number
+}
+
+export interface LibraryPaginatedResponse<T> {
+  items: T[]
+  nextCursor: string | null
+}
+
+export interface LibraryActivityEntry {
+  id: string
+  type: 'bookmark' | 'highlight' | 'list-item' | 'history'
+  title: string
+  subtitle?: string
+  occurredAt: string
+  metadata?: Record<string, string | number | boolean | null | undefined>
+}
+
+export interface LibraryActivityFeedResponse {
+  activity: LibraryActivityEntry[]
+}

--- a/src/lib/library/validation.ts
+++ b/src/lib/library/validation.ts
@@ -1,0 +1,198 @@
+import { z } from 'zod'
+
+const uuidString = () => z.string().uuid()
+
+const optionalUrl = z
+  .string()
+  .url()
+  .max(2000)
+  .optional();
+
+const baseListFields = {
+  title: z.string().min(1).max(200),
+  description: z.string().max(1000).optional().nullable(),
+  slug: z
+    .string()
+    .min(1)
+    .max(200)
+    .regex(/^[a-z0-9-]+$/i, 'Slug may only contain letters, numbers, and hyphens.'),
+  coverImageUrl: optionalUrl.or(z.literal('').transform(() => undefined)),
+} as const;
+
+export const createListSchema = z
+  .object({
+    ...baseListFields,
+    isPublic: z.boolean().default(false),
+  })
+  .strict()
+
+export const updateListSchema = z
+  .object({
+    ...baseListFields,
+    isPublic: z.boolean().optional(),
+  })
+  .partial()
+  .strict()
+  .superRefine((value, ctx) => {
+    const hasUpdates = Object.entries(value).some(([, fieldValue]) => fieldValue !== undefined);
+
+    if (!hasUpdates) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Provide at least one field to update.',
+      });
+    }
+  })
+
+export const listIdentifierSchema = z.object({
+  listId: uuidString(),
+})
+
+export const createListItemSchema = z
+  .object({
+    postId: uuidString(),
+    note: z.string().max(500).optional().nullable(),
+    position: z.number().int().min(0).optional(),
+  })
+  .strict()
+
+export const updateListItemSchema = z
+  .object({
+    note: z.string().max(500).optional().nullable(),
+    position: z.number().int().min(0).optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'Provide at least one field to update.',
+  })
+
+export const listItemIdentifierSchema = z.object({
+  listId: uuidString(),
+  itemId: uuidString(),
+})
+
+export const saveListSchema = z
+  .object({
+    listId: uuidString(),
+  })
+  .strict()
+
+export const savedListIdentifierSchema = z.object({
+  savedListId: uuidString(),
+})
+
+export const createHighlightSchema = z
+  .object({
+    postId: uuidString(),
+    highlightedText: z.string().min(1).max(5000),
+    note: z.string().max(1000).optional().nullable(),
+    color: z
+      .string()
+      .regex(/^#[0-9A-Fa-f]{6}$/)
+      .default('#FFEB3B'),
+    positionStart: z.number().int().min(0),
+    positionEnd: z.number().int().min(1),
+    isPublic: z.boolean().default(false),
+  })
+  .strict()
+  .refine((value) => value.positionEnd > value.positionStart, {
+    message: 'positionEnd must be greater than positionStart.',
+    path: ['positionEnd'],
+  })
+
+export const updateHighlightSchema = createHighlightSchema
+  .partial()
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'Provide at least one field to update.',
+  })
+  .refine(
+    (value) =>
+      !('positionStart' in value) ||
+      !('positionEnd' in value) ||
+      (typeof value.positionStart === 'number' &&
+        typeof value.positionEnd === 'number' &&
+        value.positionEnd > value.positionStart),
+    {
+      message: 'positionEnd must be greater than positionStart.',
+      path: ['positionEnd'],
+    },
+  )
+
+export const highlightIdentifierSchema = z.object({
+  highlightId: uuidString(),
+})
+
+export const recordReadingSchema = z
+  .object({
+    historyId: z.string().uuid().optional(),
+    postId: uuidString(),
+    readDurationSeconds: z.number().int().min(0).optional().nullable(),
+    scrollPercentage: z.number().int().min(0).max(100).optional().nullable(),
+    completed: z.boolean().default(false),
+    lastPosition: z.number().int().min(0).default(0),
+    readAt: z.string().datetime().optional(),
+  })
+  .strict()
+
+export const readingHistoryIdentifierSchema = z.object({
+  historyId: uuidString(),
+})
+
+export const createBookmarkSchema = z
+  .object({
+    postId: uuidString(),
+  })
+  .strict()
+
+export const bookmarkIdentifierSchema = z.object({
+  bookmarkId: uuidString(),
+})
+
+export const statsQuerySchema = z
+  .object({
+    range: z.enum(['7d', '30d', '90d', '365d']).default('30d'),
+  })
+  .strict()
+
+export const paginationQuerySchema = z
+  .object({
+    limit: z
+      .string()
+      .optional()
+      .transform((value) => {
+        if (value === undefined) return 20
+        const parsed = Number.parseInt(value, 10)
+        return parsed
+      })
+      .refine((value) => Number.isInteger(value) && value > 0 && value <= 100, {
+        message: 'limit must be an integer between 1 and 100',
+      }),
+    cursor: z.string().optional(),
+  })
+  .strict()
+
+export type CreateListInput = z.infer<typeof createListSchema>
+export type UpdateListInput = z.infer<typeof updateListSchema>
+export type CreateListItemInput = z.infer<typeof createListItemSchema>
+export type UpdateListItemInput = z.infer<typeof updateListItemSchema>
+export type SaveListInput = z.infer<typeof saveListSchema>
+export type CreateHighlightInput = z.infer<typeof createHighlightSchema>
+export type UpdateHighlightInput = z.infer<typeof updateHighlightSchema>
+export type RecordReadingInput = z.infer<typeof recordReadingSchema>
+export type CreateBookmarkInput = z.infer<typeof createBookmarkSchema>
+
+export const validateWithSchema = async <Schema extends z.ZodTypeAny>(
+  schema: Schema,
+  payload: unknown,
+): Promise<
+  | { success: true; data: z.infer<Schema> }
+  | { success: false; error: z.ZodFlattenedError<z.infer<Schema>, string> }
+> => {
+  const parsed = await schema.safeParseAsync(payload)
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.flatten() }
+  }
+
+  return { success: true, data: parsed.data }
+}

--- a/src/lib/supabase/server-client.ts
+++ b/src/lib/supabase/server-client.ts
@@ -4,6 +4,7 @@ import {
   type CookieMethodsServer,
 } from '@supabase/ssr'
 import { cookies } from 'next/headers'
+import type { Database } from '@/lib/supabase/types'
 
 type ClientOptions = Parameters<typeof createClient>[2]
 
@@ -60,8 +61,8 @@ const createCookieAdapter = (): CookieMethodsServer => {
   }
 }
 
-export const createServerClient = () =>
-  createSupabaseServerClient(supabaseUrl, supabaseAnonKey, {
+export const createServerClient = <DB = Database>() =>
+  createSupabaseServerClient<DB>(supabaseUrl, supabaseAnonKey, {
     cookies: createCookieAdapter(),
   })
 
@@ -75,7 +76,7 @@ const serviceRoleOptions: ClientOptions = {
 export const createServiceRoleClient = () =>
   createClient(supabaseUrl, supabaseServiceKey, serviceRoleOptions)
 
-export const createServerComponentClient = () =>
-  createSupabaseServerClient(supabaseUrl, supabaseAnonKey, {
+export const createServerComponentClient = <DB = Database>() =>
+  createSupabaseServerClient<DB>(supabaseUrl, supabaseAnonKey, {
     cookies: createCookieAdapter(),
   })

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -74,6 +74,138 @@ export interface Database {
         }
         Update: Partial<Database['public']['Tables']['gamification_actions']['Insert']>
       }
+      user_lists: {
+        Row: {
+          id: string
+          profile_id: string
+          title: string
+          description: string | null
+          slug: string
+          is_public: boolean
+          cover_image_url: string | null
+          item_count: number
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          profile_id: string
+          title: string
+          description?: string | null
+          slug: string
+          is_public?: boolean
+          cover_image_url?: string | null
+          item_count?: number
+          created_at?: string
+          updated_at?: string
+        }
+        Update: Partial<Database['public']['Tables']['user_lists']['Insert']>
+      }
+      list_items: {
+        Row: {
+          id: string
+          list_id: string
+          post_id: string
+          note: string | null
+          position: number
+          added_at: string
+        }
+        Insert: {
+          id?: string
+          list_id: string
+          post_id: string
+          note?: string | null
+          position?: number
+          added_at?: string
+        }
+        Update: Partial<Database['public']['Tables']['list_items']['Insert']>
+      }
+      saved_lists: {
+        Row: {
+          id: string
+          profile_id: string
+          list_id: string
+          saved_at: string
+        }
+        Insert: {
+          id?: string
+          profile_id: string
+          list_id: string
+          saved_at?: string
+        }
+        Update: Partial<Database['public']['Tables']['saved_lists']['Insert']>
+      }
+      highlights: {
+        Row: {
+          id: string
+          profile_id: string
+          post_id: string
+          highlighted_text: string
+          note: string | null
+          color: string
+          position_start: number
+          position_end: number
+          is_public: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          profile_id: string
+          post_id: string
+          highlighted_text: string
+          note?: string | null
+          color?: string
+          position_start: number
+          position_end: number
+          is_public?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: Partial<Database['public']['Tables']['highlights']['Insert']>
+      }
+      reading_history: {
+        Row: {
+          id: string
+          profile_id: string
+          post_id: string
+          read_at: string
+          read_duration_seconds: number | null
+          scroll_percentage: number | null
+          completed: boolean
+          last_position: number
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          profile_id: string
+          post_id: string
+          read_at?: string
+          read_duration_seconds?: number | null
+          scroll_percentage?: number | null
+          completed?: boolean
+          last_position?: number
+          created_at?: string
+          updated_at?: string
+        }
+        Update: Partial<Database['public']['Tables']['reading_history']['Insert']>
+      }
+      bookmarks: {
+        Row: {
+          id: string
+          profile_id: string
+          post_id: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          profile_id: string
+          post_id: string
+          created_at?: string
+        }
+        Update: Partial<Database['public']['Tables']['bookmarks']['Insert']>
+      }
       gamification_badges: {
         Row: {
           id: string

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -245,3 +245,94 @@ export interface UserContributionSnapshot {
   comments: UserCommentSummary[]
   totals: UserContributionTotals
 }
+
+export interface UserList {
+  id: string
+  profileId: string
+  title: string
+  description: string | null
+  slug: string
+  isPublic: boolean
+  coverImageUrl: string | null
+  itemCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ListItem {
+  id: string
+  listId: string
+  postId: string
+  postTitle: string
+  postSlug: string
+  postExcerpt: string | null
+  postCoverImage: string | null
+  note: string | null
+  position: number
+  addedAt: string
+}
+
+export interface SavedList {
+  id: string
+  profileId: string
+  listId: string
+  listTitle: string
+  listDescription: string | null
+  listOwnerName: string
+  listItemCount: number
+  savedAt: string
+}
+
+export interface Highlight {
+  id: string
+  profileId: string
+  postId: string
+  postTitle: string
+  postSlug: string
+  highlightedText: string
+  note: string | null
+  color: string
+  positionStart: number
+  positionEnd: number
+  isPublic: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ReadingHistoryEntry {
+  id: string
+  profileId: string
+  postId: string
+  postTitle: string
+  postSlug: string
+  postExcerpt: string | null
+  postCoverImage: string | null
+  readAt: string
+  readDurationSeconds: number | null
+  scrollPercentage: number | null
+  completed: boolean
+  lastPosition: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface Bookmark {
+  id: string
+  profileId: string
+  postId: string
+  postTitle: string
+  postSlug: string
+  postExcerpt: string | null
+  postCoverImage: string | null
+  createdAt: string
+}
+
+export interface LibraryStats {
+  totalBookmarks: number
+  totalLists: number
+  totalListItems: number
+  totalHighlights: number
+  totalReadingHistory: number
+  readingStreak: number
+  totalReadingTime: number
+}

--- a/supabase/migrations/0015_create_user_library_schema.sql
+++ b/supabase/migrations/0015_create_user_library_schema.sql
@@ -1,0 +1,339 @@
+-- =================================================================
+-- LIBRARY FEATURE SCHEMA
+-- =================================================================
+-- This migration creates tables for user library functionality:
+-- - User-created lists
+-- - List items
+-- - Saved lists from other users
+-- - Highlights
+-- - Reading history
+-- - Bookmarks (quick save)
+-- =================================================================
+
+-- Enable required extensions
+create extension if not exists "pgcrypto";
+
+-- =================================================================
+-- 1. USER LISTS TABLE
+-- =================================================================
+create table if not exists public.user_lists (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  title text not null check (char_length(title) >= 1 and char_length(title) <= 200),
+  description text check (char_length(description) <= 1000),
+  slug text not null check (char_length(slug) >= 1 and char_length(slug) <= 200),
+  is_public boolean not null default false,
+  cover_image_url text,
+  item_count integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint user_lists_profile_slug_unique unique(profile_id, slug)
+);
+
+create index user_lists_profile_id_idx on public.user_lists(profile_id);
+create index user_lists_is_public_idx on public.user_lists(is_public) where is_public = true;
+create index user_lists_created_at_idx on public.user_lists(created_at desc);
+
+comment on table public.user_lists is 'User-created lists for organizing saved posts';
+comment on column public.user_lists.item_count is 'Cached count of items in list, updated via trigger';
+
+-- =================================================================
+-- 2. LIST ITEMS TABLE
+-- =================================================================
+create table if not exists public.list_items (
+  id uuid primary key default gen_random_uuid(),
+  list_id uuid not null references public.user_lists(id) on delete cascade,
+  post_id uuid not null references public.posts(id) on delete cascade,
+  note text check (char_length(note) <= 500),
+  position integer not null default 0,
+  added_at timestamptz not null default now(),
+  constraint list_items_unique unique(list_id, post_id)
+);
+
+create index list_items_list_id_idx on public.list_items(list_id);
+create index list_items_post_id_idx on public.list_items(post_id);
+create index list_items_position_idx on public.list_items(list_id, position);
+
+comment on table public.list_items is 'Posts saved to user lists';
+comment on column public.list_items.position is 'Order of item in list, 0-indexed';
+
+-- =================================================================
+-- 3. SAVED LISTS TABLE
+-- =================================================================
+create table if not exists public.saved_lists (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  list_id uuid not null references public.user_lists(id) on delete cascade,
+  saved_at timestamptz not null default now(),
+  constraint saved_lists_unique unique(profile_id, list_id)
+);
+
+create index saved_lists_profile_id_idx on public.saved_lists(profile_id);
+create index saved_lists_list_id_idx on public.saved_lists(list_id);
+
+comment on table public.saved_lists is 'Lists saved by users from other users';
+
+-- =================================================================
+-- 4. HIGHLIGHTS TABLE
+-- =================================================================
+create table if not exists public.highlights (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  post_id uuid not null references public.posts(id) on delete cascade,
+  highlighted_text text not null check (char_length(highlighted_text) >= 1 and char_length(highlighted_text) <= 5000),
+  note text check (char_length(note) <= 1000),
+  color text not null default '#FFEB3B' check (color ~ '^#[0-9A-Fa-f]{6}$'),
+  position_start integer not null check (position_start >= 0),
+  position_end integer not null check (position_end > position_start),
+  is_public boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint highlights_position_check check (position_end > position_start)
+);
+
+create index highlights_profile_id_idx on public.highlights(profile_id);
+create index highlights_post_id_idx on public.highlights(post_id);
+create index highlights_profile_post_idx on public.highlights(profile_id, post_id);
+create index highlights_created_at_idx on public.highlights(created_at desc);
+
+comment on table public.highlights is 'Text highlights made by users while reading posts';
+comment on column public.highlights.color is 'Hex color code for highlight';
+comment on column public.highlights.position_start is 'Character position where highlight starts';
+comment on column public.highlights.position_end is 'Character position where highlight ends';
+
+-- =================================================================
+-- 5. READING HISTORY TABLE
+-- =================================================================
+create table if not exists public.reading_history (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  post_id uuid not null references public.posts(id) on delete cascade,
+  read_at timestamptz not null default now(),
+  read_duration_seconds integer check (read_duration_seconds >= 0),
+  scroll_percentage integer check (scroll_percentage >= 0 and scroll_percentage <= 100),
+  completed boolean not null default false,
+  last_position integer default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index reading_history_profile_id_idx on public.reading_history(profile_id);
+create index reading_history_post_id_idx on public.reading_history(post_id);
+create index reading_history_profile_post_idx on public.reading_history(profile_id, post_id);
+create index reading_history_read_at_idx on public.reading_history(read_at desc);
+create index reading_history_completed_idx on public.reading_history(profile_id, completed);
+
+comment on table public.reading_history is 'User reading activity tracking';
+comment on column public.reading_history.read_duration_seconds is 'Time spent reading in seconds';
+comment on column public.reading_history.scroll_percentage is 'How far user scrolled (0-100)';
+comment on column public.reading_history.completed is 'Whether user finished reading';
+comment on column public.reading_history.last_position is 'Last scroll position for resume reading';
+
+-- =================================================================
+-- 6. BOOKMARKS TABLE
+-- =================================================================
+create table if not exists public.bookmarks (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  post_id uuid not null references public.posts(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  constraint bookmarks_unique unique(profile_id, post_id)
+);
+
+create index bookmarks_profile_id_idx on public.bookmarks(profile_id);
+create index bookmarks_post_id_idx on public.bookmarks(post_id);
+create index bookmarks_created_at_idx on public.bookmarks(created_at desc);
+
+comment on table public.bookmarks is 'Quick save bookmarks for posts';
+
+-- =================================================================
+-- 7. TRIGGERS AND FUNCTIONS
+-- =================================================================
+
+-- Update updated_at timestamp
+create or replace function public.update_library_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger user_lists_updated_at
+  before update on public.user_lists
+  for each row execute function public.update_library_updated_at();
+
+create trigger highlights_updated_at
+  before update on public.highlights
+  for each row execute function public.update_library_updated_at();
+
+create trigger reading_history_updated_at
+  before update on public.reading_history
+  for each row execute function public.update_library_updated_at();
+
+-- Update list item count
+create or replace function public.update_list_item_count()
+returns trigger
+language plpgsql
+as $$
+begin
+  if (TG_OP = 'INSERT') then
+    update public.user_lists
+    set item_count = item_count + 1
+    where id = new.list_id;
+    return new;
+  elsif (TG_OP = 'DELETE') then
+    update public.user_lists
+    set item_count = item_count - 1
+    where id = old.list_id;
+    return old;
+  end if;
+  return null;
+end;
+$$;
+
+create trigger list_items_count_trigger
+  after insert or delete on public.list_items
+  for each row execute function public.update_list_item_count();
+
+-- =================================================================
+-- 8. ROW LEVEL SECURITY (RLS) POLICIES
+-- =================================================================
+
+-- Enable RLS on all tables
+alter table public.user_lists enable row level security;
+alter table public.list_items enable row level security;
+alter table public.saved_lists enable row level security;
+alter table public.highlights enable row level security;
+alter table public.reading_history enable row level security;
+alter table public.bookmarks enable row level security;
+
+-- USER LISTS POLICIES
+create policy "Users can view their own lists"
+  on public.user_lists for select
+  using (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+create policy "Users can view public lists"
+  on public.user_lists for select
+  using (is_public = true);
+
+create policy "Users can create their own lists"
+  on public.user_lists for insert
+  with check (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+create policy "Users can update their own lists"
+  on public.user_lists for update
+  using (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+create policy "Users can delete their own lists"
+  on public.user_lists for delete
+  using (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+-- LIST ITEMS POLICIES
+create policy "Users can view items in their lists or public lists"
+  on public.list_items for select
+  using (
+    exists (
+      select 1 from public.user_lists
+      where id = list_items.list_id
+      and (
+        profile_id = (select id from public.profiles where user_id = auth.uid())
+        or is_public = true
+      )
+    )
+  );
+
+create policy "Users can add items to their own lists"
+  on public.list_items for insert
+  with check (
+    exists (
+      select 1 from public.user_lists
+      where id = list_items.list_id
+      and profile_id = (select id from public.profiles where user_id = auth.uid())
+    )
+  );
+
+create policy "Users can update items in their own lists"
+  on public.list_items for update
+  using (
+    exists (
+      select 1 from public.user_lists
+      where id = list_items.list_id
+      and profile_id = (select id from public.profiles where user_id = auth.uid())
+    )
+  );
+
+create policy "Users can delete items from their own lists"
+  on public.list_items for delete
+  using (
+    exists (
+      select 1 from public.user_lists
+      where id = list_items.list_id
+      and profile_id = (select id from public.profiles where user_id = auth.uid())
+    )
+  );
+
+-- SAVED LISTS POLICIES
+create policy "Users can view their saved lists"
+  on public.saved_lists for select
+  using (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+create policy "Users can save public lists"
+  on public.saved_lists for insert
+  with check (
+    profile_id = (select id from public.profiles where user_id = auth.uid())
+    and exists (select 1 from public.user_lists where id = saved_lists.list_id and is_public = true)
+  );
+
+create policy "Users can unsave their saved lists"
+  on public.saved_lists for delete
+  using (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+-- HIGHLIGHTS POLICIES (strictly private)
+create policy "Users can view their own highlights"
+  on public.highlights for select
+  using (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+create policy "Users can create highlights"
+  on public.highlights for insert
+  with check (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+create policy "Users can update their own highlights"
+  on public.highlights for update
+  using (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+create policy "Users can delete their own highlights"
+  on public.highlights for delete
+  using (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+-- READING HISTORY POLICIES (strictly private)
+create policy "Users can view their own reading history"
+  on public.reading_history for select
+  using (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+create policy "Users can record reading activity"
+  on public.reading_history for insert
+  with check (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+create policy "Users can update their reading history"
+  on public.reading_history for update
+  using (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+create policy "Users can delete their reading history"
+  on public.reading_history for delete
+  using (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+-- BOOKMARKS POLICIES (strictly private)
+create policy "Users can view their own bookmarks"
+  on public.bookmarks for select
+  using (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+create policy "Users can create bookmarks"
+  on public.bookmarks for insert
+  with check (profile_id = (select id from public.profiles where user_id = auth.uid()));
+
+create policy "Users can delete their own bookmarks"
+  on public.bookmarks for delete
+  using (profile_id = (select id from public.profiles where user_id = auth.uid()));

--- a/tests/unit/library-reading-utils.test.ts
+++ b/tests/unit/library-reading-utils.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildReadingHistoryPayload,
+  computeScrollProgress,
+  isReadingComplete,
+  shouldPersistReadingHistory,
+} from '@/lib/library/reading-utils';
+
+describe('library reading utils', () => {
+  it('computes scroll progress with bounds handling', () => {
+    expect(computeScrollProgress(0, 1000, 500)).toBe(0);
+    expect(computeScrollProgress(250, 1000, 500)).toBe(50);
+    expect(computeScrollProgress(99999, 1000, 500)).toBe(100);
+    expect(computeScrollProgress(-10, 1000, 500)).toBe(0);
+  });
+
+  it('determines completion with configurable threshold', () => {
+    expect(isReadingComplete(94)).toBe(false);
+    expect(isReadingComplete(95)).toBe(true);
+    expect(isReadingComplete(80, 75)).toBe(true);
+  });
+
+  it('decides when to persist reading history for new and existing entries', () => {
+    expect(
+      shouldPersistReadingHistory(
+        { readDurationSeconds: 4, scrollPercentage: 10, lastPosition: 0 },
+        false,
+      ),
+    ).toBe(false);
+    expect(
+      shouldPersistReadingHistory(
+        { readDurationSeconds: 12, scrollPercentage: 10, lastPosition: 0 },
+        false,
+      ),
+    ).toBe(true);
+    expect(
+      shouldPersistReadingHistory(
+        { readDurationSeconds: 3, scrollPercentage: 8, lastPosition: 0 },
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it('builds sanitized reading history payloads', () => {
+    const payload = buildReadingHistoryPayload({
+      historyId: null,
+      postId: 'post-id',
+      readDurationSeconds: 12.8,
+      scrollPercentage: 103.4,
+      lastPosition: -12,
+      completionThreshold: 90,
+    });
+
+    expect(payload.historyId).toBeUndefined();
+    expect(payload.postId).toBe('post-id');
+    expect(payload.readDurationSeconds).toBe(13);
+    expect(payload.scrollPercentage).toBe(100);
+    expect(payload.lastPosition).toBe(0);
+    expect(payload.completed).toBe(true);
+  });
+});

--- a/tests/unit/library-validation.test.ts
+++ b/tests/unit/library-validation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bookmarkIdentifierSchema,
+  createBookmarkSchema,
+  createHighlightSchema,
+  createListSchema,
+  recordReadingSchema,
+  updateListSchema,
+} from '@/lib/library/validation';
+
+describe('library validation schemas', () => {
+  it('validates list creation payloads', () => {
+    const payload = createListSchema.parse({
+      title: 'My List',
+      description: 'Curated reads',
+      slug: 'my-list',
+      isPublic: true,
+      coverImageUrl: 'https://example.com/cover.png',
+    });
+
+    expect(payload.slug).toBe('my-list');
+    expect(() =>
+      createListSchema.parse({
+        title: '',
+        slug: 'invalid slug',
+      }),
+    ).toThrow();
+  });
+
+  it('requires at least one field when updating lists', () => {
+    expect(updateListSchema.safeParse({}).success).toBe(false);
+    expect(updateListSchema.parse({ title: 'Updated' }).title).toBe('Updated');
+  });
+
+  it('ensures highlight ranges are valid', () => {
+    const highlight = createHighlightSchema.parse({
+      postId: '67a1e997-5a74-492d-9f1b-641ed0524a27',
+      highlightedText: 'Inspiring quote',
+      positionStart: 10,
+      positionEnd: 30,
+      color: '#FF69B4',
+    });
+
+    expect(highlight.color).toBe('#FF69B4');
+    expect(() =>
+      createHighlightSchema.parse({
+        postId: '67a1e997-5a74-492d-9f1b-641ed0524a27',
+        highlightedText: 'Oops',
+        positionStart: 40,
+        positionEnd: 20,
+      }),
+    ).toThrow();
+  });
+
+  it('sanitizes reading history defaults', () => {
+    const reading = recordReadingSchema.parse({
+      postId: '67a1e997-5a74-492d-9f1b-641ed0524a27',
+    });
+
+    expect(reading.completed).toBe(false);
+    expect(reading.lastPosition).toBe(0);
+  });
+
+  it('rejects invalid bookmark identifiers', () => {
+    expect(() => bookmarkIdentifierSchema.parse({ bookmarkId: '123' })).toThrow();
+    const bookmark = createBookmarkSchema.parse({
+      postId: '67a1e997-5a74-492d-9f1b-641ed0524a27',
+    });
+    expect(bookmark.postId).toMatch(/^[0-9a-f-]+$/i);
+  });
+});


### PR DESCRIPTION
## Summary
- gate the /me overview behind Supabase auth and hydrate it with library stats
- expose Database generics on the Supabase server helpers for typed queries
- extend shared supabase and utility types with the new library tables and mappers

## Testing
- npm run test:unit
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e797475bd8832db2c7d9283d8f55a2