### PR TITLE
fix: allow content sections to forward html props

### DIFF
--- a/src/components/ui/ContentPageLayout.tsx
+++ b/src/components/ui/ContentPageLayout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 import { NewFooter } from './NewFooter';
 
 interface ContentPageLayoutProps {
@@ -44,7 +44,7 @@ export function ContentPageLayout({
   );
 }
 
-interface ContentSectionProps {
+type ContentSectionProps = Omit<ComponentPropsWithoutRef<'section'>, 'children' | 'className'> & {
   title: string;
   description?: string;
   eyebrow?: ReactNode;
@@ -52,7 +52,7 @@ interface ContentSectionProps {
   children: ReactNode;
   className?: string;
   fullWidth?: boolean;
-}
+};
 
 export function ContentSection({
   title,
@@ -62,6 +62,7 @@ export function ContentSection({
   children,
   className,
   fullWidth = false,
+  ...sectionProps
 }: ContentSectionProps) {
   const containerClassName = `neo-container bg-white ${className ?? ''}`.trim();
   const layoutClassName = fullWidth
@@ -69,7 +70,7 @@ export function ContentSection({
     : 'flex flex-col lg:flex-row lg:items-start gap-8';
 
   return (
-    <section className={containerClassName}>
+    <section {...sectionProps} className={containerClassName}>
       {eyebrow && (
         <div className="mb-4 inline-flex items-center gap-2 bg-[#06D6A0] border-4 border-black px-3 py-1 text-xs font-bold uppercase tracking-widest text-black shadow-[4px_4px_0_0_#000]">
           {eyebrow}

--- a/src/components/ui/PageLayout.tsx
+++ b/src/components/ui/PageLayout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { NewFooter } from './NewFooter';
@@ -64,7 +64,7 @@ export function PageHero({
   );
 }
 
-interface ContentSectionProps {
+type ContentSectionProps = Omit<ComponentPropsWithoutRef<'section'>, 'children'> & {
   eyebrow?: string;
   title: string;
   description?: string;
@@ -72,7 +72,7 @@ interface ContentSectionProps {
   align?: 'left' | 'center';
   tone?: 'neutral' | 'lavender' | 'peach';
   footerContent?: ReactNode;
-}
+};
 
 const toneStyles: Record<Required<ContentSectionProps>['tone'], string> = {
   neutral: 'bg-white',
@@ -88,11 +88,13 @@ export function ContentSection({
   align = 'left',
   tone = 'neutral',
   footerContent,
+  className,
+  ...sectionProps
 }: ContentSectionProps) {
   const hasChildren = children !== undefined && children !== null;
 
   return (
-    <section>
+    <section className={className} {...sectionProps}>
       <div
         className={cn(
           'relative overflow-hidden rounded-3xl border-4 border-black p-8 md:p-12 shadow-[12px_12px_0px_0px_rgba(0,0,0,0.08)]',


### PR DESCRIPTION
## Summary
- allow ContentSection components to accept native section props across page layouts
- pass through ids and other attributes while preserving existing styling and layout logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e894e47cb4832daa00ae0c4df46c95