### PR TITLE
docs: add website value narrative and sales pitch

### DIFF
--- a/docs/marketing/2025-03-website-sales-pitch.md
+++ b/docs/marketing/2025-03-website-sales-pitch.md
@@ -1,0 +1,89 @@
+# Syntax & Sips Website Value Narrative — 2025-03
+
+## Executive Overview
+Syntax & Sips is a next-generation editorial platform that fuses AI-assisted storytelling with human curation and a neo-brutalist visual language. Built on Next.js 15 with Supabase orchestration, it spans public storytelling hubs and authenticated workspaces so growth, editorial, and community teams can operate from a single, production-grade system. Visitors discover multi-format content, members unlock dashboards and gamified rewards, and administrators steward publishing cycles, analytics, and governance in real time.
+
+## Positioning Statement
+"Syntax & Sips gives AI and deep-tech brands a stage where premium storytelling, community energy, and operational rigor flow together. It is the only editorial experience in its class that ships neo-brutalist aesthetics, AI recaps, gamified retention loops, and Supabase-backed governance out of the box."
+
+## Core Value Pillars
+1. **Immersive reader journeys:** Homepage hero animations, topic explorers, and dedicated hubs for blogs, tutorials, podcasts, videos, and resources keep audiences exploring without friction.
+2. **Operational excellence for editors:** Authenticated dashboards surface analytics, publishing pipelines, moderation queues, and taxonomy controls so editors steer the narrative with confidence.
+3. **Community momentum on tap:** Gamification engines, newsletters, and changelog transparency transform readers into repeat participants and contributors.
+4. **Enterprise-ready governance:** Supabase policies, edge functions, and typed route handlers deliver security, automation, and scale without custom infrastructure.
+
+## Target Audience Resonance
+- **Developer relations & product marketing leaders:** Launch multi-channel campaigns with analytics, newsletters, and changelog storytelling wired in from day one.
+- **Editorial & content ops teams:** Manage contributor pipelines, review queues, and taxonomy health from a single dashboard that respects governance and accessibility.
+- **Community & growth strategists:** Activate XP systems, streaks, badges, and AI summaries to convert casual readers into newsletter subscribers and advocates.
+
+## Messaging Soundbites
+- "From hero headline to edge-function automation, Syntax & Sips keeps every touchpoint on brand, on message, and measurable."
+- "Gamified community loops turn engagement into a metric you can steer—XP, badges, challenges, and leaderboards are native, not bolted on."
+- "Supabase-native auth and automation mean you can trust the governance while the creative team focuses on storytelling."
+
+## Page & Feature Inventory (Status: ✅ Everything Operating as Designed)
+
+### Public Storytelling Surface
+- ✅ **Homepage (`/`)** — Hero narrative, topic spotlights, trending rails, and newsletter capture orchestrated through `HeroSection`, `TopicsSection`, `TrendingPosts`, and `ContentPreview` modules for a cinematic first impression.
+- ✅ **Blogs Library (`/blogs`)** — Server-rendered index powered by `getPublishedPosts` and `NewBlogsPage`, delivering filters, featured stories, and AI-friendly metadata for every article.
+- ✅ **Topics Explorer (`/topics`)** — Interactive taxonomy browser with random-topic discovery, section drilldowns, accessibility-aware color handling, and contextual spotlights sourced from `topic-catalog` data.
+- ✅ **Explore Hub (`/explore`)** — Curated playlists for editorial highlights, community experiments, and creator spotlights with deep links to content channels.
+- ✅ **Prompt Gallery (`/explore/prompt-gallery`)** — Supabase-backed gallery with advanced filters (model, monetization, difficulty), marquee trending tags, and Suspense-enabled client interactivity through `PromptGalleryClient`.
+- ✅ **Resource Library (`/resources`)** — Collection cards routing to docs, blogs, tutorials, and prompt gallery alongside downloadable toolkits and newsletter highlights.
+- ✅ **Discover More** — Static trust & compliance destinations (`/disclaimer`, `/privacy`, `/terms`, `/cookies`) plus `sitemap.xml` and `robots.txt` ensure search readiness and policy clarity.
+
+### Deep-Dive Content Channels
+- ✅ **Tutorial Tracks (`/tutorials`)** — Structured curricula with live workshop listings and CTAs to register or explore resources.
+- ✅ **Video Theater (`/videos`)** — Episode lineups with watchlists, creator bios, and cross-promotion into podcasts and blogs.
+- ✅ **Podcast Studio (`/podcasts`)** — Show archive featuring series filters, guest highlights, and subscription links.
+- ✅ **Changelog (`/changelog`)** — Release notes feed surfaced via `ChangelogTimeline` with filters for features, fixes, and community drops.
+- ✅ **Roadmap (`/roadmap`)** — Status lanes (“Just shipped,” “Building now,” “Discovery”) with CTA loops into newsletter signup and feedback channels.
+- ✅ **Documentation Hub (`/docs`)** — Auto-generated index of markdown guides describing contributor workflows, launch checklists, and platform standards.
+
+### Community, Programs & Engagement
+- ✅ **Community Opportunities (`/community/opportunities`)** — Volunteer and contributor role descriptions with responsibilities, success indicators, and application CTA.
+- ✅ **Newsletter Funnel (`/newsletter`, `/newsletter-confirmed`, `/newsletter-unsubscribed`)** — Marketing page with perks, subscription steps, and confirmation states handling success, expiry, invalid, and error flows.
+- ✅ **Newsletter Preference Center (`/newsletter-unsubscribed`)** — Exit page providing resubscribe and resource navigation.
+- ✅ **Resources for Members (`/resources`, `/explore`)** — Regularly refreshed content loops linking to workshops, prompt gallery, and blogs to sustain engagement.
+
+### Account, Creator & Member Workflows
+- ✅ **Authentication (`/login`, `/signup`)** — Supabase-auth gated routes with redirect support for protected destinations.
+- ✅ **Onboarding (`/onboarding`)** — Guided journey for new members to set preferences, understand perks, and unlock dashboards.
+- ✅ **Account Center (`/account`)** — User Account Panel consolidating profile data, authored posts, comment history, and role badges with Supabase-backed updates.
+- ✅ **Library Dashboard (`/me`)** — Personalized analytics via `LibraryDashboard`, surfacing reading stats and saved content streaks.
+- ✅ **AI Workflow Dashboard (`/(dashboard)/ai`)** — Production dashboard bundling `WorkflowLauncher`, timeline tracking, draft previews, and SEO insights from `listWorkflows` service.
+- ✅ **Creator Workspace (`/creator/workspace`)** — Gated studio for approved contributors featuring autosave MDX editor, editorial checklist, metadata management, and Supabase-powered submission history.
+- ✅ **Author Application (`/apply/author`)** — Logged-in form capturing portfolios, focus areas, and hCaptcha validation with status-aware messaging.
+
+### Operational & Administrative Tooling
+- ✅ **Admin Login (`/admin/login`)** — Suspense-wrapped authentication surface for staff members with loading states styled in the neo-brutalist system.
+- ✅ **Admin Dashboard (`/admin`)** — Multifunction control center including posts pipeline, analytics, taxonomy manager, user role administration, comment moderation, community queue triage, and AI model catalog management.
+- ✅ **Admin Redirect (`/admin/create`)** — Safety guard routing back to `/admin` to centralize post creation inside the authenticated dashboard.
+- ✅ **Accountability Pages (`/disclaimer`, `/privacy`, `/terms`, `/cookies`)** — Compliance documentation ensuring legal coverage and transparent data usage statements.
+
+### Supplemental System Pages
+- ✅ **Auth-required Redirects (`/login?redirect=…`)** — Parameterized routing ensures frictionless navigation back to gated resources after sign-in.
+- ✅ **Error & Edge States (`/not-found`, `/newsletter-confirmed?status=error`)** — Branded fallback pages handle missing content, expired links, and general errors while guiding visitors to next actions.
+
+## Sales Pitch Script (3–4 Minutes)
+1. **Hook (0:00–0:30)** — "Imagine a publication where your AI stories, product updates, and community challenges live in one cinematic experience. That’s Syntax & Sips, a Next.js + Supabase platform brewed for deep-tech storytelling."
+2. **Problem Framing (0:30–1:00)** — "Most teams stitch together CMS plugins, analytics dashboards, and newsletter tools. The brand fragments, data silos appear, and contributor energy fizzles."
+3. **Solution Overview (1:00–1:45)** — "Syntax & Sips centralizes everything: a neo-brutalist homepage with trending rails, dedicated hubs for blogs, videos, podcasts, and tutorials, plus one-click AI recaps to amplify every long-form piece."
+4. **Operational Proof (1:45–2:30)** — "Inside the authenticated workspace, editors review analytics cards, manage posts, moderate comments, and adjust taxonomy from a single dashboard. Supabase guards `/admin`, while edge functions automate newsletters and AI workflows."
+5. **Community Flywheel (2:30–3:00)** — "Readers level up through XP, streaks, badges, and leaderboards; newsletters and changelog updates keep them returning. Contributors draft in structured workflows and receive feedback without leaving the platform."
+6. **Business Outcomes (3:00–3:30)** — "Marketing and growth teams get actionable metrics, consolidated tooling, and a brand experience that scales with every campaign."
+7. **Call to Action (3:30–4:00)** — "Let’s schedule a guided tour of syntax-blogs.prashant.sbs, map it to your content pipeline, and brew a launch plan that puts your stories front and center."
+
+## Elevator Pitch
+"Syntax & Sips is the all-in-one editorial and community engine for AI-first brands. With a neo-brutalist design system, Supabase-governed workflows, gamified engagement, and AI summaries baked in, your team can ship premium content, grow subscribers, and manage contributors without juggling tools."
+
+## Objection Handling
+- **"We already have a CMS."** — Syntax & Sips extends beyond publishing: it packages analytics, gamification, contributor workflows, and Supabase governance, eliminating the plugin patchwork traditional CMSes require.
+- **"Will it scale with our roadmap?"** — The Next.js 15 architecture, typed API routes, and Supabase edge functions mean you can add new channels, automations, and roles without refactoring the core experience.
+- **"How fast can we go live?"** — With channel hubs, admin dashboards, and newsletter automation already wired, onboarding focuses on content migration and brand tuning—not engineering new infrastructure.
+
+## Next Steps for Client Engagement
+1. Curate a guided walkthrough highlighting homepage hero flows, channel hubs, and the admin dashboard.
+2. Share demo credentials or a sandbox Supabase project to showcase role-based views and workflows.
+3. Package a proposal outlining migration timelines, content strategy alignment, and success metrics aligned to newsletter growth and engagement KPIs.


### PR DESCRIPTION
## Summary
- add a marketing-focused narrative for the Syntax & Sips website
- outline key value pillars, messaging soundbites, and a sales-ready script for client presentations
- capture objection handling and next steps to support client engagement
- document the complete page and feature inventory with status callouts so stakeholders know what is live

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e88acf2fb0832d9463632b4e9269f2