### PR TITLE
feat: rebuild PocketLLM onboarding flow

### DIFF
--- a/pocketllm/lib/app.dart
+++ b/pocketllm/lib/app.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'onboarding/onboarding_state.dart';
+import 'onboarding/precache.dart';
+import 'router.dart';
+import 'theme/colors.dart';
+import 'theme/theme.dart';
+
+class PocketLLMApp extends HookConsumerWidget {
+  const PocketLLMApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(routerProvider);
+    final onboardingReady = ref.watch(onboardingReadyProvider);
+    final precached = useState(false);
+
+    useEffect(() {
+      var disposed = false;
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        await precacheIllustrations(context);
+        if (!disposed && context.mounted) {
+          precached.value = true;
+        }
+      });
+      return () => disposed = true;
+    }, const []);
+
+    final onboardingLoaded = onboardingReady.maybeWhen(
+      data: (_) => true,
+      error: (_, __) => true,
+      orElse: () => false,
+    );
+    final ready = onboardingLoaded && precached.value;
+
+    return MaterialApp.router(
+      debugShowCheckedModeBanner: false,
+      theme: AppTheme.create(),
+      routerConfig: router,
+      builder: (context, child) {
+        if (!ready) {
+          return Scaffold(
+            backgroundColor: AppColors.background,
+            body: const Center(
+              child: CircularProgressIndicator(),
+            ),
+          );
+        }
+        return child ?? const SizedBox.shrink();
+      },
+    );
+  }
+}

--- a/pocketllm/lib/main.dart
+++ b/pocketllm/lib/main.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'app.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const ProviderScope(child: PocketLLMApp()));
+}

--- a/pocketllm/lib/motion/effects.dart
+++ b/pocketllm/lib/motion/effects.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+
+import '../theme/colors.dart';
+import 'tokens.dart';
+
+Widget animateTitle(Widget child, {bool reduceMotion = false, Duration? delay}) {
+  if (reduceMotion) {
+    return child.animate(delay: delay ?? Duration.zero).fadeIn(duration: MotionDurations.short);
+  }
+  return child
+      .animate(delay: delay ?? Duration.zero)
+      .fadeIn(duration: MotionDurations.medium, curve: MotionCurves.easeOut)
+      .slide(begin: const Offset(0, 0.12), end: Offset.zero, duration: MotionDurations.medium, curve: MotionCurves.easeOut);
+}
+
+Widget animateSubtitle(Widget child, {bool reduceMotion = false, Duration? delay}) {
+  final effectiveDelay = delay ?? const Duration(milliseconds: 100);
+  if (reduceMotion) {
+    return child.animate(delay: effectiveDelay).fadeIn(duration: MotionDurations.short);
+  }
+  return child
+      .animate(delay: effectiveDelay)
+      .fadeIn(duration: MotionDurations.medium, curve: MotionCurves.easeOut)
+      .slide(begin: const Offset(0, 0.12), end: Offset.zero, duration: MotionDurations.medium, curve: MotionCurves.easeOut);
+}
+
+Widget animateIllustration(Widget child, {bool reduceMotion = false, Duration? delay}) {
+  if (reduceMotion) {
+    return child.animate(delay: delay ?? Duration.zero).fadeIn(duration: MotionDurations.short);
+  }
+  return child
+      .animate(delay: delay ?? Duration.zero)
+      .fadeIn(duration: MotionDurations.long, curve: Curves.easeOut)
+      .scale(begin: 0.96, end: 1, duration: MotionDurations.long, curve: MotionCurves.easeOut);
+}
+
+Widget animateCta(Widget child, {bool reduceMotion = false, Duration? delay}) {
+  if (reduceMotion) {
+    return child.animate(delay: delay ?? Duration.zero).fadeIn(duration: MotionDurations.short);
+  }
+  return child
+      .animate(delay: delay ?? Duration.zero)
+      .fadeIn(duration: MotionDurations.medium)
+      .slide(begin: const Offset(0, 0.2), end: Offset.zero, duration: MotionDurations.medium, curve: MotionCurves.spring);
+}
+
+Widget animateChip(Widget child, {bool reduceMotion = false, Duration? delay}) {
+  if (reduceMotion) {
+    return child.animate(delay: delay ?? Duration.zero).fadeIn(duration: MotionDurations.short);
+  }
+  return child
+      .animate(delay: delay ?? Duration.zero)
+      .fadeIn(duration: MotionDurations.medium)
+      .slide(begin: const Offset(0, 0.08), end: Offset.zero, curve: MotionCurves.easeOut)
+      .scale(begin: 0.96, end: 1, duration: MotionDurations.medium, curve: MotionCurves.easeOut);
+}
+
+Widget animateToggle(Widget child, {bool reduceMotion = false, Duration? delay}) {
+  if (reduceMotion) {
+    return child.animate(delay: delay ?? Duration.zero).fadeIn(duration: MotionDurations.short);
+  }
+  return child
+      .animate(delay: delay ?? Duration.zero)
+      .fadeIn(duration: MotionDurations.medium)
+      .slide(begin: const Offset(0, 0.1), end: Offset.zero, curve: MotionCurves.easeOut);
+}
+
+Widget animateCheckbox(Widget child, {bool reduceMotion = false, Duration? delay}) {
+  if (reduceMotion) {
+    return child.animate(delay: delay ?? Duration.zero).fadeIn(duration: MotionDurations.short);
+  }
+  return child
+      .animate(delay: delay ?? Duration.zero)
+      .fadeIn(duration: MotionDurations.medium)
+      .slide(begin: const Offset(0, 0.1), end: Offset.zero, curve: MotionCurves.easeOut);
+}
+
+Widget animatePagerDot(Widget child, double intensity, {bool reduceMotion = false}) {
+  if (reduceMotion) {
+    return child;
+  }
+  final scale = 1 + 0.6 * intensity;
+  final color = Color.lerp(AppColors.stroke, AppColors.primary, intensity) ?? AppColors.stroke;
+  return child
+      .animate(target: intensity)
+      .scale(begin: 1, end: scale, duration: MotionDurations.short)
+      .tint(color: color, duration: MotionDurations.short);
+}

--- a/pocketllm/lib/motion/tokens.dart
+++ b/pocketllm/lib/motion/tokens.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/animation.dart';
+
+class MotionDurations {
+  MotionDurations._();
+
+  static const Duration short = Duration(milliseconds: 180);
+  static const Duration medium = Duration(milliseconds: 260);
+  static const Duration long = Duration(milliseconds: 380);
+  static const Duration pager = Duration(milliseconds: 420);
+  static const Duration debounce = Duration(milliseconds: 300);
+}
+
+class MotionCurves {
+  MotionCurves._();
+
+  static const Curve easeOut = Curves.easeOutCubic;
+  static const Curve spring = Curves.easeOutBack;
+}

--- a/pocketllm/lib/onboarding/copy.dart
+++ b/pocketllm/lib/onboarding/copy.dart
@@ -1,0 +1,32 @@
+const OB = {
+  "s1_title": "Meet PocketLLM",
+  "s1_sub": "One chat interface. Multiple LLMs. Smart routing, tools, and memory—under your control.",
+  "s1_cta": "Continue",
+  "s1_skip": "Skip setup",
+
+  "s2_title": "Connect your LLM providers",
+  "s2_sub": "Use OpenAI, Groq, Gemini, or local (Ollama). Your keys stay private—you decide what’s stored.",
+  "s2_cta": "Connect providers",
+  "s2_later": "I’ll do this later",
+  "s2_chips": "OpenAI,Groq,Gemini,Ollama (Local),Anthropic",
+
+  "s3_title": "Smart routing. Tool use. Memory.",
+  "s3_sub": "PocketLLM picks the best model per task and can use tools (search, code, RAG). Toggle features now.",
+  "s3_toggles": "Enable smart routing,Allow tool use (web/code/RAG),Conversation memory",
+  "s3_cta": "Continue",
+
+  "s4_title": "Your data, your rules",
+  "s4_sub": "Choose where to store history and embeddings. You can change this anytime in Settings.",
+  "s4_checks": "Store chat history locally only,Sync anonymized usage analytics,Enable local vector cache for RAG",
+  "s4_cta": "Continue",
+
+  "s5_title": "Quick actions & notifications",
+  "s5_sub": "Enable notifications and clipboard access for faster replies and 'Share to PocketLLM.'",
+  "s5_cta": "Enable",
+  "s5_skip": "Not now",
+
+  "s6_title": "You’re set",
+  "s6_sub": "Start your first chat or import previous conversations.",
+  "s6_cta": "Start chatting",
+  "s6_alt": "Import history"
+};

--- a/pocketllm/lib/onboarding/illustration.dart
+++ b/pocketllm/lib/onboarding/illustration.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+class OnboardingIllustration extends StatefulWidget {
+  const OnboardingIllustration({
+    super.key,
+    required this.asset,
+    this.height,
+    this.alignment = Alignment.center,
+    this.reduceMotion = false,
+  });
+
+  final String asset;
+  final double? height;
+  final Alignment alignment;
+  final bool reduceMotion;
+
+  @override
+  State<OnboardingIllustration> createState() => _OnboardingIllustrationState();
+}
+
+class _OnboardingIllustrationState extends State<OnboardingIllustration> {
+  ImageInfo? _staticFrame;
+  ImageStream? _stream;
+  ImageStreamListener? _listener;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _resolveImage();
+  }
+
+  @override
+  void didUpdateWidget(covariant OnboardingIllustration oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.asset != widget.asset || oldWidget.reduceMotion != widget.reduceMotion) {
+      _staticFrame = null;
+      _resolveImage();
+    }
+  }
+
+  void _resolveImage() {
+    if (_listener != null && _stream != null) {
+      _stream!.removeListener(_listener!);
+    }
+    if (!widget.reduceMotion) {
+      return;
+    }
+    final provider = AssetImage(widget.asset);
+    final stream = provider.resolve(createLocalImageConfiguration(context));
+    _stream = stream;
+    _listener = ImageStreamListener((image, _) {
+      if (_staticFrame == null && mounted) {
+        setState(() {
+          _staticFrame = image;
+        });
+      }
+    });
+    stream.addListener(_listener!);
+  }
+
+  @override
+  void dispose() {
+    if (_listener != null && _stream != null) {
+      _stream!.removeListener(_listener!);
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.reduceMotion && _staticFrame != null) {
+      return Align(
+        alignment: widget.alignment,
+        child: RawImage(
+          image: _staticFrame!.image,
+          fit: BoxFit.contain,
+          height: widget.height,
+        ),
+      );
+    }
+
+    return Align(
+      alignment: widget.alignment,
+      child: Image.asset(
+        widget.asset,
+        height: widget.height,
+        fit: BoxFit.contain,
+      ),
+    );
+  }
+}

--- a/pocketllm/lib/onboarding/onboarding_pager.dart
+++ b/pocketllm/lib/onboarding/onboarding_pager.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../motion/tokens.dart';
+import '../theme/spacing.dart';
+import '../widgets/dot_pager.dart';
+import '../widgets/safe_scaffold.dart';
+import 'onboarding_state.dart';
+import 'screen1_welcome.dart';
+import 'screen2_providers.dart';
+import 'screen3_routing_tools.dart';
+import 'screen4_privacy.dart';
+import 'screen5_permissions.dart';
+import 'screen6_done.dart';
+
+class OnboardingPager extends HookConsumerWidget {
+  const OnboardingPager({
+    super.key,
+    required this.onFinished,
+  });
+
+  final VoidCallback onFinished;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final reduceMotion = MediaQuery.of(context).accessibilityFeatures.reduceMotion;
+    final controller = usePageController();
+    final page = useState(0.0);
+    final notifier = ref.read(onboardingStateProvider.notifier);
+
+    useEffect(() {
+      void listener() {
+        page.value = controller.page ?? controller.initialPage.toDouble();
+      }
+
+      controller.addListener(listener);
+      return () => controller.removeListener(listener);
+    }, [controller]);
+
+    Future<void> goTo(int index) async {
+      final clamped = index.clamp(0, 5);
+      if (reduceMotion) {
+        controller.jumpToPage(clamped);
+      } else {
+        await controller.animateToPage(
+          clamped,
+          duration: MotionDurations.pager,
+          curve: Curves.easeOutCubic,
+        );
+      }
+    }
+
+    Widget buildPage(int index) {
+      switch (index) {
+        case 0:
+          return Screen1Welcome(
+            onContinue: () => goTo(1),
+            onSkip: () {
+              notifier.markCompleted();
+              onFinished();
+            },
+            pageOffset: page.value - 0,
+            reduceMotion: reduceMotion,
+          );
+        case 1:
+          return Screen2Providers(
+            reduceMotion: reduceMotion,
+            onLater: () => goTo(2),
+          );
+        case 2:
+          return Screen3RoutingTools(
+            reduceMotion: reduceMotion,
+            onContinue: () => goTo(3),
+          );
+        case 3:
+          return Screen4Privacy(
+            reduceMotion: reduceMotion,
+            onContinue: () => goTo(4),
+          );
+        case 4:
+          return Screen5Permissions(
+            reduceMotion: reduceMotion,
+            onEnable: () async {
+              await Future<void>.delayed(const Duration(milliseconds: 1800));
+              await goTo(5);
+            },
+            onSkip: () => goTo(5),
+          );
+        case 5:
+        default:
+          return Screen6Done(
+            reduceMotion: reduceMotion,
+            onStart: () {
+              notifier.markCompleted();
+              onFinished();
+            },
+            onImport: () {
+              notifier.markCompleted();
+              onFinished();
+            },
+          );
+      }
+    }
+
+    return SafeScaffold(
+      child: Column(
+        children: [
+          Expanded(
+            child: NotificationListener<OverscrollIndicatorNotification>(
+              onNotification: (notification) {
+                notification.disallowIndicator();
+                return true;
+              },
+              child: PageView.builder(
+                controller: controller,
+                itemCount: 6,
+                physics: const ClampingScrollPhysics(),
+                itemBuilder: (context, index) => buildPage(index),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: AppSpacing.lg),
+            child: DotPager(
+              count: 6,
+              page: page.value,
+              reduceMotion: reduceMotion,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pocketllm/lib/onboarding/onboarding_state.dart
+++ b/pocketllm/lib/onboarding/onboarding_state.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../motion/tokens.dart';
+
+const _prefsKey = 'pocketllm_onboarding_v1';
+
+class OnboardingModel {
+  const OnboardingModel({
+    required this.completed,
+    required this.providerKeys,
+    required this.smartRouting,
+    required this.toolUse,
+    required this.memory,
+    required this.localHistoryOnly,
+    required this.analytics,
+    required this.localVectorCache,
+  });
+
+  factory OnboardingModel.initial() => const OnboardingModel(
+        completed: false,
+        providerKeys: {},
+        smartRouting: true,
+        toolUse: true,
+        memory: true,
+        localHistoryOnly: true,
+        analytics: false,
+        localVectorCache: true,
+      );
+
+  final bool completed;
+  final Map<String, String> providerKeys;
+  final bool smartRouting;
+  final bool toolUse;
+  final bool memory;
+  final bool localHistoryOnly;
+  final bool analytics;
+  final bool localVectorCache;
+
+  OnboardingModel copyWith({
+    bool? completed,
+    Map<String, String>? providerKeys,
+    bool? smartRouting,
+    bool? toolUse,
+    bool? memory,
+    bool? localHistoryOnly,
+    bool? analytics,
+    bool? localVectorCache,
+  }) {
+    return OnboardingModel(
+      completed: completed ?? this.completed,
+      providerKeys: providerKeys ?? this.providerKeys,
+      smartRouting: smartRouting ?? this.smartRouting,
+      toolUse: toolUse ?? this.toolUse,
+      memory: memory ?? this.memory,
+      localHistoryOnly: localHistoryOnly ?? this.localHistoryOnly,
+      analytics: analytics ?? this.analytics,
+      localVectorCache: localVectorCache ?? this.localVectorCache,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'completed': completed,
+        'providerKeys': providerKeys,
+        'smartRouting': smartRouting,
+        'toolUse': toolUse,
+        'memory': memory,
+        'localHistoryOnly': localHistoryOnly,
+        'analytics': analytics,
+        'localVectorCache': localVectorCache,
+      };
+
+  factory OnboardingModel.fromJson(Map<String, dynamic> json) {
+    return OnboardingModel(
+      completed: json['completed'] as bool? ?? false,
+      providerKeys: (json['providerKeys'] as Map?)
+              ?.map((key, value) => MapEntry(key.toString(), value.toString())) ??
+          const {},
+      smartRouting: json['smartRouting'] as bool? ?? true,
+      toolUse: json['toolUse'] as bool? ?? true,
+      memory: json['memory'] as bool? ?? true,
+      localHistoryOnly: json['localHistoryOnly'] as bool? ?? true,
+      analytics: json['analytics'] as bool? ?? false,
+      localVectorCache: json['localVectorCache'] as bool? ?? true,
+    );
+  }
+}
+
+class OnboardingNotifier extends StateNotifier<OnboardingModel> {
+  OnboardingNotifier() : super(OnboardingModel.initial()) {
+    _initCompleter = Completer<void>();
+    _hydrate();
+  }
+
+  late final Completer<void> _initCompleter;
+  bool _initialized = false;
+  Timer? _saveDebounce;
+
+  bool get isInitialized => _initialized;
+
+  Future<void> ensureInitialized() => _initCompleter.future;
+
+  Future<void> _hydrate() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw != null) {
+      try {
+        final jsonMap = json.decode(raw) as Map<String, dynamic>;
+        state = OnboardingModel.fromJson(jsonMap);
+      } catch (_) {
+        state = OnboardingModel.initial();
+      }
+    }
+    _initialized = true;
+    if (!_initCompleter.isCompleted) {
+      _initCompleter.complete();
+    }
+  }
+
+  void markCompleted() {
+    state = state.copyWith(completed: true);
+    _queueSave();
+  }
+
+  void updateProviderKey(String provider, String key) {
+    final updated = Map<String, String>.from(state.providerKeys);
+    if (key.isEmpty) {
+      updated.remove(provider);
+    } else {
+      updated[provider] = key;
+    }
+    state = state.copyWith(providerKeys: updated);
+    _queueSave();
+  }
+
+  void setRouting(bool smart, bool tool, bool memory) {
+    state = state.copyWith(smartRouting: smart, toolUse: tool, memory: memory);
+    _queueSave();
+  }
+
+  void setPrivacy({
+    bool? localHistoryOnly,
+    bool? analytics,
+    bool? localVectorCache,
+  }) {
+    state = state.copyWith(
+      localHistoryOnly: localHistoryOnly ?? state.localHistoryOnly,
+      analytics: analytics ?? state.analytics,
+      localVectorCache: localVectorCache ?? state.localVectorCache,
+    );
+    _queueSave();
+  }
+
+  void resetCompletion() {
+    state = state.copyWith(completed: false);
+    _queueSave();
+  }
+
+  void _queueSave() {
+    _saveDebounce?.cancel();
+    _saveDebounce = Timer(MotionDurations.debounce, _persist);
+  }
+
+  Future<void> _persist() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefsKey, json.encode(state.toJson()));
+  }
+
+  @override
+  void dispose() {
+    _saveDebounce?.cancel();
+    super.dispose();
+  }
+}
+
+final onboardingStateProvider = StateNotifierProvider<OnboardingNotifier, OnboardingModel>((ref) {
+  return OnboardingNotifier();
+});
+
+final onboardingInitializedProvider = Provider<bool>((ref) {
+  return ref.watch(onboardingStateProvider.notifier).isInitialized;
+});
+
+final onboardingReadyProvider = FutureProvider<void>((ref) async {
+  await ref.read(onboardingStateProvider.notifier).ensureInitialized();
+});

--- a/pocketllm/lib/onboarding/precache.dart
+++ b/pocketllm/lib/onboarding/precache.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+const illustrations = [
+  'assets/illustration/ob1.png',
+  'assets/illustration/ob2.png',
+  'assets/illustration/ob3.gif',
+  'assets/illustration/ob4.gif',
+  'assets/illustration/ob5.gif',
+  'assets/illustration/ob6.gif',
+];
+
+Future<void> precacheIllustrations(BuildContext context) async {
+  for (final asset in illustrations) {
+    final provider = AssetImage(asset);
+    await precacheImage(provider, context);
+  }
+}

--- a/pocketllm/lib/onboarding/screen1_welcome.dart
+++ b/pocketllm/lib/onboarding/screen1_welcome.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../motion/effects.dart';
+import '../theme/colors.dart';
+import '../theme/spacing.dart';
+import '../widgets/primary_button.dart';
+import '../widgets/secondary_button.dart';
+import 'copy.dart';
+import 'illustration.dart';
+
+class Screen1Welcome extends ConsumerWidget {
+  const Screen1Welcome({
+    super.key,
+    required this.onContinue,
+    required this.onSkip,
+    required this.pageOffset,
+    required this.reduceMotion,
+  });
+
+  final VoidCallback onContinue;
+  final VoidCallback onSkip;
+  final double pageOffset;
+  final bool reduceMotion;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final parallaxText = pageOffset * -32 * 0.25;
+    final parallaxImage = pageOffset * -40 * 0.15;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg, vertical: AppSpacing.xl),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: AppSpacing.lg),
+                animateTitle(
+                  Transform.translate(
+                    offset: Offset(0, parallaxText),
+                    child: Text(
+                      OB['s1_title']!,
+                      style: Theme.of(context)
+                          .textTheme
+                          .displayMedium
+                          ?.copyWith(color: AppColors.textPrimary, fontWeight: FontWeight.w700),
+                    ),
+                  ),
+                  reduceMotion: reduceMotion,
+                ),
+                const SizedBox(height: AppSpacing.md),
+                animateSubtitle(
+                  Transform.translate(
+                    offset: Offset(0, parallaxText * 0.7),
+                    child: Text(
+                      OB['s1_sub']!,
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyLarge
+                          ?.copyWith(color: AppColors.textSecondary, height: 1.5),
+                    ),
+                  ),
+                  reduceMotion: reduceMotion,
+                ),
+                const SizedBox(height: AppSpacing.xl),
+                Expanded(
+                  child: animateIllustration(
+                    Transform.translate(
+                      offset: Offset(parallaxImage, 0),
+                      child: OnboardingIllustration(
+                        asset: 'assets/illustration/ob1.png',
+                        reduceMotion: reduceMotion,
+                      ),
+                    ),
+                    reduceMotion: reduceMotion,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          animateCta(
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                PrimaryButton(
+                  label: OB['s1_cta']!,
+                  onPressed: onContinue,
+                  semanticLabel: 'Continue onboarding',
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                SecondaryButton(
+                  label: OB['s1_skip']!,
+                  onPressed: onSkip,
+                  semanticLabel: 'Skip onboarding setup',
+                ),
+              ],
+            ),
+            reduceMotion: reduceMotion,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pocketllm/lib/onboarding/screen2_providers.dart
+++ b/pocketllm/lib/onboarding/screen2_providers.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../motion/effects.dart';
+import '../theme/colors.dart';
+import '../theme/spacing.dart';
+import '../widgets/primary_button.dart';
+import '../widgets/provider_chip.dart';
+import '../widgets/secondary_button.dart';
+import '../providers/connect_sheet.dart';
+import 'copy.dart';
+import 'illustration.dart';
+import 'onboarding_state.dart';
+
+class Screen2Providers extends HookConsumerWidget {
+  const Screen2Providers({
+    super.key,
+    required this.onLater,
+    required this.reduceMotion,
+  });
+
+  final VoidCallback onLater;
+  final bool reduceMotion;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final providerLabels = useMemoized(() => OB['s2_chips']!.split(','), const []);
+    final highlight = useState<String?>(null);
+    final model = ref.watch(onboardingStateProvider);
+    final notifier = ref.read(onboardingStateProvider.notifier);
+
+    Future<void> connect(String label) async {
+      final id = _providerId(label);
+      final key = await showConnectSheet(
+        context,
+        provider: label,
+        existingKey: model.providerKeys[id],
+        reduceMotion: reduceMotion,
+      );
+      if (key != null) {
+        notifier.updateProviderKey(id, key);
+        highlight.value = id;
+        await Future<void>.delayed(const Duration(milliseconds: 1200));
+        if (highlight.value == id) {
+          highlight.value = null;
+        }
+      }
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg, vertical: AppSpacing.xl),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          animateTitle(
+            Text(
+              OB['s2_title']!,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineMedium
+                  ?.copyWith(color: AppColors.textPrimary, fontWeight: FontWeight.w700),
+            ),
+            reduceMotion: reduceMotion,
+          ),
+          const SizedBox(height: AppSpacing.md),
+          animateSubtitle(
+            Text(
+              OB['s2_sub']!,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyLarge
+                  ?.copyWith(color: AppColors.textSecondary, height: 1.5),
+            ),
+            reduceMotion: reduceMotion,
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          Expanded(
+            child: animateIllustration(
+              OnboardingIllustration(
+                asset: 'assets/illustration/ob2.png',
+                reduceMotion: reduceMotion,
+              ),
+              reduceMotion: reduceMotion,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              for (var i = 0; i < providerLabels.length; i++)
+                animateChip(
+                  ProviderChip(
+                    label: providerLabels[i],
+                    selected: model.providerKeys.containsKey(_providerId(providerLabels[i])),
+                    onTap: () => connect(providerLabels[i]),
+                    highlight: highlight.value == _providerId(providerLabels[i]),
+                    reduceMotion: reduceMotion,
+                  ),
+                  delay: Duration(milliseconds: 60 * i),
+                  reduceMotion: reduceMotion,
+                ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          animateCta(
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                PrimaryButton(
+                  label: OB['s2_cta']!,
+                  onPressed: () => connect(providerLabels.first),
+                  semanticLabel: 'Connect providers',
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                SecondaryButton(
+                  label: OB['s2_later']!,
+                  onPressed: onLater,
+                ),
+              ],
+            ),
+            reduceMotion: reduceMotion,
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _providerId(String label) =>
+      label.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_').replaceAll(RegExp('_+'), '_');
+}

--- a/pocketllm/lib/onboarding/screen3_routing_tools.dart
+++ b/pocketllm/lib/onboarding/screen3_routing_tools.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../motion/effects.dart';
+import '../theme/colors.dart';
+import '../theme/spacing.dart';
+import '../widgets/primary_button.dart';
+import '../widgets/toggle_row.dart';
+import 'copy.dart';
+import 'illustration.dart';
+import 'onboarding_state.dart';
+
+class Screen3RoutingTools extends HookConsumerWidget {
+  const Screen3RoutingTools({
+    super.key,
+    required this.onContinue,
+    required this.reduceMotion,
+  });
+
+  final VoidCallback onContinue;
+  final bool reduceMotion;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final model = ref.watch(onboardingStateProvider);
+    final notifier = ref.read(onboardingStateProvider.notifier);
+    final toggleLabels = useMemoized(() => OB['s3_toggles']!.split(','), const []);
+
+    void update(int index, bool value) {
+      switch (index) {
+        case 0:
+          notifier.setRouting(value, model.toolUse, model.memory);
+          break;
+        case 1:
+          notifier.setRouting(model.smartRouting, value, model.memory);
+          break;
+        case 2:
+          notifier.setRouting(model.smartRouting, model.toolUse, value);
+          break;
+      }
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg, vertical: AppSpacing.xl),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          animateTitle(
+            Text(
+              OB['s3_title']!,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineMedium
+                  ?.copyWith(color: AppColors.textPrimary, fontWeight: FontWeight.w700),
+            ),
+            reduceMotion: reduceMotion,
+          ),
+          const SizedBox(height: AppSpacing.md),
+          animateSubtitle(
+            Text(
+              OB['s3_sub']!,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyLarge
+                  ?.copyWith(color: AppColors.textSecondary, height: 1.5),
+            ),
+            reduceMotion: reduceMotion,
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          Expanded(
+            child: animateIllustration(
+              OnboardingIllustration(
+                asset: 'assets/illustration/ob3.gif',
+                reduceMotion: reduceMotion,
+              ),
+              reduceMotion: reduceMotion,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          for (var i = 0; i < toggleLabels.length; i++)
+            Padding(
+              padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+              child: animateToggle(
+                ToggleRow(
+                  title: toggleLabels[i],
+                  value: i == 0
+                      ? model.smartRouting
+                      : i == 1
+                          ? model.toolUse
+                          : model.memory,
+                  onChanged: (value) => update(i, value),
+                  reduceMotion: reduceMotion,
+                ),
+                delay: Duration(milliseconds: 80 * i),
+                reduceMotion: reduceMotion,
+              ),
+            ),
+          const SizedBox(height: AppSpacing.md),
+          animateCta(
+            PrimaryButton(
+              label: OB['s3_cta']!,
+              onPressed: onContinue,
+            ),
+            reduceMotion: reduceMotion,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pocketllm/lib/onboarding/screen4_privacy.dart
+++ b/pocketllm/lib/onboarding/screen4_privacy.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../motion/effects.dart';
+import '../theme/colors.dart';
+import '../theme/spacing.dart';
+import '../widgets/checkbox_row.dart';
+import '../widgets/primary_button.dart';
+import 'copy.dart';
+import 'illustration.dart';
+import 'onboarding_state.dart';
+
+class Screen4Privacy extends HookConsumerWidget {
+  const Screen4Privacy({
+    super.key,
+    required this.onContinue,
+    required this.reduceMotion,
+  });
+
+  final VoidCallback onContinue;
+  final bool reduceMotion;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final model = ref.watch(onboardingStateProvider);
+    final notifier = ref.read(onboardingStateProvider.notifier);
+    final labels = useMemoized(() => OB['s4_checks']!.split(','), const []);
+
+    void update(int index, bool value) {
+      switch (index) {
+        case 0:
+          notifier.setPrivacy(localHistoryOnly: value);
+          break;
+        case 1:
+          notifier.setPrivacy(analytics: value);
+          break;
+        case 2:
+          notifier.setPrivacy(localVectorCache: value);
+          break;
+      }
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg, vertical: AppSpacing.xl),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          animateTitle(
+            Text(
+              OB['s4_title']!,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineMedium
+                  ?.copyWith(color: AppColors.textPrimary, fontWeight: FontWeight.w700),
+            ),
+            reduceMotion: reduceMotion,
+          ),
+          const SizedBox(height: AppSpacing.md),
+          animateSubtitle(
+            Text(
+              OB['s4_sub']!,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyLarge
+                  ?.copyWith(color: AppColors.textSecondary, height: 1.5),
+            ),
+            reduceMotion: reduceMotion,
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          Expanded(
+            child: animateIllustration(
+              OnboardingIllustration(
+                asset: 'assets/illustration/ob4.gif',
+                reduceMotion: reduceMotion,
+              ),
+              reduceMotion: reduceMotion,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          for (var i = 0; i < labels.length; i++)
+            Padding(
+              padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+              child: animateCheckbox(
+                CheckboxRow(
+                  title: labels[i],
+                  value: i == 0
+                      ? model.localHistoryOnly
+                      : i == 1
+                          ? model.analytics
+                          : model.localVectorCache,
+                  onChanged: (value) => update(i, value),
+                  reduceMotion: reduceMotion,
+                ),
+                delay: Duration(milliseconds: 80 * i),
+                reduceMotion: reduceMotion,
+              ),
+            ),
+          const SizedBox(height: AppSpacing.md),
+          animateCta(
+            PrimaryButton(
+              label: OB['s4_cta']!,
+              onPressed: onContinue,
+            ),
+            reduceMotion: reduceMotion,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pocketllm/lib/onboarding/screen5_permissions.dart
+++ b/pocketllm/lib/onboarding/screen5_permissions.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../motion/effects.dart';
+import '../motion/tokens.dart';
+import '../theme/colors.dart';
+import '../theme/spacing.dart';
+import '../widgets/primary_button.dart';
+import '../widgets/secondary_button.dart';
+import 'copy.dart';
+import 'illustration.dart';
+
+class Screen5Permissions extends HookConsumerWidget {
+  const Screen5Permissions({
+    super.key,
+    required this.onEnable,
+    required this.onSkip,
+    required this.reduceMotion,
+  });
+
+  final Future<void> Function() onEnable;
+  final VoidCallback onSkip;
+  final bool reduceMotion;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isLoading = useState(false);
+    final shakeTrigger = useState(0);
+
+    Future<void> handleEnable() async {
+      isLoading.value = true;
+      await onEnable();
+      isLoading.value = false;
+    }
+
+    void handleSkip() {
+      shakeTrigger.value++;
+      onSkip();
+    }
+
+    final button = PrimaryButton(
+      label: OB['s5_cta']!,
+      onPressed: isLoading.value ? null : handleEnable,
+      isLoading: isLoading.value,
+    );
+
+    final shouldShake = shakeTrigger.value > 0;
+    final animatedButton = reduceMotion || !shouldShake
+        ? button
+        : Animate(
+            key: ValueKey(shakeTrigger.value),
+            effects: const [
+              ShakeEffect(
+                duration: Duration(milliseconds: 400),
+                hz: 4,
+                offset: Offset(8, 0),
+              ),
+            ],
+            child: button,
+          );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg, vertical: AppSpacing.xl),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          animateTitle(
+            Text(
+              OB['s5_title']!,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineMedium
+                  ?.copyWith(color: AppColors.textPrimary, fontWeight: FontWeight.w700),
+            ),
+            reduceMotion: reduceMotion,
+          ),
+          const SizedBox(height: AppSpacing.md),
+          animateSubtitle(
+            Text(
+              OB['s5_sub']!,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyLarge
+                  ?.copyWith(color: AppColors.textSecondary, height: 1.5),
+            ),
+            reduceMotion: reduceMotion,
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          Expanded(
+            child: animateIllustration(
+              OnboardingIllustration(
+                asset: 'assets/illustration/ob5.gif',
+                reduceMotion: reduceMotion,
+              ),
+              reduceMotion: reduceMotion,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          AnimatedOpacity(
+            duration: MotionDurations.medium,
+            opacity: isLoading.value ? 1 : 0,
+            child: isLoading.value
+                ? Container(
+                    height: 8,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(999),
+                      gradient: LinearGradient(
+                        colors: [
+                          AppColors.primary.withOpacity(0.2),
+                          AppColors.primary,
+                          AppColors.primary.withOpacity(0.2),
+                        ],
+                      ),
+                    ),
+                  ).animate(onPlay: (controller) => controller.repeat()).shimmer(duration: const Duration(milliseconds: 1200))
+                : const SizedBox(height: 8),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          animateCta(
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                animatedButton,
+                const SizedBox(height: AppSpacing.sm),
+                SecondaryButton(
+                  label: OB['s5_skip']!,
+                  onPressed: handleSkip,
+                ),
+              ],
+            ),
+            reduceMotion: reduceMotion,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pocketllm/lib/onboarding/screen6_done.dart
+++ b/pocketllm/lib/onboarding/screen6_done.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../motion/effects.dart';
+import '../theme/colors.dart';
+import '../theme/spacing.dart';
+import '../widgets/primary_button.dart';
+import '../widgets/secondary_button.dart';
+import 'copy.dart';
+import 'illustration.dart';
+
+class Screen6Done extends HookConsumerWidget {
+  const Screen6Done({
+    super.key,
+    required this.onStart,
+    required this.onImport,
+    required this.reduceMotion,
+  });
+
+  final VoidCallback onStart;
+  final VoidCallback onImport;
+  final bool reduceMotion;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final freeze = useState(reduceMotion);
+
+    useEffect(() {
+      if (reduceMotion) return null;
+      final timer = Timer(const Duration(seconds: 4), () => freeze.value = true);
+      return timer.cancel;
+    }, [reduceMotion]);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg, vertical: AppSpacing.xl),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          animateTitle(
+            Text(
+              OB['s6_title']!,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineMedium
+                  ?.copyWith(color: AppColors.textPrimary, fontWeight: FontWeight.w700),
+            ),
+            reduceMotion: reduceMotion,
+          ),
+          const SizedBox(height: AppSpacing.md),
+          animateSubtitle(
+            Text(
+              OB['s6_sub']!,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyLarge
+                  ?.copyWith(color: AppColors.textSecondary, height: 1.5),
+            ),
+            reduceMotion: reduceMotion,
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          Expanded(
+            child: animateIllustration(
+              OnboardingIllustration(
+                asset: 'assets/illustration/ob6.gif',
+                reduceMotion: freeze.value,
+              ),
+              reduceMotion: reduceMotion,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xl),
+          animateCta(
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Hero(
+                  tag: 'primary_cta',
+                  child: PrimaryButton(
+                    label: OB['s6_cta']!,
+                    onPressed: onStart,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                SecondaryButton(
+                  label: OB['s6_alt']!,
+                  onPressed: onImport,
+                ),
+              ],
+            ),
+            reduceMotion: reduceMotion,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pocketllm/lib/providers/connect_sheet.dart
+++ b/pocketllm/lib/providers/connect_sheet.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+
+import '../motion/tokens.dart';
+import '../theme/colors.dart';
+
+Future<String?> showConnectSheet(
+  BuildContext context, {
+  required String provider,
+  bool reduceMotion = false,
+  String? existingKey,
+}) {
+  return showModalBottomSheet<String>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (context) => _ConnectSheet(
+      provider: provider,
+      reduceMotion: reduceMotion,
+      existingKey: existingKey,
+    ),
+  );
+}
+
+class _ConnectSheet extends StatefulWidget {
+  const _ConnectSheet({
+    required this.provider,
+    required this.reduceMotion,
+    this.existingKey,
+  });
+
+  final String provider;
+  final bool reduceMotion;
+  final String? existingKey;
+
+  @override
+  State<_ConnectSheet> createState() => _ConnectSheetState();
+}
+
+class _ConnectSheetState extends State<_ConnectSheet> {
+  late final TextEditingController _controller = TextEditingController(text: widget.existingKey ?? '');
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final media = MediaQuery.of(context);
+    final safePadding = media.viewInsets.bottom;
+
+    Widget content = Container(
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+        boxShadow: const [
+          BoxShadow(color: Colors.black54, blurRadius: 24, offset: Offset(0, -6)),
+        ],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Connect ${widget.provider}',
+            style: Theme.of(context).textTheme.headlineMedium,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Enter your ${widget.provider} API key. Stored locally only.',
+            style:
+                Theme.of(context).textTheme.bodyMedium?.copyWith(color: AppColors.textSecondary),
+          ),
+          const SizedBox(height: 24),
+          TextField(
+            controller: _controller,
+            obscureText: true,
+            decoration: InputDecoration(
+              hintText: 'sk-xxxx',
+              filled: true,
+              fillColor: AppColors.background,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(16),
+                borderSide: const BorderSide(color: AppColors.stroke),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(16),
+                borderSide: const BorderSide(color: AppColors.primary),
+              ),
+            ),
+          ),
+          const SizedBox(height: 24),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Cancel'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(_controller.text.trim()),
+                  child: const Text('Save'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+
+    if (!widget.reduceMotion) {
+      content = TweenAnimationBuilder<double>(
+        tween: Tween(begin: 0.9, end: 1),
+        duration: MotionDurations.medium,
+        curve: Curves.easeOutBack,
+        builder: (context, value, child) {
+          return Transform.scale(scale: value, child: child);
+        },
+        child: content,
+      );
+    }
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: safePadding),
+      child: content,
+    );
+  }
+}

--- a/pocketllm/lib/router.dart
+++ b/pocketllm/lib/router.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'onboarding/onboarding_pager.dart';
+import 'onboarding/onboarding_state.dart';
+import 'theme/colors.dart';
+import 'theme/spacing.dart';
+import 'widgets/primary_button.dart';
+
+final routerProvider = Provider<GoRouter>((ref) {
+  final notifier = ref.watch(onboardingStateProvider.notifier);
+  final onboarding = ref.watch(onboardingStateProvider);
+
+  return GoRouter(
+    debugLogDiagnostics: false,
+    initialLocation: '/onboarding',
+    routes: [
+      GoRoute(
+        path: '/onboarding',
+        builder: (context, state) => OnboardingPager(
+          onFinished: () => context.go('/home'),
+        ),
+      ),
+      GoRoute(
+        path: '/home',
+        builder: (context, state) => const HomeScreen(),
+      ),
+    ],
+    redirect: (context, state) {
+      if (!notifier.isInitialized) {
+        return null;
+      }
+      final completed = onboarding.completed;
+      final isOnboarding = state.subloc.startsWith('/onboarding');
+      if (!completed && !isOnboarding) {
+        return '/onboarding';
+      }
+      if (completed && isOnboarding) {
+        return '/home';
+      }
+      return null;
+    },
+  );
+});
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'PocketLLM',
+                  style: Theme.of(context)
+                      .textTheme
+                      .displayMedium
+                      ?.copyWith(color: AppColors.textPrimary, fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: AppSpacing.lg),
+                Hero(
+                  tag: 'primary_cta',
+                  child: PrimaryButton(
+                    label: 'Start chatting',
+                    onPressed: () {},
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pocketllm/lib/theme/colors.dart
+++ b/pocketllm/lib/theme/colors.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+/// Core color tokens for the PocketLLM dark theme.
+class AppColors {
+  AppColors._();
+
+  static const background = Color(0xFF0B1220);
+  static const surface = Color(0xFF0F172A);
+  static const primary = Color(0xFF3B82F6);
+  static const accent = Color(0xFF10B981);
+  static const textPrimary = Color(0xFFE2E8F0);
+  static const textSecondary = Color(0xFF94A3B8);
+  static const stroke = Color(0xFF1F2937);
+}

--- a/pocketllm/lib/theme/spacing.dart
+++ b/pocketllm/lib/theme/spacing.dart
@@ -1,0 +1,11 @@
+class AppSpacing {
+  AppSpacing._();
+
+  static const double xxs = 4;
+  static const double xs = 8;
+  static const double sm = 12;
+  static const double md = 16;
+  static const double lg = 24;
+  static const double xl = 32;
+  static const double xxl = 40;
+}

--- a/pocketllm/lib/theme/theme.dart
+++ b/pocketllm/lib/theme/theme.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+import 'colors.dart';
+import 'typography.dart';
+
+class AppTheme {
+  AppTheme._();
+
+  static ThemeData create() {
+    final colorScheme = const ColorScheme(
+      brightness: Brightness.dark,
+      primary: AppColors.primary,
+      onPrimary: AppColors.textPrimary,
+      secondary: AppColors.accent,
+      onSecondary: AppColors.textPrimary,
+      error: Colors.redAccent,
+      onError: Colors.white,
+      background: AppColors.background,
+      onBackground: AppColors.textPrimary,
+      surface: AppColors.surface,
+      onSurface: AppColors.textPrimary,
+      surfaceVariant: AppColors.stroke,
+      onSurfaceVariant: AppColors.textSecondary,
+      tertiary: AppColors.accent,
+      onTertiary: AppColors.textPrimary,
+      outline: AppColors.stroke,
+      shadow: Colors.black54,
+      inverseSurface: Color(0xFF1E293B),
+      onInverseSurface: AppColors.textPrimary,
+      outlineVariant: AppColors.stroke,
+      scrim: Colors.black54,
+    );
+
+    final textTheme = AppTypography.createTextTheme();
+
+    return ThemeData(
+      useMaterial3: true,
+      brightness: Brightness.dark,
+      scaffoldBackgroundColor: AppColors.background,
+      canvasColor: AppColors.background,
+      colorScheme: colorScheme,
+      textTheme: textTheme,
+      appBarTheme: const AppBarTheme(
+        backgroundColor: AppColors.background,
+        elevation: 0,
+      ),
+      cardTheme: CardTheme(
+        color: AppColors.surface,
+        elevation: 4,
+        shadowColor: Colors.black.withOpacity(0.4),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          minimumSize: const Size.fromHeight(56),
+          backgroundColor: AppColors.primary,
+          foregroundColor: AppColors.textPrimary,
+          textStyle: textTheme.labelLarge,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          elevation: 0,
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          minimumSize: const Size.fromHeight(56),
+          side: const BorderSide(color: AppColors.stroke),
+          foregroundColor: AppColors.textPrimary,
+          textStyle: textTheme.labelLarge,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        ),
+      ),
+      checkboxTheme: CheckboxThemeData(
+        fillColor: MaterialStateProperty.resolveWith((states) {
+          if (states.contains(MaterialState.selected)) {
+            return AppColors.accent;
+          }
+          return AppColors.stroke;
+        }),
+        checkColor: const MaterialStatePropertyAll(AppColors.textPrimary),
+        side: const BorderSide(color: AppColors.stroke, width: 1.2),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      ),
+      switchTheme: SwitchThemeData(
+        thumbColor: MaterialStateProperty.resolveWith((states) {
+          if (states.contains(MaterialState.selected)) {
+            return AppColors.primary;
+          }
+          return AppColors.stroke;
+        }),
+        trackColor: MaterialStateProperty.resolveWith((states) {
+          if (states.contains(MaterialState.selected)) {
+            return AppColors.primary.withOpacity(0.3);
+          }
+          return AppColors.stroke.withOpacity(0.4);
+        }),
+      ),
+    );
+  }
+}

--- a/pocketllm/lib/theme/typography.dart
+++ b/pocketllm/lib/theme/typography.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class AppTypography {
+  AppTypography._();
+
+  static TextTheme createTextTheme() {
+    final base = ThemeData(brightness: Brightness.dark).textTheme;
+    return TextTheme(
+      displayLarge: GoogleFonts.sora(
+        textStyle: base.displayLarge?.copyWith(fontSize: 32, height: 36 / 32),
+      ),
+      displayMedium: GoogleFonts.sora(
+        textStyle: base.displayMedium?.copyWith(fontSize: 28, height: 32 / 28),
+      ),
+      headlineMedium: GoogleFonts.sora(
+        textStyle: base.headlineMedium?.copyWith(fontSize: 22, height: 28 / 22),
+      ),
+      titleLarge: GoogleFonts.sora(
+        textStyle: base.titleLarge?.copyWith(fontSize: 20, height: 26 / 20),
+      ),
+      bodyLarge: GoogleFonts.inter(
+        textStyle: base.bodyLarge?.copyWith(fontSize: 16, height: 24 / 16),
+      ),
+      bodyMedium: GoogleFonts.inter(
+        textStyle: base.bodyMedium?.copyWith(fontSize: 15, height: 22 / 15),
+      ),
+      bodySmall: GoogleFonts.inter(
+        textStyle: base.bodySmall?.copyWith(fontSize: 13, height: 20 / 13),
+      ),
+      labelLarge: GoogleFonts.inter(
+        textStyle: base.labelLarge?.copyWith(fontSize: 14, height: 20 / 14, fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}

--- a/pocketllm/lib/widgets/checkbox_row.dart
+++ b/pocketllm/lib/widgets/checkbox_row.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import '../motion/tokens.dart';
+import '../theme/colors.dart';
+import '../theme/spacing.dart';
+
+class CheckboxRow extends StatelessWidget {
+  const CheckboxRow({
+    super.key,
+    required this.title,
+    required this.value,
+    required this.onChanged,
+    this.reduceMotion = false,
+  });
+
+  final String title;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final bool reduceMotion;
+
+  @override
+  Widget build(BuildContext context) {
+    final duration = reduceMotion ? const Duration(milliseconds: 120) : MotionDurations.medium;
+
+    return GestureDetector(
+      onTap: () => onChanged(!value),
+      child: AnimatedContainer(
+        duration: duration,
+        curve: MotionCurves.easeOut,
+        decoration: BoxDecoration(
+          color: value ? AppColors.surface : AppColors.background,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: value ? AppColors.accent.withOpacity(0.7) : AppColors.stroke),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(value ? 0.32 : 0.18),
+              blurRadius: value ? 22 : 12,
+              offset: const Offset(0, 6),
+            ),
+          ],
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg, vertical: AppSpacing.md),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                title,
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: AppColors.textPrimary,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ),
+            Checkbox(
+              value: value,
+              onChanged: (_) => onChanged(!value),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pocketllm/lib/widgets/dot_pager.dart
+++ b/pocketllm/lib/widgets/dot_pager.dart
@@ -1,0 +1,49 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import '../motion/effects.dart';
+import '../theme/colors.dart';
+
+class DotPager extends StatelessWidget {
+  const DotPager({
+    super.key,
+    required this.count,
+    required this.page,
+    this.reduceMotion = false,
+  });
+
+  final int count;
+  final double page;
+  final bool reduceMotion;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: List.generate(count, (index) {
+        final distance = (page - index).abs();
+        final intensity = (1 - min(distance, 1.0)).clamp(0.0, 1.0);
+        final size = 10.0 + 4.0 * intensity;
+        final color = Color.lerp(AppColors.stroke, AppColors.primary, intensity) ?? AppColors.stroke;
+
+        Widget dot = AnimatedContainer(
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOut,
+          width: size,
+          height: 10,
+          margin: const EdgeInsets.symmetric(horizontal: 4),
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(999),
+          ),
+        );
+
+        if (!reduceMotion) {
+          dot = animatePagerDot(dot, intensity, reduceMotion: reduceMotion);
+        }
+        return dot;
+      }),
+    );
+  }
+}

--- a/pocketllm/lib/widgets/primary_button.dart
+++ b/pocketllm/lib/widgets/primary_button.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+class PrimaryButton extends StatelessWidget {
+  const PrimaryButton({
+    super.key,
+    required this.label,
+    this.onPressed,
+    this.semanticLabel,
+    this.icon,
+    this.isLoading = false,
+    this.expand = true,
+  });
+
+  final String label;
+  final VoidCallback? onPressed;
+  final String? semanticLabel;
+  final Widget? icon;
+  final bool isLoading;
+  final bool expand;
+
+  @override
+  Widget build(BuildContext context) {
+    final child = isLoading
+        ? Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2.4),
+              ),
+              const SizedBox(width: 12),
+              Text(label),
+            ],
+          )
+        : Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (icon != null) ...[
+                icon!,
+                const SizedBox(width: 12),
+              ],
+              Text(label),
+            ],
+          );
+
+    final button = ElevatedButton(
+      onPressed: isLoading ? null : onPressed,
+      child: child,
+    );
+
+    final semantics = Semantics(
+      button: true,
+      label: semanticLabel ?? label,
+      child: expand ? SizedBox(width: double.infinity, child: button) : button,
+    );
+
+    return semantics;
+  }
+}

--- a/pocketllm/lib/widgets/provider_chip.dart
+++ b/pocketllm/lib/widgets/provider_chip.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+
+import '../motion/tokens.dart';
+import '../theme/colors.dart';
+
+class ProviderChip extends StatelessWidget {
+  const ProviderChip({
+    super.key,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    this.highlight = false,
+    this.reduceMotion = false,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+  final bool highlight;
+  final bool reduceMotion;
+
+  @override
+  Widget build(BuildContext context) {
+    final bgColor = selected ? AppColors.surface : Colors.transparent;
+    final borderColor = selected ? AppColors.primary : AppColors.stroke;
+
+    Widget chip = AnimatedContainer(
+      duration: MotionDurations.medium,
+      curve: MotionCurves.easeOut,
+      decoration: BoxDecoration(
+        color: bgColor.withOpacity(selected ? 0.8 : 0.4),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: borderColor, width: 1.4),
+        boxShadow: highlight
+            ? [
+                BoxShadow(
+                  color: AppColors.primary.withOpacity(0.35),
+                  blurRadius: 16,
+                  spreadRadius: 1,
+                ),
+              ]
+            : [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.25),
+                  blurRadius: 10,
+                  spreadRadius: 0,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          AnimatedOpacity(
+            duration: MotionDurations.medium,
+            opacity: selected ? 1 : 0,
+            child: Icon(Icons.check, size: 18, color: AppColors.textPrimary),
+          ),
+          if (selected) const SizedBox(width: 8),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: AppColors.textPrimary,
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ],
+      ),
+    );
+
+    if (!reduceMotion) {
+      chip = chip
+          .animate(target: selected ? 1 : 0)
+          .scale(begin: const Offset(0.98, 0.98), end: const Offset(1, 1), duration: MotionDurations.short);
+
+      if (highlight) {
+        chip = chip.animate(onPlay: (controller) => controller.repeat(reverse: true)).scale(
+              begin: const Offset(1, 1),
+              end: const Offset(1.04, 1.04),
+              duration: const Duration(milliseconds: 700),
+              curve: Curves.easeInOut,
+            );
+      }
+    }
+
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: label,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(999),
+          onTap: onTap,
+          child: chip,
+        ),
+      ),
+    );
+  }
+}

--- a/pocketllm/lib/widgets/safe_scaffold.dart
+++ b/pocketllm/lib/widgets/safe_scaffold.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+import '../theme/colors.dart';
+
+class SafeScaffold extends StatelessWidget {
+  const SafeScaffold({
+    super.key,
+    required this.child,
+  });
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          color: AppColors.background,
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/pocketllm/lib/widgets/secondary_button.dart
+++ b/pocketllm/lib/widgets/secondary_button.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class SecondaryButton extends StatelessWidget {
+  const SecondaryButton({
+    super.key,
+    required this.label,
+    this.onPressed,
+    this.semanticLabel,
+    this.expand = true,
+  });
+
+  final String label;
+  final VoidCallback? onPressed;
+  final String? semanticLabel;
+  final bool expand;
+
+  @override
+  Widget build(BuildContext context) {
+    final button = OutlinedButton(
+      onPressed: onPressed,
+      child: Text(label),
+    );
+
+    return Semantics(
+      button: true,
+      label: semanticLabel ?? label,
+      child: expand ? SizedBox(width: double.infinity, child: button) : button,
+    );
+  }
+}

--- a/pocketllm/lib/widgets/toggle_row.dart
+++ b/pocketllm/lib/widgets/toggle_row.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+import '../motion/tokens.dart';
+import '../theme/colors.dart';
+import '../theme/spacing.dart';
+
+class ToggleRow extends StatelessWidget {
+  const ToggleRow({
+    super.key,
+    required this.title,
+    required this.value,
+    required this.onChanged,
+    this.reduceMotion = false,
+  });
+
+  final String title;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final bool reduceMotion;
+
+  @override
+  Widget build(BuildContext context) {
+    final duration = reduceMotion ? const Duration(milliseconds: 120) : MotionDurations.medium;
+
+    return Semantics(
+      toggled: value,
+      button: false,
+      container: true,
+      label: title,
+      child: AnimatedContainer(
+        duration: duration,
+        curve: MotionCurves.easeOut,
+        decoration: BoxDecoration(
+          color: value ? AppColors.surface : AppColors.background,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: value ? AppColors.primary.withOpacity(0.6) : AppColors.stroke),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(value ? 0.3 : 0.18),
+              blurRadius: value ? 20 : 12,
+              offset: const Offset(0, 6),
+            ),
+          ],
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg, vertical: AppSpacing.md),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                title,
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: AppColors.textPrimary,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ),
+            Semantics(
+              toggled: value,
+              child: Switch(
+                value: value,
+                onChanged: onChanged,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pocketllm/pubspec.yaml
+++ b/pocketllm/pubspec.yaml
@@ -1,0 +1,26 @@
+name: pocketllm
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_hooks: ^0.20.5
+  hooks_riverpod: ^2.5.1
+  go_router: ^13.2.0
+  shared_preferences: ^2.2.2
+  flutter_animate: ^4.5.0
+  google_fonts: ^6.2.1
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/illustration/ob1.png
+    - assets/illustration/ob2.png
+    - assets/illustration/ob3.gif
+    - assets/illustration/ob4.gif
+    - assets/illustration/ob5.gif
+    - assets/illustration/ob6.gif


### PR DESCRIPTION
## Summary
- scaffold a dedicated PocketLLM Flutter app with theme tokens, motion helpers, and shared widgets
- implement a six-screen animated onboarding experience with provider setup, feature toggles, privacy, and permissions flows
- persist onboarding choices with SharedPreferences and gate routing so users land on Home once setup is complete

## Testing
- not run (Flutter tooling unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_6904879e9888832da452ad0d7ea80ce8