### PR TITLE
docs: add community volunteer roadmap

### DIFF
--- a/docs/community-volunteer-roadmap.md
+++ b/docs/community-volunteer-roadmap.md
@@ -1,0 +1,164 @@
+# Community Volunteer & Content Creator Roadmap
+
+## Vision
+Establish a vibrant Syntax & Sips community program that attracts, supports, and retains volunteer contributors who grow the platform's reach and content catalog while reinforcing the brand voice.
+
+## Program Objectives
+- Launch a public call for volunteer and internship collaborators focused on content, social storytelling, developer advocacy, and community support.
+- Build a repeatable pipeline for recruiting, onboarding, mentoring, and retaining contributors.
+- Gather continuous feedback through a Google Form to refine offerings, understand community needs, and surface potential leaders.
+
+## Timeline Overview
+| Phase | Duration | Goals |
+| --- | --- | --- |
+| **Preparation** | Weeks 1-2 | Finalize role descriptions, design Google Form application, prepare onboarding materials, establish editorial calendar template. |
+| **Recruitment** | Weeks 3-6 | Promote volunteer openings, collect applications, conduct screening interviews, run kickoff orientation. |
+| **Activation** | Weeks 7-12 | Pair volunteers with mentors, publish first wave of content campaigns, launch feedback loop, gather analytics on reach. |
+| **Sustain & Scale** | Ongoing | Track performance metrics, highlight top contributors, expand program to new roles (podcasts, events), iterate on processes. |
+
+## Core Volunteer & Internship Roles
+
+### 1. Social Media Storyteller
+- **Mission:** Grow awareness by turning product updates, blog posts, and community highlights into compelling short-form narratives.
+- **Key Responsibilities:**
+  - Draft platform-specific content for Instagram, X/Twitter, LinkedIn, and TikTok.
+  - Coordinate weekly content drops aligned with the editorial calendar.
+  - Collaborate with designers for visuals and motion assets.
+  - Monitor platform analytics, engage with community replies, report weekly insights.
+- **Requirements:**
+  - Demonstrated experience creating social content (portfolio or handles required).
+  - Understanding of brand tone, storytelling, and platform best practices.
+  - Ability to commit 4-6 hours/week and respond within 24 hours on collaboration tools.
+- **Success Metrics:** Audience growth, engagement rate, and click-through conversions to Syntax & Sips.
+
+### 2. Blog & Documentation Writer
+- **Mission:** Expand the knowledge base with tutorials, product updates, and thought leadership pieces.
+- **Key Responsibilities:**
+  - Pitch topics aligned with roadmap, SEO strategy, and community questions.
+  - Draft long-form articles in Markdown, incorporating visuals and code samples.
+  - Collaborate with editors for revisions; publish via CMS workflows.
+  - Update docs for features, ensuring Supabase and Next.js guides stay current.
+- **Requirements:**
+  - Excellent written communication; prior tech writing or blogging experience.
+  - Familiarity with Next.js, Supabase, or modern web tooling.
+  - Ability to synthesize feedback quickly and meet bi-weekly deadlines.
+- **Success Metrics:** Published articles per month, organic traffic uplift, reader feedback scores.
+
+### 3. Technical Tutorial Creator (Video/Streaming)
+- **Mission:** Produce educational videos or livestreams that showcase Syntax & Sips features, integrations, and best practices.
+- **Key Responsibilities:**
+  - Script tutorials, record high-quality video/audio, and edit for clarity.
+  - Host monthly livestreams with Q&A, featuring community projects or product demos.
+  - Coordinate with marketing for promotional snippets and cross-posting.
+- **Requirements:**
+  - Comfortable on camera with clear presentation skills.
+  - Experience using screen capture and editing tools (OBS, Final Cut, DaVinci, etc.).
+  - Basic understanding of the platform’s stack to explain workflows accurately.
+- **Success Metrics:** View count, watch time, live attendance, and post-event survey ratings.
+
+### 4. Community Moderator & Discord Host
+- **Mission:** Maintain a safe, welcoming community space across Discord, forums, and events.
+- **Key Responsibilities:**
+  - Welcome newcomers, answer FAQs, escalate product issues, and enforce guidelines.
+  - Organize weekly themed discussions or office hours with core team members.
+  - Document recurring questions to feed into knowledge base updates.
+  - Track sentiment and surface product feedback to the core team.
+- **Requirements:**
+  - Prior moderation or community leadership experience.
+  - Strong empathy, conflict resolution, and communication skills.
+  - Availability to check channels daily and host at least two live sessions per month.
+- **Success Metrics:** Community satisfaction (survey results), retention of active members, reduced response time for questions.
+
+### 5. Developer Advocate Intern
+- **Mission:** Showcase integrations, build sample apps, and champion developer experience improvements.
+- **Key Responsibilities:**
+  - Create demo repositories, starter kits, and code walkthroughs.
+  - Run mini-hackathons or code challenges highlighting Syntax & Sips APIs.
+  - Collect developer pain points and collaborate with product/engineering for fixes.
+  - Present monthly demos to the community and document release notes.
+- **Requirements:**
+  - Intermediate experience with TypeScript, Next.js, and database-backed apps.
+  - Public speaking or workshop facilitation skills.
+  - Commitment of 8-10 hours/week for at least three months.
+- **Success Metrics:** Number of sample projects shipped, workshop attendance, adoption of featured integrations.
+
+### 6. Design & Branding Collaborator
+- **Mission:** Elevate the neobrutalist aesthetic across marketing collateral, social templates, and in-product visuals.
+- **Key Responsibilities:**
+  - Design reusable social graphics, blog headers, and event assets.
+  - Partner with storytellers to ensure consistent branding across channels.
+  - Maintain component libraries (Figma) aligned with product UI.
+  - Conduct design feedback sessions with contributors to uphold brand quality.
+- **Requirements:**
+  - Strong portfolio demonstrating bold visual design and systems thinking.
+  - Familiarity with Figma, Adobe CC, or similar tools.
+  - Ability to iterate quickly based on feedback and accessibility guidelines.
+- **Success Metrics:** Asset adoption rate, brand consistency scores, community feedback on visuals.
+
+### 7. Partnership & Outreach Coordinator
+- **Mission:** Forge collaborations with influencers, tech communities, and educational partners to broaden reach.
+- **Key Responsibilities:**
+  - Identify potential partners, draft outreach sequences, and manage responses.
+  - Coordinate joint events, guest blog posts, or cross-promotions.
+  - Maintain CRM of partner status, deliverables, and results.
+  - Share monthly recap of partnership impact and recommendations.
+- **Requirements:**
+  - Experience in community outreach, marketing, or business development.
+  - Excellent interpersonal and negotiation skills.
+  - Organized with ability to manage multiple partner timelines simultaneously.
+- **Success Metrics:** Number of partnerships formed, referral traffic, co-created content volume.
+
+### 8. Feedback & Research Analyst
+- **Mission:** Gather, analyze, and synthesize community insights to guide product and content decisions.
+- **Key Responsibilities:**
+  - Own the Google Form pipeline: monitor submissions, tag themes, and summarize key takeaways.
+  - Conduct quarterly community surveys and occasional interviews.
+  - Build dashboards for sentiment, feature requests, and satisfaction metrics.
+  - Present findings during team retros and document action items.
+- **Requirements:**
+  - Analytical skills with experience in survey design and data visualization.
+  - Familiarity with tools like Airtable, Notion, or Google Data Studio.
+  - Comfortable translating qualitative feedback into actionable recommendations.
+- **Success Metrics:** Response rates, stakeholder adoption of insights, turnaround time for reporting.
+
+## Application & Google Form Workflow
+1. Draft a Google Form capturing:
+   - Basic details (name, pronouns, location, time zone).
+   - Role(s) of interest and availability.
+   - Portfolio links (social handles, blog posts, GitHub, design portfolios).
+   - Short responses: "Why Syntax & Sips?", "How can you support the community?", "Share a memorable community experience."
+   - Optional demographic and accessibility needs to ensure inclusive support.
+2. Embed or link the form in the Careers/Community page with a CTA button (e.g., "Apply to be a Community Contributor").
+3. Configure automatic email confirmation that includes next steps, timeline, and community code of conduct.
+4. Route responses to a shared spreadsheet or Airtable for triaging and tagging.
+5. Schedule bi-weekly review meetings to evaluate applicants and send status updates.
+
+## Onboarding & Enablement Plan
+- **Orientation Session:** Host a live kickoff covering mission, values, brand tone, tooling (Notion, Slack, Supabase access), and communication expectations.
+- **Role Playbooks:** Provide templates (e.g., social calendar, blog outlines, moderation scripts) and brand assets in a shared drive.
+- **Mentorship:** Pair each volunteer with a core team buddy; hold weekly standups to unblock work and celebrate wins.
+- **Tooling Access:** Set up necessary accounts (Figma, CMS, analytics dashboards) with clear usage guidelines.
+- **Learning Path:** Offer optional workshops on storytelling, SEO, video production, or Supabase integration, recorded for asynchronous access.
+
+## Feedback & Retention Loops
+- Collect quick pulse surveys after the first month and every quarter to gauge satisfaction and improvement areas.
+- Highlight standout contributors on the website, newsletters, and social channels to recognize impact.
+- Provide badges or XP boosts within Syntax & Sips to gamify participation and encourage consistency.
+- Host monthly community town halls to share roadmap updates, celebrate milestones, and gather live feedback.
+- Document lessons learned and adjust role descriptions, onboarding, and tooling accordingly.
+
+## Promotion Channels
+- Publish volunteer call-to-action on the blog, Careers page, and community hub.
+- Announce across social platforms, relevant Discord/Slack communities, Reddit, and partner newsletters.
+- Encourage existing members to refer peers with a referral recognition program.
+- Collaborate with Supabase, Next.js, and design communities to co-promote opportunities.
+
+## Success Metrics Dashboard
+Track the following indicators monthly:
+- Number of applications per role and conversion rate to active contributors.
+- Content production volume (posts, videos, events) versus targets.
+- Audience growth across channels and engagement benchmarks.
+- Community satisfaction (CSAT), Net Promoter Score (NPS), and qualitative sentiment.
+- Contributor retention (active volunteers after 3 and 6 months).
+
+By following this roadmap, Syntax & Sips can cultivate an engaged contributor base, deliver consistent content, and build a thriving community around the product launch.


### PR DESCRIPTION
## Summary
- add a community volunteer and content creator roadmap document
- document role descriptions, application workflow, and program success metrics

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e807e646bc832d96c47b1d7106ea10